### PR TITLE
Cleo return arguments count check

### DIFF
--- a/cleo_sdk/CLEO.h
+++ b/cleo_sdk/CLEO.h
@@ -370,7 +370,7 @@ void WINAPI CLEO_SetThreadCondResult(CRunningScript* thread, BOOL result);
 void WINAPI CLEO_ThreadJumpAtLabelPtr(CRunningScript* thread, int labelPtr);
 
 eDataType WINAPI CLEO_GetOperandType(const CRunningScript* thread); // peek parameter data type
-DWORD WINAPI CLEO_GetVarArgCount(CRunningScript* thread); // peek var-args count
+DWORD WINAPI CLEO_GetVarArgCount(CRunningScript* thread); // peek remaining var-args count
 
 extern SCRIPT_VAR* opcodeParams;
 extern SCRIPT_VAR* missionLocals;

--- a/source/CCustomOpcodeSystem.cpp
+++ b/source/CCustomOpcodeSystem.cpp
@@ -2075,7 +2075,7 @@ namespace CLEO
 		int label = 0;
 
 		char* moduleTxt = nullptr;
-		auto paramType = CLEO_GetOperandType(thread);
+		auto paramType = (eDataType)*thread->GetBytePointer();
 		switch (paramType)
 		{
 			// label of current script
@@ -2104,7 +2104,7 @@ namespace CLEO
 				break;
 
 			default:
-				SHOW_ERROR("Invalid type (%s) of the first argument in opcode [0AB1] in script %s \nScript suspended.", ToKindStr(paramType), ((CCustomScript*)thread)->GetInfoStr().c_str());
+				SHOW_ERROR("Invalid type (%s) of the 'input param count' argument in opcode [0AB1] in script %s \nScript suspended.", ToKindStr(paramType), ((CCustomScript*)thread)->GetInfoStr().c_str());
 				return CCustomOpcodeSystem::ErrorSuspendScript(thread);
 		}
 
@@ -2142,13 +2142,41 @@ namespace CLEO
 			label = scriptRef.offset;
 		}
 
-		DWORD nParams = 0;
-		if(*thread->GetBytePointer()) *thread >> nParams;
-		if(nParams > 32)
+		// "number of input parameters" opcode argument
+		DWORD nParams;
+		paramType = (eDataType)*thread->GetBytePointer();
+		switch (paramType)
 		{
-			SHOW_ERROR("Argument count (%d), out of supported range (32) of opcode [0AB1] in script %s", nParams, ((CCustomScript*)thread)->GetInfoStr().c_str());
+			case DT_END:
+				nParams = 0;
+				break;
 
-			return CCustomOpcodeSystem::ErrorSuspendScript(thread);
+			// literal integers
+			case DT_BYTE:
+			case DT_WORD:
+			case DT_DWORD:
+				*thread >> nParams;
+				break;
+
+			default:
+				SHOW_ERROR("Invalid type of first argument in opcode [0AB1], in script %s", ((CCustomScript*)thread)->GetInfoStr().c_str());
+				return CCustomOpcodeSystem::ErrorSuspendScript(thread);
+		}
+		if (nParams)
+		{
+			auto nVarArg = GetVarArgCount(thread);
+			if (nParams > nVarArg) // if less it means there are return params too
+			{
+				SHOW_ERROR("Opcode [0AB1] declared %d input args, but provided %d in script %s\nScript suspended.", nParams, nVarArg, ((CCustomScript*)thread)->GetInfoStr().c_str());
+				return CCustomOpcodeSystem::ErrorSuspendScript(thread);
+			}
+
+			if (nParams > 32)
+			{
+				SHOW_ERROR("Argument count %d is out of supported range (32) of opcode [0AB1] in script %s", nParams, ((CCustomScript*)thread)->GetInfoStr().c_str());
+
+				return CCustomOpcodeSystem::ErrorSuspendScript(thread);
+			}
 		}
 
 		static SCRIPT_VAR arguments[32];

--- a/source/CCustomOpcodeSystem.cpp
+++ b/source/CCustomOpcodeSystem.cpp
@@ -2261,9 +2261,10 @@ namespace CLEO
 		delete scmFunc;
 
 		DWORD returnSlotCount = GetVarArgCount(thread);
-		if (returnSlotCount > returnParamCount)
+		if(returnParamCount) returnParamCount--; // do not count the 'num args' argument itself
+		if (returnSlotCount != returnParamCount)
 		{
-			SHOW_ERROR("Opcode [0AB2] returned fewer params than expected by function caller in script %s\nScript suspended.", ((CCustomScript*)thread)->GetInfoStr().c_str());
+			SHOW_ERROR("Opcode [0AB2] returned %d params, while function caller expected %d in script %s\nScript suspended.", returnParamCount, returnSlotCount, ((CCustomScript*)thread)->GetInfoStr().c_str());
 			return CCustomOpcodeSystem::ErrorSuspendScript(thread);
 		}
 


### PR DESCRIPTION
Second commit is still discussable:
In previous CLEO versions it was possible to ignore some values returned by **cleo_return** as copied values count was determined by variable arguments count in **cleo_call**. So remaining arguments and varg-arg terminator byte were never used. 

This also could be used as way to prevent decompilation by removing or changing **cleo_return** var-arg terminator char.
