### PR TITLE
Paths resolving updates

### DIFF
--- a/cleo_sdk/CLEO.h
+++ b/cleo_sdk/CLEO.h
@@ -114,11 +114,11 @@ static eLogicalOperation& operator--(eLogicalOperation& o)
 }
 
 // CLEO virtual path prefixes. Expandable with CLEO_ResolvePath
-const char DIR_GAME[] = "0:"; // game root directory
-const char DIR_USER[] = "1:"; // game save directory
-const char DIR_SCRIPT[] = "2:"; // current script directory
-const char DIR_CLEO[] = "3:"; // game\cleo directory
-const char DIR_MODULES[] = "4:"; // game\cleo\modules directory
+const char DIR_GAME[] = "root:"; // game root directory
+const char DIR_USER[] = "userfiles:"; // game save directory
+const char DIR_SCRIPT[] = "."; // current script directory
+const char DIR_CLEO[] = "cleo:"; // game\cleo directory
+const char DIR_MODULES[] = "modules:"; // game\cleo\modules directory
 
 // argument of CLEO_RegisterCallback
 enum class eCallbackId : DWORD

--- a/source/CCustomOpcodeSystem.cpp
+++ b/source/CCustomOpcodeSystem.cpp
@@ -3007,9 +3007,20 @@ namespace CLEO {
 
 		if(fullPath != 0)
 		{
-			std::ostringstream ss;
-			ss << script->GetScriptFileDir() << "\\" << script->GetScriptFileName();
-			CLEO_WriteStringOpcodeParam(thread, ss.str().c_str());
+			const size_t len =
+				strlen(script->GetScriptFileDir()) +
+				1 + // path separator
+				strlen(script->GetScriptFileName());
+
+			std::string path;
+			path.reserve(len);
+
+			path = script->GetScriptFileDir();
+			path.push_back('\\');
+			path.append(script->GetScriptFileName());
+			path = script->ResolvePath(path.c_str()); // real absolute path
+
+			CLEO_WriteStringOpcodeParam(thread, path.c_str());
 		}
 		else
 			CLEO_WriteStringOpcodeParam(thread, script->GetScriptFileName());

--- a/source/CCustomOpcodeSystem.cpp
+++ b/source/CCustomOpcodeSystem.cpp
@@ -1485,15 +1485,29 @@ namespace CLEO {
 	OpcodeResult __stdcall opcode_0A99(CRunningScript *thread)
 	{
 		auto paramType = *thread->GetBytePointer();
-		if (paramType >= 1 && paramType <= 8)
+		if (paramType == DT_BYTE ||
+			paramType == DT_WORD ||
+			paramType == DT_DWORD ||
+			paramType == DT_VAR ||
+			paramType == DT_LVAR ||
+			paramType == DT_VAR_ARRAY ||
+			paramType == DT_LVAR_ARRAY)
 		{
 			// numbered predefined paths
-			DWORD param;
-			*thread >> param;
+			DWORD param; *thread >> param;
 
-			std::string path = std::to_string(param);
-			path += ":";
-			reinterpret_cast<CCustomScript*>(thread)->SetWorkDir(path.c_str());
+			const char* path;
+			switch(param)
+			{
+				case 0: path = DIR_GAME; break;
+				case 1: path = DIR_USER; break;
+				case 2: path = DIR_SCRIPT; break;
+				default:
+					LOG_WARNING("Value (%d) not known by opcode [0A99] in script %s", param, ((CCustomScript*)thread)->GetInfoStr().c_str());
+					return OR_CONTINUE;
+			}
+
+			reinterpret_cast<CCustomScript*>(thread)->SetWorkDir(path);
 		}
 		else
 		{
@@ -2032,11 +2046,8 @@ namespace CLEO {
 				break;
 
 			default:
-			{
 				SHOW_ERROR("Invalid type (%02X) of the first argument in opcode [0AB1] in script %s \nScript suspended.", *thread->GetBytePointer(), ((CCustomScript*)thread)->GetInfoStr().c_str());
-
 				return CCustomOpcodeSystem::ErrorSuspendScript(thread);
-			}
 		}
 
 		ScmFunction* scmFunc = new ScmFunction(thread);

--- a/source/FileEnumerator.h
+++ b/source/FileEnumerator.h
@@ -56,8 +56,7 @@ void FilesWalk(const char* directory, const char* extension, T callback)
             continue; // skip directories
         }
 
-        //auto result = std::filesystem::absolute(std::string(baseDir) + wfd.cFileName);
-        auto result = std::filesystem::path(std::string(baseDir) + wfd.cFileName); // ModLoader supports only relative paths...
+        auto result = std::filesystem::weakly_canonical(std::string(baseDir) + wfd.cFileName); // will use CWD if input path was relative!
         callback(result.string().c_str(), result.filename().string().c_str());
 
     } while (FindNextFile(hSearch, &wfd));


### PR DESCRIPTION
Opcode 2001 returning only resolved paths
Added support for parent directory references "..\" in paths.
Replaced virtual path numbers with text keywords.