### PR TITLE
Return strings support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   - 'argument count' parameter of **0AB1 (cleo_call)** is now optional. `cleo_call @LABEL args 0` can be written as `cleo_call @LABEL`
   - 'argument count' parameter of **0AB2 (cleo_return)** is now optional. `cleo_return 0` can be written as `cleo_return`
   - opcodes **0AAB**, **0AE4**, **0AE5**, **0AE6**, **0AE7** and **0AE8** moved to the [FileSystemOperations](https://github.com/cleolibrary/CLEO5/tree/master/cleo_plugins/FileSystemOperations) plugin
+  - **cleo_return_\*** opcodes now can pass strings as return arguments
   - SCM functions **(0AB1)** now keep their own GOSUB's call stack
   - new opcode **0B1E ([sign_extend](https://library.sannybuilder.com/#/sa/bitwise/0B1E))**
 - changes in file operations

--- a/cleo_sdk/CLEO.h
+++ b/cleo_sdk/CLEO.h
@@ -47,7 +47,7 @@ enum eGameVersion : int
 };
 
 // operand types
-enum eDataType : int
+enum eDataType : BYTE
 {
 	DT_END, // variable args end marker
 	DT_DWORD, // literal int 32

--- a/source/CCustomOpcodeSystem.cpp
+++ b/source/CCustomOpcodeSystem.cpp
@@ -1023,10 +1023,10 @@ namespace CLEO
 				return CCustomOpcodeSystem::ErrorSuspendScript(thread);
 			}
 
-			std::fill(std::begin(argumentIsStr), std::end(argumentIsStr), 0);
 			for (DWORD i = 0; i < returnArgCount; i++)
 			{
 				SCRIPT_VAR* arg = arguments + i;
+				argumentIsStr[i] = false;
 
 				auto paramType = (eDataType)*thread->GetBytePointer();
 				if (IsImmInteger(paramType) || IsVariable(paramType))

--- a/source/CCustomOpcodeSystem.cpp
+++ b/source/CCustomOpcodeSystem.cpp
@@ -9,10 +9,11 @@
 
 #include <tlhelp32.h>
 #include <sstream>
+#include <forward_list>
 
-#define OPCODE_VALIDATE_STR_ARG_READ(x) if((void*)x == nullptr) { SHOW_ERROR("%s in script %s \nScript suspended.", lastErrorMsg.c_str(), ((CCustomScript*)thread)->GetInfoStr().c_str()); return CCustomOpcodeSystem::ErrorSuspendScript(thread); }
-#define OPCODE_VALIDATE_STR_ARG_WRITE(x) if((void*)x == nullptr) { SHOW_ERROR("%s in script %s \nScript suspended.", lastErrorMsg.c_str(), ((CCustomScript*)thread)->GetInfoStr().c_str()); return CCustomOpcodeSystem::ErrorSuspendScript(thread); }
-#define OPCODE_READ_FORMATTED_STRING(thread, buf, bufSize, format) if(ReadFormattedString(thread, buf, bufSize, format) == -1) { SHOW_ERROR("%s in script %s \nScript suspended.", lastErrorMsg.c_str(), ((CCustomScript*)thread)->GetInfoStr().c_str()); return CCustomOpcodeSystem::ErrorSuspendScript(thread); }
+#define OPCODE_VALIDATE_STR_ARG_READ(x) if((void*)x == nullptr) { SHOW_ERROR("%s in script %s \nScript suspended.", CLEO::lastErrorMsg.c_str(), ((CCustomScript*)thread)->GetInfoStr().c_str()); return CCustomOpcodeSystem::ErrorSuspendScript(thread); }
+#define OPCODE_VALIDATE_STR_ARG_WRITE(x) if((void*)x == nullptr) { SHOW_ERROR("%s in script %s \nScript suspended.", CLEO::lastErrorMsg.c_str(), ((CCustomScript*)thread)->GetInfoStr().c_str()); return CCustomOpcodeSystem::ErrorSuspendScript(thread); }
+#define OPCODE_READ_FORMATTED_STRING(thread, buf, bufSize, format) if(ReadFormattedString(thread, buf, bufSize, format) == -1) { SHOW_ERROR("%s in script %s \nScript suspended.", CLEO::lastErrorMsg.c_str(), ((CCustomScript*)thread)->GetInfoStr().c_str()); return CCustomOpcodeSystem::ErrorSuspendScript(thread); }
 
 namespace CLEO 
 {
@@ -262,44 +263,6 @@ namespace CLEO
 		}
 
 		return (callbackResult != OR_NONE) ? callbackResult : result;
-	}
-
-	OpcodeResult CCustomOpcodeSystem::CleoReturnGeneric(WORD opcode, CRunningScript* thread, bool returnArgs)
-	{
-		auto cs = reinterpret_cast<CCustomScript*>(thread);
-
-		ScmFunction* scmFunc = ScmFunction::Get(cs->GetScmFunction());
-		if (scmFunc == nullptr)
-		{
-			SHOW_ERROR("Invalid Cleo Call reference. [%04X] possibly used without preceding [0AB1] in script %s\nScript suspended.", opcode, cs->GetInfoStr().c_str());
-			return CCustomOpcodeSystem::ErrorSuspendScript(thread);
-		}
-
-		DWORD returnParamCount = 0;
-		if(returnArgs)
-		{
-			returnParamCount = GetVarArgCount(cs);
-			if (returnParamCount) GetScriptParams(cs, returnParamCount);
-		}
-
-		scmFunc->Return(cs); // jump back to cleo_call, right after last input param. Return slot var args starts here
-		if (scmFunc->moduleExportRef != nullptr) GetInstance().ModuleSystem.ReleaseModuleRef((char*)scmFunc->moduleExportRef); // exiting export - release module
-		delete scmFunc;
-
-		if (returnArgs)
-		{
-			DWORD returnSlotCount = GetVarArgCount(cs);
-			if (returnParamCount != returnSlotCount) // new CLEO5 opcode, strict error checks
-			{
-				SHOW_ERROR("Opcode [%04X] returned %d params, while function caller expected %d in script %s\nScript suspended.", opcode, returnParamCount, returnSlotCount, cs->GetInfoStr().c_str());
-				return CCustomOpcodeSystem::ErrorSuspendScript(cs);
-			}
-
-			if (returnSlotCount) SetScriptParams(cs, returnSlotCount);
-			cs->IncPtr(); // skip var args
-		}
-
-		return OR_CONTINUE;
 	}
 
 	OpcodeResult CCustomOpcodeSystem::ErrorSuspendScript(CRunningScript* thread)
@@ -990,6 +953,116 @@ namespace CLEO
 		thread->IncPtr(); // skip vararg terminator
 		outputStr[written] = '\0';
 		return -1; // error
+	}
+
+	OpcodeResult CCustomOpcodeSystem::CleoReturnGeneric(WORD opcode, CRunningScript* thread, bool returnArgs, DWORD returnArgCount, bool strictArgCount)
+	{
+		auto cs = reinterpret_cast<CCustomScript*>(thread);
+
+		ScmFunction* scmFunc = ScmFunction::Get(cs->GetScmFunction());
+		if (scmFunc == nullptr)
+		{
+			SHOW_ERROR("Invalid Cleo Call reference. [%04X] possibly used without preceding [0AB1] in script %s\nScript suspended.", opcode, cs->GetInfoStr().c_str());
+			return CCustomOpcodeSystem::ErrorSuspendScript(thread);
+		}
+
+		// store return arguments
+		static SCRIPT_VAR arguments[32];
+		static bool argumentIsStr[32];
+		std::forward_list<std::string> stringParams; // scope guard for strings
+		if (returnArgs)
+		{
+			if (returnArgCount > 32)
+			{
+				SHOW_ERROR("Opcode [%04X] has too many (%d) args in script %s\nScript suspended.", opcode, returnArgCount, cs->GetInfoStr().c_str());
+				return CCustomOpcodeSystem::ErrorSuspendScript(thread);
+			}
+
+			auto nVarArg = GetVarArgCount(thread);
+			if (returnArgCount > nVarArg)
+			{
+				SHOW_ERROR("Opcode [%04X] declared %d args, but %d was provided in script %s\nScript suspended.", opcode, returnArgCount, nVarArg, ((CCustomScript*)thread)->GetInfoStr().c_str());
+				return CCustomOpcodeSystem::ErrorSuspendScript(thread);
+			}
+
+			std::fill(std::begin(argumentIsStr), std::end(argumentIsStr), 0);
+			for (DWORD i = 0; i < returnArgCount; i++)
+			{
+				SCRIPT_VAR* arg = arguments + i;
+
+				auto paramType = (eDataType)*thread->GetBytePointer();
+				if (IsImmInteger(paramType) || IsVariable(paramType))
+				{
+					*thread >> arg->dwParam;
+				}
+				else if (paramType == DT_FLOAT)
+				{
+					*thread >> arg->fParam;
+				}
+				else if (IsImmString(paramType) || IsVarString(paramType))
+				{
+					argumentIsStr[i] = true;
+
+					auto str = ReadStringParam(thread); OPCODE_VALIDATE_STR_ARG_READ(str)
+					stringParams.push_front(std::move(str));
+					arg->pcParam = stringParams.front().data();
+				}
+				else
+				{
+					SHOW_ERROR("Invalid argument type '0x%02X' in opcode [%04X] in script %s\nScript suspended.", paramType, opcode, ((CCustomScript*)thread)->GetInfoStr().c_str());
+					return CCustomOpcodeSystem::ErrorSuspendScript(thread);
+				}
+			}
+		}
+
+		// handle program flow
+		scmFunc->Return(cs); // jump back to cleo_call, right after last input param. Return slot var args starts here
+		if (scmFunc->moduleExportRef != nullptr) GetInstance().ModuleSystem.ReleaseModuleRef((char*)scmFunc->moduleExportRef); // exiting export - release module
+		delete scmFunc;
+
+		if (returnArgs)
+		{
+			DWORD returnSlotCount = GetVarArgCount(cs);
+			if (returnSlotCount > returnArgCount || (strictArgCount && returnSlotCount < returnArgCount))
+			{
+				SHOW_ERROR("Opcode [%04X] returned %d params, while function caller expected %d in script %s\nScript suspended.", opcode, returnArgCount, returnSlotCount, cs->GetInfoStr().c_str());
+				return CCustomOpcodeSystem::ErrorSuspendScript(cs);
+			}
+			else if (returnSlotCount < returnArgCount)
+			{
+				LOG_WARNING(thread, "Opcode [%04X] returned %d params, while function caller expected %d in script %s", opcode, returnArgCount, returnSlotCount, cs->GetInfoStr().c_str());
+			}
+
+			// set return args
+			for (DWORD i = 0; i < returnArgCount; i++)
+			{
+				auto arg = (SCRIPT_VAR*)thread->GetBytePointer();
+
+				auto paramType = *(eDataType*)arg;
+				if (IsVarString(paramType))
+				{
+					WriteStringParam(thread, arguments[i].pcParam);
+				} 
+				else if (IsVariable(paramType))
+				{
+					if (argumentIsStr[i]) // source was string, write it into provided buffer ptr
+					{
+						auto ok = WriteStringParam(thread, arguments[i].pcParam); OPCODE_VALIDATE_STR_ARG_WRITE(ok)
+					}
+					else
+						*thread << arguments[i].dwParam;
+				}
+				else
+				{
+					SHOW_ERROR("Invalid output argument type '0x%02X' in opcode [%04X] in script %s\nScript suspended.", paramType, opcode, ((CCustomScript*)thread)->GetInfoStr().c_str());
+					return CCustomOpcodeSystem::ErrorSuspendScript(thread);
+				}
+			}
+		}
+
+		SkipUnusedVarArgs(thread); // skip var args terminator too
+
+		return OR_CONTINUE;
 	}
 
 	// Legacy modes for CLEO 3
@@ -2092,58 +2165,31 @@ namespace CLEO
 	//0AB2=-1,cleo_return
 	OpcodeResult __stdcall opcode_0AB2(CRunningScript *thread)
 	{
-		auto cs = reinterpret_cast<CCustomScript*>(thread);
-
-		ScmFunction* scmFunc = ScmFunction::Get(cs->GetScmFunction());
-		if (scmFunc == nullptr)
-		{
-			SHOW_ERROR("Invalid Cleo Call reference. [0AB2] possibly used without preceding [0AB1] in script %s\nScript suspended.", cs->GetInfoStr().c_str());
-			return CCustomOpcodeSystem::ErrorSuspendScript(thread);
-		}
-		
 		DWORD returnParamCount = GetVarArgCount(thread);
 		if (returnParamCount)
 		{
 			auto paramType = (eDataType)*thread->GetBytePointer();
 			if (!IsImmInteger(paramType))
 			{
-				SHOW_ERROR("Invalid type of first argument in opcode [0AB2], in script %s", cs->GetInfoStr().c_str());
+				SHOW_ERROR("Invalid type of first argument in opcode [0AB2], in script %s", ((CCustomScript*)thread)->GetInfoStr().c_str());
 				return CCustomOpcodeSystem::ErrorSuspendScript(thread);
 			}
 			DWORD declaredParamCount; *thread >> declaredParamCount;
 
-			if(returnParamCount - 1 < declaredParamCount) // minus 'num args' itself
+			if (returnParamCount - 1 < declaredParamCount) // minus 'num args' itself
 			{
-				SHOW_ERROR("Opcode [0AB2] declared %d return args, but provided %d in script %s\nScript suspended.", declaredParamCount, returnParamCount - 1, cs->GetInfoStr().c_str());
+				SHOW_ERROR("Opcode [0AB2] declared %d return args, but provided %d in script %s\nScript suspended.", declaredParamCount, returnParamCount - 1, ((CCustomScript*)thread)->GetInfoStr().c_str());
 				return CCustomOpcodeSystem::ErrorSuspendScript(thread);
 			}
 			else if (returnParamCount - 1 > declaredParamCount) // more args than needed, not critical
 			{
-				LOG_WARNING(thread, "Opcode [0AB2] declared %d return args, but provided %d in script %s", declaredParamCount, returnParamCount - 1, cs->GetInfoStr().c_str());
+				LOG_WARNING(thread, "Opcode [0AB2] declared %d return args, but provided %d in script %s", declaredParamCount, returnParamCount - 1, ((CCustomScript*)thread)->GetInfoStr().c_str());
 			}
-		}
-		if (returnParamCount) GetScriptParams(thread, returnParamCount);
 
-		scmFunc->Return(thread); // jump back to cleo_call, right after last input param. Return slot var args starts here
-		if (scmFunc->moduleExportRef != nullptr) GetInstance().ModuleSystem.ReleaseModuleRef((char*)scmFunc->moduleExportRef); // export - release module
-		delete scmFunc;
-
-		DWORD returnSlotCount = GetVarArgCount(thread);
-		if(returnParamCount) returnParamCount--; // do not count the 'num args' argument itself
-		if (returnSlotCount > returnParamCount)
-		{
-			SHOW_ERROR("Opcode [0AB2] returned %d params, while function caller expected %d in script %s\nScript suspended.", returnParamCount, returnSlotCount, cs->GetInfoStr().c_str());
-			return CCustomOpcodeSystem::ErrorSuspendScript(thread);
-		}
-		else if (returnSlotCount < returnParamCount) // more args than needed, not critical
-		{
-			LOG_WARNING(thread, "Opcode [0AB2] returned %d params, while function caller expected %d in script %s", returnParamCount, returnSlotCount, cs->GetInfoStr().c_str());
+			returnParamCount = declaredParamCount;
 		}
 
-		if (returnSlotCount) SetScriptParams(thread, returnSlotCount);
-		thread->IncPtr(); // skip var args terminator
-
-		return OR_CONTINUE;
+		return GetInstance().OpcodeSystem.CleoReturnGeneric(0x0AB2, thread, true, returnParamCount);
 	}
 
 	//0AB3=2,var %1d% = %2d%
@@ -3014,9 +3060,10 @@ namespace CLEO
 		}
 
 		DWORD result; *thread >> result;
+		argCount--;
 		SetScriptCondResult(thread, result != 0);
 
-		return CCustomOpcodeSystem::CleoReturnGeneric(0x2002, thread, true);
+		return GetInstance().OpcodeSystem.CleoReturnGeneric(0x2002, thread, true, argCount);
 	}
 
 	//2003=-1, cleo_return_fail
@@ -3030,7 +3077,7 @@ namespace CLEO
 		}
 
 		SetScriptCondResult(thread, false);
-		return CCustomOpcodeSystem::CleoReturnGeneric(0x2003, thread, false);
+		return GetInstance().OpcodeSystem.CleoReturnGeneric(0x2003, thread);
 	}
 }
 

--- a/source/CCustomOpcodeSystem.h
+++ b/source/CCustomOpcodeSystem.h
@@ -43,7 +43,7 @@ namespace CLEO
 
         static bool RegisterOpcode(WORD opcode, CustomOpcodeHandler callback);
 
-        static OpcodeResult CleoReturnGeneric(WORD opcode, CRunningScript* thread, bool returnArgs);
+        OpcodeResult CleoReturnGeneric(WORD opcode, CRunningScript* thread, bool returnArgs = false, DWORD returnArgCount = 0, bool strictArgCount = true);
         static OpcodeResult ErrorSuspendScript(CRunningScript* thread); // suspend script execution forever
 
     private:

--- a/source/CCustomOpcodeSystem.h
+++ b/source/CCustomOpcodeSystem.h
@@ -73,10 +73,20 @@ namespace CLEO
 
     extern void(__thiscall * ProcessScript)(CRunningScript*);
     
+    struct StringParamBufferInfo
+    {
+        char* data = nullptr;
+        DWORD size = 0;
+        bool needTerminator = false;
+    };
+
     char* ReadStringParam(CRunningScript* thread, char* buf = nullptr, DWORD bufSize = 0);
-    bool WriteStringParam(CRunningScript* thread, const char* str);
-    std::pair<char*, DWORD> GetStringParamWriteBuffer(CRunningScript* thread); // consumes the param
+    StringParamBufferInfo GetStringParamWriteBuffer(CRunningScript* thread); // consumes the param
     int ReadFormattedString(CRunningScript* thread, char* buf, DWORD bufSize, const char* format);
+
+    bool WriteStringParam(CRunningScript* thread, const char* str);
+    bool WriteStringParam(const StringParamBufferInfo& target, const char* str);
+
     void SkipUnusedVarArgs(CRunningScript* thread); // for var-args opcodes
     DWORD GetVarArgCount(CRunningScript* thread); // for var-args opcodes
 }


### PR DESCRIPTION
Test script

```
{$CLEO .cs}
0000:

20@ = allocate_memory 128

while true
    cleo_call @GET_TEXT_L {args} 0 {result} 20@
    cleo_call @GET_TEXT_L {args} 0 {result} 1@s
    cleo_call @GET_TEXT_L {args} 0 {result} 3@v
    print_formatted "literal~n~ptr: %s~n~short: %s~n~long: %s" {time} 3000 {args} 20@ 1@s 3@v
    wait 3000
    
    cleo_call @GET_TEXT_SHORT {args} 0 {result} 20@
    cleo_call @GET_TEXT_SHORT {args} 0 {result} 1@s
    cleo_call @GET_TEXT_SHORT {args} 0 {result} 3@v
    print_formatted "short~n~ptr: %s~n~short: %s~n~long: %s" {time} 3000 {args} 20@ 1@s 3@v
    wait 3000
    
    cleo_call @GET_TEXT_LONG {args} 0 {result} 20@
    cleo_call @GET_TEXT_LONG {args} 0 {result} 1@s
    cleo_call @GET_TEXT_LONG {args} 0 {result} 3@v
    print_formatted "long~n~ptr: %s~n~short: %s~n~long: %s" {time} 3000 {args} 20@ 1@s 3@v
    wait 3000
    
    cleo_call @GET_TEXT_MIX {args} 0 {result} 0@v 4@s 20@
    print_formatted "mixed~n~ptr: %s~n~short: %s~n~long: %s" {time} 3000 {args} 20@ 4@s 0@v
    wait 3000
end

0A93: terminate_this_custom_script

:GET_TEXT_L
cleo_return_with true {args} "SOME LONG TESTING TEXT"

:GET_TEXT_SHORT
0@s = 'Label'
cleo_return_with true {args} 0@s

:GET_TEXT_LONG
0@v = "variable string"
cleo_return_with true {args} 0@v

:GET_TEXT_MIX
0@s = 'short'
2@v = "longer text"
cleo_return_with true {args} 0@s 2@v "and the literal string"
```