### PR TITLE
New opcode sign_extend. Updates in read_memory opcode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
   - 'argument count' parameter of **0AB1 (cleo_call)** is now optional. `cleo_call @LABEL args 0` can be written as `cleo_call @LABEL`
   - 'argument count' parameter of **0AB2 (cleo_return)** is now optional. `cleo_return 0` can be written as `cleo_return`
   - opcodes **0AAB**, **0AE4**, **0AE5**, **0AE6**, **0AE7** and **0AE8** moved to the [FileSystemOperations](https://github.com/cleolibrary/CLEO5/tree/master/cleo_plugins/FileSystemOperations) plugin
+  - SCM functions **(0AB1)** now keep their own GOSUB's call stack
+  - new opcode **0B1E ([sign_extend](https://library.sannybuilder.com/#/sa/bitwise/0B1E))**
 - changes in file operations
   - file paths can now use 'virtual absolute paths'. Use prefix in file path strings to access predefined locations: 
     - `root:\` for _game root_ directory
@@ -24,11 +26,9 @@
     - `modules:\` for _CLEO\cleo_modules_ directory
   - rewritten opcode **0A99 (set_current_directory)**. It no longer affects internal game state and other scripts
 - improved error handling
-  - more detailed error messages in some scenarios
+  - more detailed error messages in multiple scenarios
   - some errors now cause the script to pause, instead of crashing the game
-- SCM functions **(0AB1)** now keep their own GOSUB's call stack
 - updated included Silent's ASI Loader to version 1.3
-
 
 ### Bug Fixes
 - fixed error in **004E (terminate_this_script)** allowing to run multiple missions


### PR DESCRIPTION
Test script
```
{$CLEO .cs}
{$USE debug}
0000:

{$OPCODE 0B1E=2,sign_extend %1d% size %2d%}

debug_on

0@ = -42
1@ = allocate_memory size 4

// byte
write_memory address 1@ size 1 value 0@ vp false
2@ = read_memory address 1@ size 1 vp false
3@ = 2@
0B1E: sign_extend 3@ size 1
trace "1 BYTE: original value: %d, read value: %d, extended sign: %d" 0@ 2@ 3@

// 2 bytes
write_memory address 1@ size 2 value 0@ vp false
2@ = read_memory address 1@ size 2 vp false
3@ = 2@
0B1E: sign_extend 3@ size 2
trace "2 BYTES: original value: %d, read value: %d, extended sign: %d" 0@ 2@ 3@

// 3 bytes
write_memory address 1@ size 3 value 0@ vp false
2@ = read_memory address 1@ size 3 vp false
3@ = 2@
0B1E: sign_extend 3@ size 3
trace "3 BYTES: original value: %d, read value: %d, extended sign: %d" 0@ 2@ 3@

// 4 bytes
write_memory address 1@ size 4 value 0@ vp false
2@ = read_memory address 1@ size 4 vp false
3@ = 2@
0B1E: sign_extend 3@ size 4
trace "4 BYTES: original value: %d, read value: %d, extended sign: %d" 0@ 2@ 3@

0A93: terminate_this_custom_script
```