### PR TITLE
File related opcodes updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,12 @@
   - **2002 ([cleo_return_with](https://library.sannybuilder.com/#/sa/CLEO/2002))**
   - **2003 ([cleo_return_fail](https://library.sannybuilder.com/#/sa/CLEO/2003))**
   - **2004 ([forget_memory](https://library.sannybuilder.com/#/sa/CLEO/2004))**
-  - **2200 ([read_block_from_file](https://library.sannybuilder.com/#/sa/file/2200))**
+  - **2300 ([get_file_position](https://library.sannybuilder.com/#/sa/file/2300))**
+  - **2301 ([read_block_from_file](https://library.sannybuilder.com/#/sa/file/2301))**
   - opcodes **0A9A**, **0A9B**, **0A9C**, **0A9D**, **0A9E**, **0AAB**, **0AD5**, **0AD6**, **0AD7**, **0AD8**, **0AD9**, **0ADA**, **0AE4**, **0AE5**, **0AE6**, **0AE7**  and **0AE8** moved to the [FileSystemOperations](https://github.com/cleolibrary/CLEO5/tree/master/cleo_plugins/FileSystemOperations) plugin
+  - fixed bug preventing file stream opcodes from working correctly for read-write modes
+  - fixed buffer overflows in file stream read opcodes
+  - added/fixed support of all file stream opcodes in legacy mode (Cleo3)
   - 'argument count' parameter of **0AB1 (cleo_call)** is now optional. `cleo_call @LABEL args 0` can be written as `cleo_call @LABEL`
   - 'argument count' parameter of **0AB2 (cleo_return)** is now optional. `cleo_return 0` can be written as `cleo_return`
   - **cleo_return_\*** opcodes now can pass strings as return arguments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,19 @@
   - new opcode **2102 ([log_to_file](https://library.sannybuilder.com/#/sa/debug/2102))**
   - implemented support of opcodes **0662**, **0663** and **0664** (original Rockstar's script debugging opcodes. See DebugUtils.ini)
 - new and updated opcodes
+  - **0B1E ([sign_extend](https://library.sannybuilder.com/#/sa/bitwise/0B1E))**
   - **0DD5 ([get_game_platform](https://library.sannybuilder.com/#/sa/CLEO/0DD5))**
   - **2000 ([resolve_filepath](https://library.sannybuilder.com/#/sa/CLEO/2000))**
   - **2001 ([get_script_filename](https://library.sannybuilder.com/#/sa/CLEO/2001))**
   - **2002 ([cleo_return_with](https://library.sannybuilder.com/#/sa/CLEO/2002))**
   - **2003 ([cleo_return_fail](https://library.sannybuilder.com/#/sa/CLEO/2003))**
   - **2004 ([forget_memory](https://library.sannybuilder.com/#/sa/CLEO/2004))**
+  - **2200 ([read_block_from_file](https://library.sannybuilder.com/#/sa/file/2200))**
+  - opcodes **0A9A**, **0A9B**, **0A9C**, **0A9D**, **0A9E**, **0AAB**, **0AD5**, **0AD6**, **0AD7**, **0AD8**, **0AD9**, **0ADA**, **0AE4**, **0AE5**, **0AE6**, **0AE7**  and **0AE8** moved to the [FileSystemOperations](https://github.com/cleolibrary/CLEO5/tree/master/cleo_plugins/FileSystemOperations) plugin
   - 'argument count' parameter of **0AB1 (cleo_call)** is now optional. `cleo_call @LABEL args 0` can be written as `cleo_call @LABEL`
   - 'argument count' parameter of **0AB2 (cleo_return)** is now optional. `cleo_return 0` can be written as `cleo_return`
-  - opcodes **0A9A**, **0A9B**, **0A9C**, **0A9D**, **0A9E**, **0AAB**, **0AD5**, **0AD6**, **0AD7**, **0AD8**, **0AD9**, **0ADA**, **0AE4**, **0AE5**, **0AE6**, **0AE7**  and **0AE8** moved to the [FileSystemOperations](https://github.com/cleolibrary/CLEO5/tree/master/cleo_plugins/FileSystemOperations) plugin
   - **cleo_return_\*** opcodes now can pass strings as return arguments
   - SCM functions **(0AB1)** now keep their own GOSUB's call stack
-  - new opcode **0B1E ([sign_extend](https://library.sannybuilder.com/#/sa/bitwise/0B1E))**
 - changes in file operations
   - file paths can now use 'virtual absolute paths'. Use prefix in file path strings to access predefined locations: 
     - `root:\` for _game root_ directory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
   - **2004 ([forget_memory](https://library.sannybuilder.com/#/sa/CLEO/2004))**
   - 'argument count' parameter of **0AB1 (cleo_call)** is now optional. `cleo_call @LABEL args 0` can be written as `cleo_call @LABEL`
   - 'argument count' parameter of **0AB2 (cleo_return)** is now optional. `cleo_return 0` can be written as `cleo_return`
-  - opcodes **0AAB**, **0AE4**, **0AE5**, **0AE6**, **0AE7** and **0AE8** moved to the [FileSystemOperations](https://github.com/cleolibrary/CLEO5/tree/master/cleo_plugins/FileSystemOperations) plugin
+  - opcodes **0A9A**, **0A9B**, **0A9C**, **0A9D**, **0A9E**, **0AAB**, **0AD5**, **0AD6**, **0AD7**, **0AD8**, **0AD9**, **0ADA**, **0AE4**, **0AE5**, **0AE6**, **0AE7**  and **0AE8** moved to the [FileSystemOperations](https://github.com/cleolibrary/CLEO5/tree/master/cleo_plugins/FileSystemOperations) plugin
   - **cleo_return_\*** opcodes now can pass strings as return arguments
   - SCM functions **(0AB1)** now keep their own GOSUB's call stack
   - new opcode **0B1E ([sign_extend](https://library.sannybuilder.com/#/sa/bitwise/0B1E))**
@@ -49,6 +49,7 @@
 - new SDK method: CLEO_GetVarArgCount
 - new SDK method: CLEO_SkipUnusedVarArgs
 - new SDK method: CLEO_ReadParamsFormatted
+- new SDK method: CLEO_ReadStringParamWriteBuffer
 - new SDK method: CLEO_GetScriptVersion
 - new SDK method: CLEO_GetScriptInfoStr
 - new SDK method: CLEO_ResolvePath

--- a/cleo_plugins/FileSystemOperations/FileSystemOperations.cpp
+++ b/cleo_plugins/FileSystemOperations/FileSystemOperations.cpp
@@ -217,13 +217,6 @@ public:
 
         int size = CLEO_GetIntOpcodeParam(thread);
 
-        if (is_legacy_handle(handle))
-        {
-            auto info = scriptInfoStr(thread);
-            SHOW_ERROR("Opcode [0AD7] used in legacy mode in script %s\nScript suspended.", info.c_str());
-            return thread->Suspend();
-        }
-
         if (size <= 0)
         {
             CLEO_SetThreadCondResult(thread, false);
@@ -234,8 +227,7 @@ public:
         tmpBuff.resize(size);
         auto data = tmpBuff.data();
 
-        FILE* file = convert_handle_to_file(handle);
-        bool ok = fgets(data, size, file) != nullptr;
+        bool ok = file_get_s(data, size, handle) != nullptr;
         if(!ok)
         {
             CLEO_SetThreadCondResult(thread, false);
@@ -249,7 +241,7 @@ public:
         memcpy(buffer, data, resultSize);
         if(resultSize < bufferSize) buffer[resultSize] = '\0'; // terminate string whenever possible
 
-        CLEO_SetThreadCondResult(thread, false);
+        CLEO_SetThreadCondResult(thread, true);
         return OR_CONTINUE;
     }
 

--- a/cleo_plugins/FileSystemOperations/FileSystemOperations.cpp
+++ b/cleo_plugins/FileSystemOperations/FileSystemOperations.cpp
@@ -218,11 +218,17 @@ public:
         CLEO_ReadStringParamWriteBuffer(thread, &buffer, &bufferSize, &needsTerminator);
 
         int size = CLEO_GetIntOpcodeParam(thread);
-
-        if (size <= 0)
+        if (size == 0)
         {
+            if (bufferSize > 0) buffer[0] = '\0';
             CLEO_SetThreadCondResult(thread, false);
             return OR_CONTINUE;
+        }
+        if (size < 0)
+        {
+            auto info = scriptInfoStr(thread);
+            SHOW_ERROR("Invalid size argument (%d) in opcode [0AD7] in script %s\nScript suspended.", size, info.c_str());
+            return thread->Suspend();
         }
 
         std::vector<char> tmpBuff;

--- a/cleo_plugins/FileSystemOperations/FileSystemOperations.vcxproj
+++ b/cleo_plugins/FileSystemOperations/FileSystemOperations.vcxproj
@@ -112,6 +112,9 @@ xcopy /Y "$(OutDir)$(TargetName).*" "$(GTA_SA_DIR)\cleo\cleo_plugins\" </Command
   <ItemGroup>
     <ClCompile Include="FileSystemOperations.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="FileUtils.h" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/cleo_plugins/FileSystemOperations/FileSystemOperations.vcxproj
+++ b/cleo_plugins/FileSystemOperations/FileSystemOperations.vcxproj
@@ -114,6 +114,7 @@ xcopy /Y "$(OutDir)$(TargetName).*" "$(GTA_SA_DIR)\cleo\cleo_plugins\" </Command
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="FileUtils.h" />
+    <ClInclude Include="Utils.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/cleo_plugins/FileSystemOperations/FileSystemOperations.vcxproj
+++ b/cleo_plugins/FileSystemOperations/FileSystemOperations.vcxproj
@@ -111,6 +111,7 @@ xcopy /Y "$(OutDir)$(TargetName).*" "$(GTA_SA_DIR)\cleo\cleo_plugins\" </Command
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="FileSystemOperations.cpp" />
+    <ClCompile Include="FileUtils.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="FileUtils.h" />

--- a/cleo_plugins/FileSystemOperations/FileSystemOperations.vcxproj.filters
+++ b/cleo_plugins/FileSystemOperations/FileSystemOperations.vcxproj.filters
@@ -5,5 +5,6 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="FileUtils.h" />
+    <ClInclude Include="Utils.h" />
   </ItemGroup>
 </Project>

--- a/cleo_plugins/FileSystemOperations/FileSystemOperations.vcxproj.filters
+++ b/cleo_plugins/FileSystemOperations/FileSystemOperations.vcxproj.filters
@@ -3,4 +3,7 @@
   <ItemGroup>
     <ClCompile Include="FileSystemOperations.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="FileUtils.h" />
+  </ItemGroup>
 </Project>

--- a/cleo_plugins/FileSystemOperations/FileSystemOperations.vcxproj.filters
+++ b/cleo_plugins/FileSystemOperations/FileSystemOperations.vcxproj.filters
@@ -2,6 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClCompile Include="FileSystemOperations.cpp" />
+    <ClCompile Include="FileUtils.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="FileUtils.h" />

--- a/cleo_plugins/FileSystemOperations/FileUtils.cpp
+++ b/cleo_plugins/FileSystemOperations/FileUtils.cpp
@@ -1,0 +1,425 @@
+#include "FileUtils.h"
+#include <string>
+
+DWORD File::FUNC_fopen = 0;
+DWORD File::FUNC_fclose = 0;
+DWORD File::FUNC_fread = 0;
+DWORD File::FUNC_fwrite = 0;
+DWORD File::FUNC_fgetc = 0;
+DWORD File::FUNC_fgets = 0;
+DWORD File::FUNC_fputs = 0;
+DWORD File::FUNC_fseek = 0;
+DWORD File::FUNC_fprintf = 0;
+DWORD File::FUNC_ftell = 0;
+DWORD File::FUNC_fflush = 0;
+DWORD File::FUNC_feof = 0;
+DWORD File::FUNC_ferror = 0;
+
+void File::initialize(CLEO::eGameVersion version)
+{
+	// GV_US10, GV_US11, GV_EU10, GV_EU11, GV_STEAM
+	const DWORD MA_FOPEN_FUNCTION[] =	{ 0x008232D8, 0, 0x00823318, 0x00824098, 0x0085C75E };
+	const DWORD MA_FCLOSE_FUNCTION[] =	{ 0x0082318B, 0, 0x008231CB, 0x00823F4B, 0x0085C396 };
+	const DWORD MA_FGETC_FUNCTION[] =	{ 0x008231DC, 0, 0x0082321C, 0x00823F9C, 0x0085C680 };
+	const DWORD MA_FGETS_FUNCTION[] =	{ 0x00823798, 0, 0x008237D8, 0x00824558, 0x0085D00C };
+	const DWORD MA_FPUTS_FUNCTION[] =	{ 0x008262B8, 0, 0x008262F8, 0x00826BA8, 0x008621F1 };
+	const DWORD MA_FREAD_FUNCTION[] =	{ 0x00823521, 0, 0x00823561, 0x008242E1, 0x0085CD04 };
+	const DWORD MA_FWRITE_FUNCTION[] =	{ 0x00823674, 0, 0x008236B4, 0x00824434, 0x0085CE7E };
+	const DWORD MA_FSEEK_FUNCTION[] =	{ 0x0082374F, 0, 0x0082378F, 0x0082450F, 0x0085CF87 };
+	const DWORD MA_FPRINTF_FUNCTION[] = { 0x00823A30, 0, 0x00823A70, 0x008247F0, 0x0085D464 };
+	const DWORD MA_FTELL_FUNCTION[] =	{ 0x00826261, 0, 0x008262A1, 0x00826B51, 0x00862183 };
+	const DWORD MA_FFLUSH_FUNCTION[] =	{ 0x00823E86, 0, 0x00823EC6, 0x00824C46, 0x0085DDDD };
+	const DWORD MA_FEOF_FUNCTION[] =	{ 0x008262A2, 0, 0x008262E2, 0x00826B92, 0x0085D193 };
+	const DWORD MA_FERROR_FUNCTION[] =	{ 0x008262AD, 0, 0x008262ED, 0x00826B9D, 0x0085D1C2 };
+
+	FUNC_fopen = MA_FOPEN_FUNCTION[version];
+	FUNC_fclose = MA_FCLOSE_FUNCTION[version];
+	FUNC_fread = MA_FREAD_FUNCTION[version];
+	FUNC_fwrite = MA_FWRITE_FUNCTION[version];
+	FUNC_fgetc = MA_FGETC_FUNCTION[version];
+	FUNC_fgets = MA_FGETS_FUNCTION[version];
+	FUNC_fputs = MA_FPUTS_FUNCTION[version];
+	FUNC_fseek = MA_FSEEK_FUNCTION[version];
+	FUNC_fprintf = MA_FPRINTF_FUNCTION[version];
+	FUNC_ftell = MA_FTELL_FUNCTION[version];
+	FUNC_fflush = MA_FFLUSH_FUNCTION[version];
+	FUNC_feof = MA_FEOF_FUNCTION[version];
+	FUNC_ferror = MA_FERROR_FUNCTION[version];;
+}
+
+bool File::isLegacy(DWORD handle) { return (handle & 0x1) == 0; }
+
+FILE* File::handleToFile(DWORD handle) { return (FILE*)(handle & ~0x1); }
+
+DWORD File::fileToHandle(FILE* file, bool legacy)
+{
+	if (file == nullptr) return 0;
+
+	auto handle = (DWORD)file;
+	if (!legacy) handle |= 0x1;
+	return handle;
+}
+
+bool File::flush(DWORD handle)
+{
+	FILE* file = handleToFile(handle);
+	if (file == nullptr) return false;
+
+	int result = 0;
+	if (isLegacy(handle))
+	{
+		_asm
+		{
+			push file
+			call FUNC_fflush
+			add esp, 0x4
+			mov result, eax
+		}
+	}
+	else
+		result = fflush(file);
+
+	return result == 0;
+}
+
+DWORD File::open(const char* filename, const char* mode, bool legacy)
+{
+	FILE* file = nullptr;
+	if (legacy)
+	{
+		_asm
+		{
+			push mode
+			push filename
+			call FUNC_fopen
+			add esp, 8
+			mov file, eax
+		}
+	}
+	else
+		file = fopen(filename, mode);
+
+	return fileToHandle(file, legacy);
+}
+
+void File::close(DWORD handle)
+{
+	FILE* file = handleToFile(handle);
+	if (file == nullptr) return;
+
+	if (isLegacy(handle))
+	{
+		_asm
+		{
+			push file
+			call FUNC_fclose
+			add esp, 4
+		}
+	}
+	else
+		fclose(file);
+}
+
+bool File::isOk(DWORD handle)
+{
+	FILE* file = handleToFile(handle);
+	if (file == nullptr) return false;
+
+	int result = 0;
+	if (isLegacy(handle))
+	{
+		_asm
+		{
+			push file
+			call FUNC_ferror
+			add esp, 0x4
+		}
+	}
+	else
+		result = ferror(file);
+
+	return result == 0;
+}
+
+DWORD File::getSize(DWORD handle)
+{
+	auto pos = getPos(handle);
+	seek(handle, 0, SEEK_END);
+	DWORD size = getPos(handle);
+	seek(handle, pos, SEEK_SET);
+	return size;
+}
+
+bool File::seek(DWORD handle, int offset, DWORD orign)
+{
+	FILE* file = handleToFile(handle);
+	if (file == nullptr) return false;
+
+	int result = 0;
+	if (isLegacy(handle))
+	{
+		auto off = offset; // 'offset' is keyword in asm
+		_asm
+		{
+			push orign
+			push off
+			push file
+			call FUNC_fseek
+			add esp, 0xC
+			mov result, eax
+		}
+	}
+	else
+		result = fseek(file, offset, orign);
+
+	return result == 0;
+}
+
+DWORD File::getPos(DWORD handle)
+{
+	FILE* file = handleToFile(handle);
+	if (file == nullptr) return 0;
+
+	DWORD pos = 0;
+	if (isLegacy(handle))
+	{
+		_asm
+		{
+			push file
+			call FUNC_ftell
+			add esp, 0x4
+			mov pos, eax
+		}
+	}
+	else
+		pos = (DWORD)ftell(file);
+
+	return pos;
+}
+
+bool File::isEndOfFile(DWORD handle)
+{
+	FILE* file = handleToFile(handle);
+	if (file == nullptr) return true;
+
+	int result = 0;
+	if (isLegacy(handle))
+	{
+		_asm
+		{
+			push file
+			call FUNC_feof
+			add esp, 0x4
+			mov result, eax
+		}
+	}
+	else
+		result = feof(file);
+
+	return result != 0;
+}
+
+DWORD File::read(DWORD handle, void* buffer, DWORD size)
+{
+	FILE* file = handleToFile(handle);
+	if (file == nullptr) return 0;
+
+	DWORD read = 0;
+	if (isLegacy(handle))
+	{
+		auto siz = size; // 'size' is keyword in asm
+		_asm
+		{
+			push file
+			push siz
+			push 1
+			push buffer
+			call FUNC_fread
+			add esp, 0x10
+			mov read, eax
+		}
+	}
+	else
+		read = fread(buffer, 1, size, file);
+
+	seek(handle, 0, SEEK_CUR); // required for RW streams (https://en.wikibooks.org/wiki/C_Programming/stdio.h/fopen)
+
+	return read;
+}
+
+char File::readChar(DWORD handle)
+{
+	FILE* file = handleToFile(handle);
+	if (file == nullptr) return 0;
+
+	char result = '_';
+	if (isLegacy(handle))
+	{
+		_asm
+		{
+			push file
+			call FUNC_fgetc
+			add esp, 0x4
+			mov result, al
+		}
+	}
+	else
+		result = fgetc(file);
+
+	seek(handle, 0, SEEK_CUR); // required for RW streams (https://en.wikibooks.org/wiki/C_Programming/stdio.h/fopen)
+
+	return result;
+}
+
+char* File::readString(DWORD handle, char* buffer, DWORD bufferSize)
+{
+	FILE* file = handleToFile(handle);
+	if (file == nullptr) return nullptr;
+
+	char* result = nullptr;
+	if (isLegacy(handle))
+	{
+		_asm
+		{
+			push file
+			push bufferSize
+			push buffer
+			call FUNC_fgets
+			add esp, 0xC
+			mov result, eax
+		}
+	}
+	else
+		result = fgets(buffer, bufferSize, file);
+
+	seek(handle, 0, SEEK_CUR); // required for RW streams (https://en.wikibooks.org/wiki/C_Programming/stdio.h/fopen)
+
+	return result;
+}
+
+DWORD File::write(DWORD handle, const void* buffer, DWORD size)
+{
+	FILE* file = handleToFile(handle);
+	if (file == nullptr) return 0;
+
+	DWORD writen = 0;
+	if (isLegacy(handle))
+	{
+		auto siz = size; // 'size' is keyword in asm
+		_asm
+		{
+			push file
+			push siz
+			push 1
+			push buffer
+			call FUNC_fwrite
+			add esp, 0x10
+			mov writen, eax
+		}
+	}
+	else
+		writen = (DWORD)fwrite(buffer, 1, size, file);
+
+	seek(handle, 0, SEEK_CUR); // required for RW streams (https://en.wikibooks.org/wiki/C_Programming/stdio.h/fopen)
+
+	return writen;
+}
+
+bool File::writeString(DWORD handle, const char* text)
+{
+	FILE* file = handleToFile(handle);
+	if (file == nullptr) return 0;
+
+	int result = 0;
+	if (isLegacy(handle))
+	{
+		_asm
+		{
+			push file
+			push text
+			call FUNC_fputs
+			add esp, 0x8
+			mov result, eax
+		}
+	}
+	else
+		result = (DWORD)fputs(text, file);
+
+	seek(handle, 0, SEEK_CUR); // required for RW streams (https://en.wikibooks.org/wiki/C_Programming/stdio.h/fopen)
+
+	return result >= 0;
+}
+
+DWORD File::scan(DWORD handle, const char* format, void** outputParams)
+{
+	FILE* file = handleToFile(handle);
+	if (file == nullptr) return 0;
+
+	int read = 0;
+	if (isLegacy(handle))
+	{
+		// fscanf not existent in game's code. Emulate it
+
+		size_t paramCount = 0;
+		const char* f = format;
+		while(*f != '\0')
+		{
+			if (*f == '%')
+			{
+				if (*(f + 1) != '%') // not escaped %
+					paramCount++;
+				else
+					f++; // skip escaped
+			}
+			f++;
+		}
+
+		auto newFormat = std::string(format) + "%n"; // %n returns characters processed by
+		DWORD charRead = 0;
+		outputParams[paramCount] = &charRead;
+
+		DWORD prevCharRead = 0;
+		std::string readText;
+		while(true)
+		{
+			readText += readChar(handle);
+
+			prevCharRead = charRead;
+			auto p = outputParams;
+			read = sscanf(readText.c_str(), newFormat.c_str(),
+				p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8], p[9], // 10
+				p[10], p[11], p[12], p[13], p[14], p[15], p[16], p[17], p[18], p[19], // 20
+				p[20], p[21], p[22], p[23], p[24], p[25], p[26], p[27], p[28], p[29], // 30
+				p[30], p[31], p[32], p[33], p[34]); // 35
+
+			if (!isOk(handle)) break;
+
+			if (read == paramCount)
+			{
+				if (charRead == prevCharRead) // all params collected and scan doesn't consume input text anymore
+				{
+					seek(handle, -1, SEEK_CUR); // return the character not used by scan
+					break;
+				}
+
+				if (isEndOfFile(handle))
+				{
+					break;
+				}
+			}
+		}
+	}
+	else
+	{
+		auto p = outputParams;
+		read = 	fscanf(file, format, 
+			p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8], p[9], // 10
+			p[10], p[11], p[12], p[13], p[14], p[15], p[16], p[17], p[18], p[19], // 20
+			p[20], p[21], p[22], p[23], p[24], p[25], p[26], p[27], p[28], p[29], // 30
+			p[30], p[31], p[32], p[33], p[34]); // 35
+	}
+
+	seek(handle, 0, SEEK_CUR); // required for RW streams (https://en.wikibooks.org/wiki/C_Programming/stdio.h/fopen)
+
+	return read;
+}

--- a/cleo_plugins/FileSystemOperations/FileUtils.h
+++ b/cleo_plugins/FileSystemOperations/FileUtils.h
@@ -1,283 +1,49 @@
 #pragma once
 #include "CLEO.h"
-#include <cstdio>
+#include <stdio.h>
 #include <wtypes.h>
 
-static DWORD FUNC_fopen = 0;
-static DWORD FUNC_fclose = 0;
-static DWORD FUNC_fread = 0;
-static DWORD FUNC_fwrite = 0;
-static DWORD FUNC_fgetc = 0;
-static DWORD FUNC_fgets = 0;
-static DWORD FUNC_fputs = 0;
-static DWORD FUNC_fseek = 0;
-static DWORD FUNC_fprintf = 0;
-static DWORD FUNC_ftell = 0;
-static DWORD FUNC_fflush = 0;
-static DWORD FUNC_feof = 0;
-static DWORD FUNC_ferror = 0;
-
-void InitializeFileFunc(CLEO::eGameVersion version)
+class File
 {
-	// GV_US10, GV_US11, GV_EU10, GV_EU11, GV_STEAM
-	const DWORD MA_FOPEN_FUNCTION[] =	{ 0x008232D8,	0, 0x00823318, 0x00824098, 0x0085C75E };
-	const DWORD MA_FCLOSE_FUNCTION[] =	{ 0x0082318B,	0, 0x008231CB, 0x00823F4B, 0x0085C396 };
-	const DWORD MA_FGETC_FUNCTION[]	=	{ 0x008231DC,	0, 0x0082321C, 0x00823F9C, 0x0085C680 };
-	const DWORD MA_FGETS_FUNCTION[]	= 	{ 0x00823798,	0, 0x008237D8, 0x00824558, 0x0085D00C };
-	const DWORD MA_FPUTS_FUNCTION[]	= 	{ 0x008262B8,	0, 0x008262F8, 0x00826BA8, 0x008621F1 };
-	const DWORD MA_FREAD_FUNCTION[]	= 	{ 0x00823521,	0, 0x00823561, 0x008242E1, 0x0085CD04 };
-	const DWORD MA_FWRITE_FUNCTION[] =	{ 0x00823674,	0, 0x008236B4, 0x00824434, 0x0085CE7E };
-	const DWORD MA_FSEEK_FUNCTION[]	= 	{ 0x0082374F,	0, 0x0082378F, 0x0082450F, 0x0085CF87 };
-	const DWORD MA_FPRINTF_FUNCTION[] =	{ 0x00823A30,	0, 0x00823A70, 0x008247F0, 0x0085D464 };
-	const DWORD MA_FTELL_FUNCTION[] = 	{ 0x00826261,	0, 0x008262A1, 0x00826B51, 0x00862183 };
-	const DWORD MA_FFLUSH_FUNCTION[] =	{ 0x00823E86,	0, 0x00823EC6, 0x00824C46, 0x0085DDDD };
-	const DWORD MA_FEOF_FUNCTION[] =	{ 0x008262A2,	0, 0x008262E2, 0x00826B92, 0x0085D193 };
-	const DWORD MA_FERROR_FUNCTION[] =	{ 0x008262AD,	0, 0x008262ED, 0x00826B9D, 0x0085D1C2 };
+public:
+	static void initialize(CLEO::eGameVersion version);
 
-	FUNC_fopen = MA_FOPEN_FUNCTION[version];
-	FUNC_fclose = MA_FCLOSE_FUNCTION[version];
-	FUNC_fread = MA_FREAD_FUNCTION[version];
-	FUNC_fwrite = MA_FWRITE_FUNCTION[version];
-	FUNC_fgetc = MA_FGETC_FUNCTION[version];
-	FUNC_fgets = MA_FGETS_FUNCTION[version];
-	FUNC_fputs = MA_FPUTS_FUNCTION[version];
-	FUNC_fseek = MA_FSEEK_FUNCTION[version];
-	FUNC_fprintf = MA_FPRINTF_FUNCTION[version];
-	FUNC_ftell = MA_FTELL_FUNCTION[version];
-	FUNC_fflush = MA_FFLUSH_FUNCTION[version];
-	FUNC_feof = MA_FEOF_FUNCTION[version];
-	FUNC_ferror = MA_FERROR_FUNCTION[version];
-}
+	static DWORD open(const char* filename, const char* mode, bool legacy);
+	static void close(DWORD handle);
 
-// Legacy modes for CLEO 3
-bool is_legacy_handle(DWORD dwHandle) 
-{ 
-	return (dwHandle & 0x1) == 0; 
-}
+	static bool isOk(DWORD handle);
 
-FILE* convert_handle_to_file(DWORD dwHandle) 
-{
-	return (FILE*)(dwHandle & ~0x1);
-}
+	static DWORD getSize(DWORD handle);
+	static bool seek(DWORD handle, int offset, DWORD orign);
+	static DWORD getPos(DWORD handle);
+	static bool isEndOfFile(DWORD handle);
 
-DWORD convert_file_to_handle(FILE* file, bool legacy)
-{
-	if (file == nullptr) return 0;
+	static DWORD read(DWORD handle, void* buffer, DWORD size);
+	static char readChar(DWORD handle);
+	static char* readString(DWORD handle, char* buffer, DWORD bufferSize);
 
-	auto handle = (DWORD)file;
-	if (!legacy) handle |= 0x1;
-	return handle;
-}
+	static DWORD write(DWORD handle, const void* buffer, DWORD size);
+	static bool writeString(DWORD handle, const char* text);
+	static DWORD scan(DWORD handle, const char* format, void** outputParams);
+	static bool flush(DWORD handle);
 
-FILE* legacy_fopen(const char* szPath, const char* szMode)
-{
-	FILE* hFile;
-	_asm
-	{
-		push szMode
-		push szPath
-		call FUNC_fopen
-		add esp, 8
-		mov hFile, eax
-	}
-	return hFile;
-}
+	static bool isLegacy(DWORD handle); // Legacy modes for CLEO 3
+	static FILE* handleToFile(DWORD handle);
+	
+private:
+	static DWORD FUNC_fopen;
+	static DWORD FUNC_fclose;
+	static DWORD FUNC_fread;
+	static DWORD FUNC_fwrite;
+	static DWORD FUNC_fgetc;
+	static DWORD FUNC_fgets;
+	static DWORD FUNC_fputs;
+	static DWORD FUNC_fseek;
+	static DWORD FUNC_fprintf;
+	static DWORD FUNC_ftell;
+	static DWORD FUNC_fflush;
+	static DWORD FUNC_feof;
+	static DWORD FUNC_ferror;
 
-void legacy_fclose(FILE* hFile)
-{
-	_asm
-	{
-		push hFile
-		call FUNC_fclose
-		add esp, 4
-	}
-}
-
-size_t legacy_fread(void* buf, size_t len, size_t count, FILE* stream)
-{
-	_asm
-	{
-		push stream
-		push count
-		push len
-		push buf
-		call FUNC_fread
-		add esp, 0x10
-	}
-}
-
-size_t legacy_fwrite(const void* buf, size_t len, size_t count, FILE* stream)
-{
-	_asm
-	{
-		push stream
-		push count
-		push len
-		push buf
-		call FUNC_fwrite
-		add esp, 0x10
-	}
-}
-
-char legacy_fgetc(FILE* stream)
-{
-	_asm
-	{
-		push stream
-		call FUNC_fgetc
-		add esp, 0x4
-	}
-}
-
-char* legacy_fgets(char* pStr, int num, FILE* stream)
-{
-	_asm
-	{
-		push stream
-		push num
-		push pStr
-		call FUNC_fgets
-		add esp, 0xC
-	}
-}
-
-int legacy_fputs(const char* pStr, FILE* stream)
-{
-	_asm
-	{
-		push stream
-		push pStr
-		call FUNC_fputs
-		add esp, 0x8
-	}
-}
-
-int legacy_fseek(FILE* stream, long int offs, int original)
-{
-	_asm
-	{
-		push stream
-		push offs
-		push original
-		call FUNC_fseek
-		add esp, 0xC
-	}
-}
-
-int legacy_ftell(FILE* stream)
-{
-	_asm
-	{
-		push stream
-		call FUNC_ftell
-		add esp, 0x4
-	}
-}
-
-/*int __declspec(naked) fprintf(FILE* stream, const char* format, ...)
-{
-	_asm jmp FUNC_fprintf
-}*/
-
-int legacy_fflush(FILE* stream)
-{
-	_asm
-	{
-		push stream
-		call FUNC_fflush
-		add esp, 0x4
-	}
-}
-
-int legacy_feof(FILE* stream)
-{
-	_asm
-	{
-		push stream
-		call FUNC_feof
-		add esp, 0x4
-	}
-}
-
-int legacy_ferror(FILE* stream)
-{
-	_asm
-	{
-		push stream
-		call FUNC_ferror
-		add esp, 0x4
-	}
-}
-
-DWORD open_file(const char* path, const char* mode, bool legacy)
-{
-	FILE* hFile = legacy ? legacy_fopen(path, mode) : fopen(path, mode);
-	return convert_file_to_handle(hFile, legacy);
-}
-
-void close_file(DWORD handle)
-{
-	FILE* file = convert_handle_to_file(handle);
-	if (file == nullptr) return;
-
-	if (is_legacy_handle(handle))
-		legacy_fclose(file);
-	else 
-		fclose(file);
-}
-
-DWORD file_get_size(DWORD handle)
-{
-	FILE* file = convert_handle_to_file(handle);
-	if (file == nullptr) return 0;
-
-	auto savedPos = ftell(file);
-	fseek(file, 0, SEEK_END);
-	DWORD size = static_cast<DWORD>(ftell(file));
-	fseek(file, savedPos, SEEK_SET);
-	return size;
-}
-
-DWORD read_file(void* buf, DWORD size, DWORD count, DWORD handle)
-{
-	FILE* file = convert_handle_to_file(handle);
-	if (file == nullptr) return 0;
-
-	if (is_legacy_handle(handle))
-		return legacy_fread(buf, size, 1, file);
-	else
-		return fread(buf, size, 1, file);
-}
-
-DWORD write_file(const void* buf, DWORD size, DWORD count, DWORD handle)
-{
-	FILE* file = convert_handle_to_file(handle);
-	if (file == nullptr) return 0;
-
-	if (is_legacy_handle(handle))
-		return legacy_fwrite(buf, size, 1, file);
-	else
-		return fwrite(buf, size, 1, file);
-}
-
-char* file_get_s(char* buf, DWORD bufSize, DWORD handle)
-{
-	FILE* file = convert_handle_to_file(handle);
-	if (file == nullptr) return nullptr;
-
-	if (is_legacy_handle(handle))
-		return legacy_fgets(buf, bufSize, file);
-	else
-		return fgets(buf, bufSize, file);
-}
-
-void flush_file(DWORD handle)
-{
-	FILE* file = convert_handle_to_file(handle);
-	if (file == nullptr) return;
-
-	if (is_legacy_handle(handle))
-		legacy_fflush(file);
-	else
-		fflush(file);
-}
+	static DWORD fileToHandle(FILE* file, bool legacy);
+};

--- a/cleo_plugins/FileSystemOperations/FileUtils.h
+++ b/cleo_plugins/FileSystemOperations/FileUtils.h
@@ -1,0 +1,272 @@
+#pragma once
+#include "CLEO.h"
+#include <cstdio>
+#include <wtypes.h>
+
+static DWORD FUNC_fopen = 0;
+static DWORD FUNC_fclose = 0;
+static DWORD FUNC_fread = 0;
+static DWORD FUNC_fwrite = 0;
+static DWORD FUNC_fgetc = 0;
+static DWORD FUNC_fgets = 0;
+static DWORD FUNC_fputs = 0;
+static DWORD FUNC_fseek = 0;
+static DWORD FUNC_fprintf = 0;
+static DWORD FUNC_ftell = 0;
+static DWORD FUNC_fflush = 0;
+static DWORD FUNC_feof = 0;
+static DWORD FUNC_ferror = 0;
+
+void InitializeFileFunc(CLEO::eGameVersion version)
+{
+	// GV_US10, GV_US11, GV_EU10, GV_EU11, GV_STEAM
+	const DWORD MA_FOPEN_FUNCTION[] =	{ 0x008232D8,	0, 0x00823318, 0x00824098, 0x0085C75E };
+	const DWORD MA_FCLOSE_FUNCTION[] =	{ 0x0082318B,	0, 0x008231CB, 0x00823F4B, 0x0085C396 };
+	const DWORD MA_FGETC_FUNCTION[]	=	{ 0x008231DC,	0, 0x0082321C, 0x00823F9C, 0x0085C680 };
+	const DWORD MA_FGETS_FUNCTION[]	= 	{ 0x00823798,	0, 0x008237D8, 0x00824558, 0x0085D00C };
+	const DWORD MA_FPUTS_FUNCTION[]	= 	{ 0x008262B8,	0, 0x008262F8, 0x00826BA8, 0x008621F1 };
+	const DWORD MA_FREAD_FUNCTION[]	= 	{ 0x00823521,	0, 0x00823561, 0x008242E1, 0x0085CD04 };
+	const DWORD MA_FWRITE_FUNCTION[] =	{ 0x00823674,	0, 0x008236B4, 0x00824434, 0x0085CE7E };
+	const DWORD MA_FSEEK_FUNCTION[]	= 	{ 0x0082374F,	0, 0x0082378F, 0x0082450F, 0x0085CF87 };
+	const DWORD MA_FPRINTF_FUNCTION[] =	{ 0x00823A30,	0, 0x00823A70, 0x008247F0, 0x0085D464 };
+	const DWORD MA_FTELL_FUNCTION[] = 	{ 0x00826261,	0, 0x008262A1, 0x00826B51, 0x00862183 };
+	const DWORD MA_FFLUSH_FUNCTION[] =	{ 0x00823E86,	0, 0x00823EC6, 0x00824C46, 0x0085DDDD };
+	const DWORD MA_FEOF_FUNCTION[] =	{ 0x008262A2,	0, 0x008262E2, 0x00826B92, 0x0085D193 };
+	const DWORD MA_FERROR_FUNCTION[] =	{ 0x008262AD,	0, 0x008262ED, 0x00826B9D, 0x0085D1C2 };
+
+	FUNC_fopen = MA_FOPEN_FUNCTION[version];
+	FUNC_fclose = MA_FCLOSE_FUNCTION[version];
+	FUNC_fread = MA_FGETC_FUNCTION[version];
+	FUNC_fwrite = MA_FGETS_FUNCTION[version];
+	FUNC_fgetc = MA_FPUTS_FUNCTION[version];
+	FUNC_fgets = MA_FREAD_FUNCTION[version];
+	FUNC_fputs = MA_FWRITE_FUNCTION[version];
+	FUNC_fseek = MA_FSEEK_FUNCTION[version];
+	FUNC_fprintf = MA_FPRINTF_FUNCTION[version];
+	FUNC_ftell = MA_FTELL_FUNCTION[version];
+	FUNC_fflush = MA_FFLUSH_FUNCTION[version];
+	FUNC_feof = MA_FEOF_FUNCTION[version];
+	FUNC_ferror = MA_FERROR_FUNCTION[version];
+}
+
+// Legacy modes for CLEO 3
+bool is_legacy_handle(DWORD dwHandle) 
+{ 
+	return (dwHandle & 0x1) == 0; 
+}
+
+FILE* convert_handle_to_file(DWORD dwHandle) 
+{
+	return (FILE*)(dwHandle & ~0x1);
+}
+
+DWORD convert_file_to_handle(FILE* file, bool legacy)
+{
+	if (file == nullptr) return 0;
+
+	auto handle = (DWORD)file;
+	if (!legacy) handle |= 0x1;
+	return handle;
+}
+
+FILE* legacy_fopen(const char* szPath, const char* szMode)
+{
+	FILE* hFile;
+	_asm
+	{
+		push szMode
+		push szPath
+		call FUNC_fopen
+		add esp, 8
+		mov hFile, eax
+	}
+	return hFile;
+}
+
+void legacy_fclose(FILE* hFile)
+{
+	_asm
+	{
+		push hFile
+		call FUNC_fclose
+		add esp, 4
+	}
+}
+
+size_t legacy_fread(void* buf, size_t len, size_t count, FILE* stream)
+{
+	_asm
+	{
+		push stream
+		push count
+		push len
+		push buf
+		call FUNC_fread
+		add esp, 0x10
+	}
+}
+
+size_t legacy_fwrite(const void* buf, size_t len, size_t count, FILE* stream)
+{
+	_asm
+	{
+		push stream
+		push count
+		push len
+		push buf
+		call FUNC_fwrite
+		add esp, 0x10
+	}
+}
+
+char legacy_fgetc(FILE* stream)
+{
+	_asm
+	{
+		push stream
+		call FUNC_fgetc
+		add esp, 0x4
+	}
+}
+
+char* legacy_fgets(char* pStr, int num, FILE* stream)
+{
+	_asm
+	{
+		push stream
+		push num
+		push pStr
+		call FUNC_fgets
+		add esp, 0xC
+	}
+}
+
+int legacy_fputs(const char* pStr, FILE* stream)
+{
+	_asm
+	{
+		push stream
+		push pStr
+		call FUNC_fputs
+		add esp, 0x8
+	}
+}
+
+int legacy_fseek(FILE* stream, long int offs, int original)
+{
+	_asm
+	{
+		push stream
+		push offs
+		push original
+		call FUNC_fseek
+		add esp, 0xC
+	}
+}
+
+int legacy_ftell(FILE* stream)
+{
+	_asm
+	{
+		push stream
+		call FUNC_ftell
+		add esp, 0x4
+	}
+}
+
+/*int __declspec(naked) fprintf(FILE* stream, const char* format, ...)
+{
+	_asm jmp FUNC_fprintf
+}*/
+
+int legacy_fflush(FILE* stream)
+{
+	_asm
+	{
+		push stream
+		call FUNC_fflush
+		add esp, 0x4
+	}
+}
+
+int legacy_feof(FILE* stream)
+{
+	_asm
+	{
+		push stream
+		call FUNC_feof
+		add esp, 0x4
+	}
+}
+
+int legacy_ferror(FILE* stream)
+{
+	_asm
+	{
+		push stream
+		call FUNC_ferror
+		add esp, 0x4
+	}
+}
+
+DWORD open_file(const char* path, const char* mode, bool legacy)
+{
+	FILE* hFile = legacy ? legacy_fopen(path, mode) : fopen(path, mode);
+	return convert_file_to_handle(hFile, legacy);
+}
+
+void close_file(DWORD handle)
+{
+	FILE* file = convert_handle_to_file(handle);
+	if (file == nullptr) return;
+
+	if (is_legacy_handle(handle))
+		legacy_fclose(file);
+	else 
+		fclose(file);
+}
+
+DWORD file_get_size(DWORD handle)
+{
+	FILE* file = convert_handle_to_file(handle);
+	if (file == nullptr) return 0;
+
+	auto savedPos = ftell(file);
+	fseek(file, 0, SEEK_END);
+	DWORD size = static_cast<DWORD>(ftell(file));
+	fseek(file, savedPos, SEEK_SET);
+	return size;
+}
+
+DWORD read_file(void* buf, DWORD size, DWORD count, DWORD handle)
+{
+	FILE* file = convert_handle_to_file(handle);
+	if (file == nullptr) return 0;
+
+	if (is_legacy_handle(handle))
+		return legacy_fread(buf, size, 1, file);
+	else
+		return fread(buf, size, 1, file);
+}
+
+DWORD write_file(const void* buf, DWORD size, DWORD count, DWORD handle)
+{
+	FILE* file = convert_handle_to_file(handle);
+	if (file == nullptr) return 0;
+
+	if (is_legacy_handle(handle))
+		return legacy_fwrite(buf, size, 1, file);
+	else
+		return fwrite(buf, size, 1, file);
+}
+
+void flush_file(DWORD handle)
+{
+	FILE* file = convert_handle_to_file(handle);
+	if (file == nullptr) return;
+
+	if (is_legacy_handle(handle))
+		legacy_fflush(file);
+	else
+		fflush(file);
+}

--- a/cleo_plugins/FileSystemOperations/FileUtils.h
+++ b/cleo_plugins/FileSystemOperations/FileUtils.h
@@ -260,6 +260,17 @@ DWORD write_file(const void* buf, DWORD size, DWORD count, DWORD handle)
 		return fwrite(buf, size, 1, file);
 }
 
+char* file_get_s(char* buf, DWORD bufSize, DWORD handle)
+{
+	FILE* file = convert_handle_to_file(handle);
+	if (file == nullptr) return nullptr;
+
+	if (is_legacy_handle(handle))
+		return legacy_fgets(buf, bufSize, file);
+	else
+		return fgets(buf, bufSize, file);
+}
+
 void flush_file(DWORD handle)
 {
 	FILE* file = convert_handle_to_file(handle);

--- a/cleo_plugins/FileSystemOperations/FileUtils.h
+++ b/cleo_plugins/FileSystemOperations/FileUtils.h
@@ -36,11 +36,11 @@ void InitializeFileFunc(CLEO::eGameVersion version)
 
 	FUNC_fopen = MA_FOPEN_FUNCTION[version];
 	FUNC_fclose = MA_FCLOSE_FUNCTION[version];
-	FUNC_fread = MA_FGETC_FUNCTION[version];
-	FUNC_fwrite = MA_FGETS_FUNCTION[version];
-	FUNC_fgetc = MA_FPUTS_FUNCTION[version];
-	FUNC_fgets = MA_FREAD_FUNCTION[version];
-	FUNC_fputs = MA_FWRITE_FUNCTION[version];
+	FUNC_fread = MA_FREAD_FUNCTION[version];
+	FUNC_fwrite = MA_FWRITE_FUNCTION[version];
+	FUNC_fgetc = MA_FGETC_FUNCTION[version];
+	FUNC_fgets = MA_FGETS_FUNCTION[version];
+	FUNC_fputs = MA_FPUTS_FUNCTION[version];
 	FUNC_fseek = MA_FSEEK_FUNCTION[version];
 	FUNC_fprintf = MA_FPRINTF_FUNCTION[version];
 	FUNC_ftell = MA_FTELL_FUNCTION[version];

--- a/cleo_plugins/FileSystemOperations/Utils.h
+++ b/cleo_plugins/FileSystemOperations/Utils.h
@@ -1,0 +1,90 @@
+#pragma once
+#include "CLEO.h"
+#include <string>
+#include <wtypes.h>
+
+std::string stringPrintf(const char* format, ...)
+{
+    va_list args;
+
+    va_start(args, format);
+    auto len = std::vsnprintf(nullptr, 0, format, args) + 1;
+    va_end(args);
+
+    std::string result(len, '\0');
+
+    va_start(args, format);
+    std::vsnprintf(result.data(), result.length(), format, args);
+    va_end(args);
+
+    return result;
+}
+
+std::string scriptInfoStr(CLEO::CRunningScript* thread)
+{
+    std::string info(1024, '\0');
+    CLEO_GetScriptInfoStr(thread, true, info.data(), info.length());
+    return std::move(info);
+}
+
+const char* TraceVArg(CLEO::eLogLevel level, const char* format, va_list args)
+{
+    static char szBuf[1024];
+    vsprintf(szBuf, format, args); // put params into format
+    CLEO_Log(level, szBuf);
+    return szBuf;
+}
+
+void Trace(CLEO::eLogLevel level, const char* format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    TraceVArg(level, format, args);
+    va_end(args);
+}
+
+void Trace(const CLEO::CRunningScript* thread, CLEO::eLogLevel level, const char* format, ...)
+{
+    if (CLEO_GetScriptVersion(thread) < CLEO::eCLEO_Version::CLEO_VER_5)
+    {
+        return; // do not log this in older versions
+    }
+
+    va_list args;
+    va_start(args, format);
+    TraceVArg(level, format, args);
+    va_end(args);
+}
+
+void ShowError(const char* format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    auto msg = TraceVArg(CLEO::eLogLevel::Error, format, args);
+    va_end(args);
+
+    QUERY_USER_NOTIFICATION_STATE pquns;
+    SHQueryUserNotificationState(&pquns);
+    bool fullscreen = (pquns == QUNS_BUSY) || (pquns == QUNS_RUNNING_D3D_FULL_SCREEN) || (pquns == QUNS_PRESENTATION_MODE);
+
+    if (fullscreen)
+    {
+        PostMessage(NULL, WM_SYSCOMMAND, SC_MINIMIZE, 0);
+        ShowWindow(NULL, SW_MINIMIZE);
+    }
+
+    MessageBox(NULL, msg, "CLEO error", MB_SYSTEMMODAL | MB_TOPMOST | MB_ICONERROR | MB_OK);
+
+    if (fullscreen)
+    {
+        PostMessage(NULL, WM_SYSCOMMAND, SC_RESTORE, 0);
+        ShowWindow(NULL, SW_RESTORE);
+    }
+}
+
+#define TRACE(format,...) {Trace(CLEO::eLogLevel::Default, format, __VA_ARGS__);}
+#define LOG_WARNING(script, format, ...) {Trace(script, CLEO::eLogLevel::Error, format, __VA_ARGS__);}
+#define SHOW_ERROR(a,...) {ShowError(a, __VA_ARGS__);}
+
+static const size_t MinValidAddress = 0x10000; // used for validation of pointers received from scripts. First 64kb are for sure reserved by Windows.
+#define OPCODE_VALIDATE_POINTER(x) if((size_t)x <= MinValidAddress) { auto info = scriptInfoStr(thread); SHOW_ERROR("Invalid '0x%X' pointer param in script %s \nScript suspended.", x, info.c_str()); return thread->Suspend(); }

--- a/cleo_sdk/CLEO.h
+++ b/cleo_sdk/CLEO.h
@@ -269,6 +269,14 @@ enum class eLogLevel : DWORD
 	Default // all log messages
 };
 
+enum OpcodeResult : char
+{
+	OR_NONE = -2,
+	OR_ERROR = -1,
+	OR_CONTINUE = 0,
+	OR_INTERRUPT = 1,
+};
+
 typedef int SCRIPT_HANDLE;
 typedef SCRIPT_HANDLE HANDLE_ACTOR, ACTOR, HACTOR, PED, HPED, HANDLE_PED;
 typedef SCRIPT_HANDLE HANDLE_CAR, CAR, HCAR, VEHICLE, HVEHICLE, HANDLE_VEHICLE;
@@ -354,6 +362,7 @@ public:
 	CRunningScript* GetPrev() const { return Previous; }
 	void SetIsExternal(bool b) { bIsExternal = b; }
 	void SetActive(bool b) { bIsActive = b; }
+	OpcodeResult Suspend() { WakeTime = 0xFFFFFFFF; return OpcodeResult::OR_INTERRUPT; } // suspend script execution forever
 	void SetNext(CRunningScript* v) { Next = v; }
 	void SetPrev(CRunningScript* v) { Previous = v; }
 	SCRIPT_VAR* GetVarPtr() { return LocalVar; }
@@ -397,14 +406,6 @@ static_assert(sizeof(CRunningScript) == 0xE0, "Invalid size of CRunningScript!")
 #else
 	typedef struct CRunningScript CScriptThread;
 #endif
-
-enum OpcodeResult : char
-{
-	OR_NONE = -2,
-	OR_ERROR = -1,
-	OR_CONTINUE = 0,
-	OR_INTERRUPT = 1,
-};
 
 typedef OpcodeResult (CALLBACK* _pOpcodeHandler)(CRunningScript*);
 typedef void(*FuncScriptDeleteDelegateT) (CRunningScript*);

--- a/cleo_sdk/CLEO.h
+++ b/cleo_sdk/CLEO.h
@@ -440,6 +440,7 @@ DWORD WINAPI CLEO_GetIntOpcodeParam(CRunningScript* thread);
 float WINAPI CLEO_GetFloatOpcodeParam(CRunningScript* thread);
 LPSTR WINAPI CLEO_ReadStringOpcodeParam(CRunningScript* thread, char* buf = nullptr, int bufSize = 0);
 LPSTR WINAPI CLEO_ReadStringPointerOpcodeParam(CRunningScript* thread, char* buf = nullptr, int bufSize = 0); // exactly same as CLEO_ReadStringOpcodeParam
+void WINAPI CLEO_ReadStringParamWriteBuffer(CRunningScript* thread, char** outBuf, int* outBufSize, DWORD* outNeedsTerminator); // get info about the string opcode param, so it can be written latter. If outNeedsTerminator is not 0 then whole bufSize can be used as text characters. Advances script to next param
 char* WINAPI CLEO_ReadParamsFormatted(CRunningScript* thread, const char* format, char* buf = nullptr, int bufSize = 0); // consumes all var-arg params and terminator
 
 // param skip without reading

--- a/source/CCustomOpcodeSystem.cpp
+++ b/source/CCustomOpcodeSystem.cpp
@@ -22,20 +22,6 @@ namespace CLEO
 	template<typename T> inline CRunningScript& operator<<(CRunningScript& thread, memory_pointer pval);
 	template<typename T> inline CRunningScript& operator>>(CRunningScript& thread, memory_pointer& pval);
 
-	DWORD FUNC_fopen;
-	DWORD FUNC_fclose;
-	DWORD FUNC_fwrite;
-	DWORD FUNC_fread;
-	DWORD FUNC_fgetc;
-	DWORD FUNC_fgets;
-	DWORD FUNC_fputs;
-	DWORD FUNC_fseek;
-	DWORD FUNC_fprintf;
-	DWORD FUNC_ftell;
-	DWORD FUNC_fflush;
-	DWORD FUNC_feof;
-	DWORD FUNC_ferror;
-
 	OpcodeResult __stdcall opcode_0A8C(CRunningScript *thread);
 	OpcodeResult __stdcall opcode_0A8D(CRunningScript *thread);
 	OpcodeResult __stdcall opcode_0A8E(CRunningScript *thread);
@@ -50,11 +36,6 @@ namespace CLEO
 	OpcodeResult __stdcall opcode_0A97(CRunningScript *thread);
 	OpcodeResult __stdcall opcode_0A98(CRunningScript *thread);
 	OpcodeResult __stdcall opcode_0A99(CRunningScript *thread);
-	OpcodeResult __stdcall opcode_0A9A(CRunningScript *thread);
-	OpcodeResult __stdcall opcode_0A9B(CRunningScript *thread);
-	OpcodeResult __stdcall opcode_0A9C(CRunningScript *thread);
-	OpcodeResult __stdcall opcode_0A9D(CRunningScript *thread);
-	OpcodeResult __stdcall opcode_0A9E(CRunningScript *thread);
 	OpcodeResult __stdcall opcode_0A9F(CRunningScript *thread);
 	OpcodeResult __stdcall opcode_0AA0(CRunningScript *thread);
 	OpcodeResult __stdcall opcode_0AA1(CRunningScript *thread);
@@ -108,12 +89,6 @@ namespace CLEO
 	OpcodeResult __stdcall opcode_0AD2(CRunningScript *thread);
 	OpcodeResult __stdcall opcode_0AD3(CRunningScript *thread);
 	OpcodeResult __stdcall opcode_0AD4(CRunningScript *thread);
-	OpcodeResult __stdcall opcode_0AD5(CRunningScript *thread);
-	OpcodeResult __stdcall opcode_0AD6(CRunningScript *thread);
-	OpcodeResult __stdcall opcode_0AD7(CRunningScript *thread);
-	OpcodeResult __stdcall opcode_0AD8(CRunningScript *thread);
-	OpcodeResult __stdcall opcode_0AD9(CRunningScript *thread);
-	OpcodeResult __stdcall opcode_0ADA(CRunningScript *thread);
 	OpcodeResult __stdcall opcode_0ADB(CRunningScript *thread);
 	OpcodeResult __stdcall opcode_0ADC(CRunningScript *thread);
 	OpcodeResult __stdcall opcode_0ADD(CRunningScript *thread);
@@ -390,8 +365,8 @@ namespace CLEO
 
 	void CCustomOpcodeSystem::FinalizeScriptObjects()
 	{
-		TRACE("Cleaning up script data... %u files, %u libs, %u allocations...",
-			m_hFiles.size(), m_hNativeLibs.size(), m_pAllocations.size()
+		TRACE("Cleaning up script data... %u libs, %u allocations...",
+			m_hNativeLibs.size(), m_pAllocations.size()
 		);
 
 		for (void* func : GetInstance().GetCallbacks(eCallbackId::ScriptsFinalize))
@@ -399,14 +374,6 @@ namespace CLEO
 			typedef void WINAPI callback(void);
 			((callback*)func)();
 		}
-
-		// clean up after opcode_0A9A
-		for (auto i = m_hFiles.begin(); i != m_hFiles.end(); ++i)
-		{
-			if (!is_legacy_handle(*i))
-				fclose(convert_handle_to_file(*i));
-		}
-		m_hFiles.clear();
 
 		// clean up after opcode_0AA2
 		std::for_each(m_hNativeLibs.begin(), m_hNativeLibs.end(), FreeLibrary);
@@ -437,11 +404,6 @@ namespace CLEO
 		CLEO_RegisterOpcode(0x0A97, opcode_0A97);
 		CLEO_RegisterOpcode(0x0A98, opcode_0A98);
 		CLEO_RegisterOpcode(0x0A99, opcode_0A99);
-		CLEO_RegisterOpcode(0x0A9A, opcode_0A9A);
-		CLEO_RegisterOpcode(0x0A9B, opcode_0A9B);
-		CLEO_RegisterOpcode(0x0A9C, opcode_0A9C);
-		CLEO_RegisterOpcode(0x0A9D, opcode_0A9D);
-		CLEO_RegisterOpcode(0x0A9E, opcode_0A9E);
 		CLEO_RegisterOpcode(0x0A9F, opcode_0A9F);
 		CLEO_RegisterOpcode(0x0AA0, opcode_0AA0);
 		CLEO_RegisterOpcode(0x0AA1, opcode_0AA1);
@@ -495,12 +457,6 @@ namespace CLEO
 		CLEO_RegisterOpcode(0x0AD2, opcode_0AD2);
 		CLEO_RegisterOpcode(0x0AD3, opcode_0AD3);
 		CLEO_RegisterOpcode(0x0AD4, opcode_0AD4);
-		CLEO_RegisterOpcode(0x0AD5, opcode_0AD5);
-		CLEO_RegisterOpcode(0x0AD6, opcode_0AD6);
-		CLEO_RegisterOpcode(0x0AD7, opcode_0AD7);
-		CLEO_RegisterOpcode(0x0AD8, opcode_0AD8);
-		CLEO_RegisterOpcode(0x0AD9, opcode_0AD9);
-		CLEO_RegisterOpcode(0x0ADA, opcode_0ADA);
 		CLEO_RegisterOpcode(0x0ADB, opcode_0ADB);
 		CLEO_RegisterOpcode(0x0ADC, opcode_0ADC);
 		CLEO_RegisterOpcode(0x0ADD, opcode_0ADD);
@@ -546,20 +502,6 @@ namespace CLEO
 		}
 		MemWrite(gvm.TranslateMemoryAddress(MA_OPCODE_HANDLER_REF), &customOpcodeHandlers);
 		MemWrite(0x00469EF0, &customOpcodeHandlers); // TODO: game version translation
-
-		FUNC_fopen = gvm.TranslateMemoryAddress(MA_FOPEN_FUNCTION);
-		FUNC_fclose = gvm.TranslateMemoryAddress(MA_FCLOSE_FUNCTION);
-		FUNC_fread = gvm.TranslateMemoryAddress(MA_FREAD_FUNCTION);
-		FUNC_fwrite = gvm.TranslateMemoryAddress(MA_FWRITE_FUNCTION);
-		FUNC_fgetc = gvm.TranslateMemoryAddress(MA_FGETC_FUNCTION);
-		FUNC_fgets = gvm.TranslateMemoryAddress(MA_FGETS_FUNCTION);
-		FUNC_fputs = gvm.TranslateMemoryAddress(MA_FPUTS_FUNCTION);
-		FUNC_fseek = gvm.TranslateMemoryAddress(MA_FSEEK_FUNCTION);
-		FUNC_fprintf = gvm.TranslateMemoryAddress(MA_FPRINTF_FUNCTION);
-		FUNC_ftell = gvm.TranslateMemoryAddress(MA_FTELL_FUNCTION);
-		FUNC_fflush = gvm.TranslateMemoryAddress(MA_FFLUSH_FUNCTION);
-		FUNC_feof = gvm.TranslateMemoryAddress(MA_FEOF_FUNCTION);
-		FUNC_ferror = gvm.TranslateMemoryAddress(MA_FERROR_FUNCTION);
 
 		pedPool = gvm.TranslateMemoryAddress(MA_PED_POOL);
 		vehiclePool = gvm.TranslateMemoryAddress(MA_VEHICLE_POOL);
@@ -1220,176 +1162,6 @@ namespace CLEO
 		return OR_CONTINUE;
 	}
 
-	// Legacy modes for CLEO 3
-	FILE* legacy_fopen(const char* szPath, const char* szMode)
-	{
-		FILE* hFile;
-		_asm
-		{
-			push szMode
-			push szPath
-			call FUNC_fopen
-			add esp, 8
-			mov hFile, eax
-		}
-		return hFile;
-	}
-	void legacy_fclose(FILE * hFile)
-	{
-		_asm
-		{
-			push hFile
-			call FUNC_fclose
-			add esp, 4
-		}
-	}
-	size_t legacy_fread(void * buf, size_t len, size_t count, FILE * stream)
-	{
-		_asm
-		{
-			push stream
-			push count
-			push len
-			push buf
-			call FUNC_fread
-			add esp, 0x10
-		}
-	}
-	size_t legacy_fwrite(const void * buf, size_t len, size_t count, FILE * stream)
-	{
-		_asm
-		{
-			push stream
-			push count
-			push len
-			push buf
-			call FUNC_fwrite
-			add esp, 0x10
-		}
-	}
-	char legacy_fgetc(FILE * stream)
-	{
-		_asm
-		{
-			push stream
-			call FUNC_fgetc
-			add esp, 0x4
-		}
-	}
-	char * legacy_fgets(char *pStr, int num, FILE * stream)
-	{
-		_asm
-		{
-			push stream
-			push num
-			push pStr
-			call FUNC_fgets
-			add esp, 0xC
-		}
-	}
-	int legacy_fputs(const char *pStr, FILE * stream)
-	{
-		_asm
-		{
-			push stream
-			push pStr
-			call FUNC_fputs
-			add esp, 0x8
-		}
-	}
-	int legacy_fseek(FILE * stream, long int offs, int original)
-	{
-		_asm
-		{
-			push stream
-			push offs
-			push original
-			call FUNC_fseek
-			add esp, 0xC
-		}
-	}
-	int legacy_ftell(FILE * stream)
-	{
-		_asm
-		{
-			push stream
-			call FUNC_ftell
-			add esp, 0x4
-		}
-	}
-	int __declspec(naked) fprintf(FILE * stream, const char * format, ...)
-	{
-		_asm jmp FUNC_fprintf
-	}
-	int legacy_fflush(FILE * stream)
-	{
-		_asm
-		{
-			push stream
-			call FUNC_fflush
-			add esp, 0x4
-		}
-	}
-	int legacy_feof(FILE * stream)
-	{
-		_asm
-		{
-			push stream
-			call FUNC_feof
-			add esp, 0x4
-		}
-	}
-	int legacy_ferror(FILE * stream)
-	{
-		_asm
-		{
-			push stream
-			call FUNC_ferror
-			add esp, 0x4
-		}
-	}
-
-	bool is_legacy_handle(DWORD dwHandle) { return (dwHandle & 0x1) == 0; }
-	FILE * convert_handle_to_file(DWORD dwHandle) { return dwHandle ? reinterpret_cast<FILE*>(is_legacy_handle(dwHandle) ? dwHandle : dwHandle & ~(0x1)) : nullptr; }
-
-	inline DWORD open_file(const char * szPath, const char * szMode, bool bLegacy)
-	{
-		FILE * hFile = bLegacy ? legacy_fopen(szPath, szMode) : fopen(szPath, szMode);
-		if (hFile) return bLegacy ? (DWORD)hFile : (DWORD)hFile | 0x1;
-		return NULL;
-	}
-	inline void close_file(DWORD dwHandle)
-	{
-		if (is_legacy_handle(dwHandle)) legacy_fclose(convert_handle_to_file(dwHandle));
-		else fclose(convert_handle_to_file(dwHandle));
-	}
-	inline DWORD file_get_size(DWORD file_handle)
-	{
-		FILE * hFile = convert_handle_to_file(file_handle);
-		if (hFile)
-		{
-			auto savedPos = ftell(hFile);
-			fseek(hFile, 0, SEEK_END);
-			DWORD dwSize = static_cast<DWORD>(ftell(hFile));
-			fseek(hFile, savedPos, SEEK_SET);
-			return dwSize;
-		}
-		return 0;
-	}
-	inline DWORD read_file(void *buf, DWORD size, DWORD count, DWORD hFile)
-	{
-		return is_legacy_handle(hFile) ? legacy_fread(buf, size, 1, convert_handle_to_file(hFile)) : fread(buf, size, 1, convert_handle_to_file(hFile));
-	}
-	inline DWORD write_file(const void *buf, DWORD size, DWORD count, DWORD hFile)
-	{
-		return is_legacy_handle(hFile) ? legacy_fwrite(buf, size, 1, convert_handle_to_file(hFile)) : fwrite(buf, size, 1, convert_handle_to_file(hFile));
-	}
-	inline void flush_file(DWORD dwHandle)
-	{
-		if (is_legacy_handle(dwHandle)) legacy_fflush(convert_handle_to_file(dwHandle));
-		else fflush(convert_handle_to_file(dwHandle));
-	}
-
 	inline void ThreadJump(CRunningScript *thread, int off)
 	{
 		thread->SetIp(off < 0 ? thread->GetBasePointer() - off : scmBlock + off);
@@ -1660,105 +1432,6 @@ namespace CLEO
 		{
 			auto path = ReadStringParam(thread); OPCODE_VALIDATE_STR_ARG_READ(path)
 			reinterpret_cast<CCustomScript*>(thread)->SetWorkDir(path);
-		}
-		return OR_CONTINUE;
-	}
-
-	//0A9A=3,%3d% = openfile %1d% mode %2d% // IF and SET
-	OpcodeResult __stdcall opcode_0A9A(CRunningScript *thread)
-	{
-		auto path = ReadStringParam(thread); OPCODE_VALIDATE_STR_ARG_READ(path)
-
-		auto filename = reinterpret_cast<CCustomScript*>(thread)->ResolvePath(path);
-		auto paramType = *thread->GetBytePointer();
-		char mode[0x10];
-
-		// either CLEO 3 or CLEO 4 made a big mistake! (they differ in one major unapparent preference)
-		// lets try to resolve this with a legacy mode
-		auto cs = (CCustomScript*)thread;
-		bool bLegacyMode = cs->IsCustom() && cs->GetCompatibility() < CLEO_VER_4_3;
-
-		if (paramType >= 1 && paramType <= 8)
-		{
-			// integer param (for backward compatibility with CLEO 3)
-			union
-			{
-				DWORD uParam;
-				char strParam[4];
-			} param;
-			*thread >> param.uParam;
-			strcpy(mode, param.strParam);
-		}
-		else
-		{
-			auto modeOk = ReadStringParam(thread, mode, sizeof(mode)); 
-			OPCODE_VALIDATE_STR_ARG_READ(modeOk)
-		}
-
-		if (auto hfile = open_file(filename.c_str(), mode, bLegacyMode))
-		{
-			GetInstance().OpcodeSystem.m_hFiles.insert(hfile);
-
-			*thread << hfile;
-			SetScriptCondResult(thread, true);
-		}
-		else
-		{
-			*thread << NULL;
-			SetScriptCondResult(thread, false);
-		}
-
-		return OR_CONTINUE;
-	}
-
-	//0A9B=1,closefile %1d%
-	OpcodeResult __stdcall opcode_0A9B(CRunningScript *thread)
-	{
-		DWORD hFile;
-		*thread >> hFile;
-		if (convert_handle_to_file(hFile))
-		{
-			close_file(hFile);
-			GetInstance().OpcodeSystem.m_hFiles.erase(hFile);
-		}
-		return OR_CONTINUE;
-	}
-
-	//0A9C=2,%2d% = file %1d% size
-	OpcodeResult __stdcall opcode_0A9C(CRunningScript *thread)
-	{
-		DWORD hFile;
-		*thread >> hFile;
-		if (convert_handle_to_file(hFile)) *thread << file_get_size(hFile);
-		return OR_CONTINUE;
-	}
-
-	//0A9D=3,readfile %1d% size %2d% to %3d%
-	OpcodeResult __stdcall opcode_0A9D(CRunningScript *thread)
-	{
-		DWORD hFile;
-		DWORD size;
-		*thread >> hFile >> size;
-
-		SCRIPT_VAR* buf = GetScriptParamPointer(thread);
-		buf->dwParam = 0; // https://github.com/cleolibrary/CLEO4/issues/91
-
-		if (convert_handle_to_file(hFile)) read_file(buf, size, 1, hFile);
-		return OR_CONTINUE;
-	}
-
-	//0A9E=3,writefile %1d% size %2d% from %3d%
-	OpcodeResult __stdcall opcode_0A9E(CRunningScript *thread)
-	{
-		DWORD hFile;
-		DWORD size;
-		const void *buf;
-		*thread >> hFile >> size;
-		buf = GetScriptParamPointer(thread);
-		if (convert_handle_to_file(hFile))
-		{
-			write_file(buf, size, 1, hFile);
-			flush_file(hFile);
 		}
 		return OR_CONTINUE;
 	}
@@ -2548,105 +2221,6 @@ namespace CLEO
 		return OR_CONTINUE;
 	}
 
-	//0AD5=3,file %1d% seek %2d% from_origin %3d% //IF and SET
-	OpcodeResult __stdcall opcode_0AD5(CRunningScript *thread)
-	{
-		DWORD hFile;
-		int seek, origin;
-		*thread >> hFile >> seek >> origin;
-		if (convert_handle_to_file(hFile)) SetScriptCondResult(thread, fseek(convert_handle_to_file(hFile), seek, origin) == 0);
-		else SetScriptCondResult(thread, false);
-		return OR_CONTINUE;
-	}
-
-	//0AD6=1,end_of_file %1d% reached
-	OpcodeResult __stdcall opcode_0AD6(CRunningScript *thread)
-	{
-		DWORD hFile;
-		*thread >> hFile;
-		if (FILE *file = convert_handle_to_file(hFile))
-			SetScriptCondResult(thread, ferror(file) || feof(file) != 0);
-		else
-			SetScriptCondResult(thread, true);
-		return OR_CONTINUE;
-	}
-
-	//0AD7=3,read_string_from_file %1d% to %2d% size %3d% //IF and SET
-	OpcodeResult __stdcall opcode_0AD7(CRunningScript *thread)
-	{
-		DWORD hFile;
-		char *buf;
-		DWORD size;
-		*thread >> hFile;
-		if (*thread->GetBytePointer() >= 1 && *thread->GetBytePointer() <= 8) *thread >> buf;
-		else buf = (char *)GetScriptParamPointer(thread);
-		*thread >> size;
-		if (convert_handle_to_file(hFile)) SetScriptCondResult(thread, fgets(buf, size, convert_handle_to_file(hFile)) == buf);
-		else SetScriptCondResult(thread, false);
-		return OR_CONTINUE;
-	}
-
-	//0AD8=2,write_string_to_file %1d% from %2d% //IF and SET
-	OpcodeResult __stdcall opcode_0AD8(CRunningScript *thread)
-	{
-		DWORD hFile; *thread >> hFile;
-		auto text = ReadStringParam(thread); OPCODE_VALIDATE_STR_ARG_READ(text)
-
-		if (FILE * file = convert_handle_to_file(hFile))
-		{
-			SetScriptCondResult(thread, fputs(text, file) > 0);
-			fflush(file);
-		}
-		else 
-		{
-			SetScriptCondResult(thread, false);
-		}
-		return OR_CONTINUE;
-	}
-
-	//0AD9=-1,write_formated_text %2d% to_file %1d%
-	OpcodeResult __stdcall opcode_0AD9(CRunningScript *thread)
-	{
-		DWORD hFile; *thread >> hFile;
-		auto format = ReadStringParam(thread); OPCODE_VALIDATE_STR_ARG_READ(format)
-		char text[MAX_STR_LEN]; OPCODE_READ_FORMATTED_STRING(thread, text, sizeof(text), format)
-		
-		if (FILE * file = convert_handle_to_file(hFile))
-		{
-			fputs(text, file);
-			fflush(file);
-		}
-		return OR_CONTINUE;
-	}
-
-	//0ADA=-1,%3d% = scan_file %1d% format %2d% //IF and SET
-	OpcodeResult __stdcall opcode_0ADA(CRunningScript *thread)
-	{
-		DWORD hFile; *thread >> hFile;
-		auto format = ReadStringParam(thread); OPCODE_VALIDATE_STR_ARG_READ(format)
-		int *result = (int *)GetScriptParamPointer(thread);
-
-		size_t cExParams = 0;
-		SCRIPT_VAR *ExParams[35];
-		// read extra params
-		while (*thread->GetBytePointer()) ExParams[cExParams++] = GetScriptParamPointer(thread);
-		thread->IncPtr();
-
-		if (FILE *file = convert_handle_to_file(hFile))
-		{
-			*result = fscanf(file, format,
-							 /* extra parameters (will be aligned automatically, but the limit of 35 elements maximum exists) */
-							 ExParams[0], ExParams[1], ExParams[2], ExParams[3], ExParams[4], ExParams[5],
-							 ExParams[6], ExParams[7], ExParams[8], ExParams[9], ExParams[10], ExParams[11],
-							 ExParams[12], ExParams[13], ExParams[14], ExParams[15], ExParams[16], ExParams[17],
-							 ExParams[18], ExParams[19], ExParams[20], ExParams[21], ExParams[22], ExParams[23],
-							 ExParams[24], ExParams[25], ExParams[26], ExParams[27], ExParams[28], ExParams[29],
-							 ExParams[30], ExParams[31], ExParams[32], ExParams[33], ExParams[34]);
-		}
-		SetScriptCondResult(thread, cExParams == *result);
-		return OR_CONTINUE;
-	}
-
 	//0ADB=2,%2d% = car_model %1o% name
 	OpcodeResult __stdcall opcode_0ADB(CRunningScript *thread)
 	{
@@ -3096,6 +2670,23 @@ extern "C"
 			LOG_WARNING(thread, "%s in script %s", CCustomOpcodeSystem::lastErrorMsg.c_str(), ((CCustomScript*)thread)->GetInfoStr().c_str());
 
 		return result;
+	}
+
+	void WINAPI CLEO_ReadStringParamWriteBuffer(CLEO::CRunningScript* thread, char** outBuf, int* outBufSize, DWORD* outNeedsTerminator)
+	{
+		if (thread == nullptr || 
+			outBuf == nullptr || 
+			outBufSize == nullptr ||
+			outNeedsTerminator == nullptr)
+		{
+			LOG_WARNING(thread, "Invalid argument of CLEO_ReadStringParamWriteBuffer in script %s\nScript suspended.", ((CCustomScript*)thread)->GetInfoStr().c_str());
+			return;
+		}
+
+		auto target = GetStringParamWriteBuffer(thread);
+		*outBuf = target.data;
+		*outBufSize = target.size;
+		*outNeedsTerminator = target.needTerminator;
 	}
 
 	void WINAPI CLEO_WriteStringOpcodeParam(CLEO::CRunningScript* thread, const char* str)

--- a/source/CCustomOpcodeSystem.cpp
+++ b/source/CCustomOpcodeSystem.cpp
@@ -2672,7 +2672,7 @@ extern "C"
 			outBufSize == nullptr ||
 			outNeedsTerminator == nullptr)
 		{
-			LOG_WARNING(thread, "Invalid argument of CLEO_ReadStringParamWriteBuffer in script %s\nScript suspended.", ((CCustomScript*)thread)->GetInfoStr().c_str());
+			LOG_WARNING(thread, "Invalid argument of CLEO_ReadStringParamWriteBuffer in script %s", ((CCustomScript*)thread)->GetInfoStr().c_str());
 			return;
 		}
 

--- a/source/CCustomOpcodeSystem.h
+++ b/source/CCustomOpcodeSystem.h
@@ -43,7 +43,6 @@ namespace CLEO
 
         static OpcodeResult CallFunctionGeneric(WORD opcode, CRunningScript* thread, bool thisCall, bool returnArg);
         static OpcodeResult CleoReturnGeneric(WORD opcode, CRunningScript* thread, bool returnArgs = false, DWORD returnArgCount = 0, bool strictArgCount = true);
-        static OpcodeResult ErrorSuspendScript(CRunningScript* thread); // suspend script execution forever
 
     private:
         friend OpcodeResult __stdcall opcode_0AA2(CRunningScript *pScript);

--- a/source/CCustomOpcodeSystem.h
+++ b/source/CCustomOpcodeSystem.h
@@ -8,8 +8,6 @@
 namespace CLEO
 {
     typedef OpcodeResult(__stdcall * CustomOpcodeHandler)(CRunningScript*);
-    bool is_legacy_handle(DWORD dwHandle);
-    FILE * convert_handle_to_file(DWORD dwHandle);
 
     extern const char* (__cdecl* GetUserDirectory)();
     extern void(__cdecl* ChangeToUserDir)();
@@ -48,15 +46,12 @@ namespace CLEO
         static OpcodeResult ErrorSuspendScript(CRunningScript* thread); // suspend script execution forever
 
     private:
-        friend OpcodeResult __stdcall opcode_0A9A(CRunningScript *pScript);
-        friend OpcodeResult __stdcall opcode_0A9B(CRunningScript *pScript);
         friend OpcodeResult __stdcall opcode_0AA2(CRunningScript *pScript);
         friend OpcodeResult __stdcall opcode_0AA3(CRunningScript *pScript);
         friend OpcodeResult __stdcall opcode_0AC8(CRunningScript *pScript);
         friend OpcodeResult __stdcall opcode_0AC9(CRunningScript *pScript);
         friend OpcodeResult __stdcall opcode_2004(CRunningScript* pScript);
 
-        std::set<DWORD> m_hFiles;
         std::set<HMODULE> m_hNativeLibs;
         std::set<void*> m_pAllocations;
 

--- a/source/CGameVersionManager.cpp
+++ b/source/CGameVersionManager.cpp
@@ -10,21 +10,6 @@ namespace CLEO
         { 0x0053BEE0,	memory_und, 0x0053BEE0, 0x0053C380, 0x0054DE60 },		// MA_UPDATE_GAME_LOGICS_FUNCTION,
 
                                                                                 // GV_US10,		GV_US11,		GV_EU10,		GV_EU11,		GV_STEAM
-        { 0x008232D8,	memory_und, 0x00823318, 0x00824098, 0x0085C75E },		// MA_FOPEN_FUNCTION,
-        { 0x0082318B,	memory_und, 0x008231CB, 0x00823F4B, 0x0085C396 },		// MA_FCLOSE_FUNCTION,
-        { 0x008231DC,	memory_und, 0x0082321C, 0x00823F9C, 0x0085C680 },		// MA_FGETC_FUNCTION,
-        { 0x00823798,	memory_und, 0x008237D8, 0x00824558, 0x0085D00C },		// MA_FGETS_FUNCTION,
-        { 0x008262B8,	memory_und, 0x008262F8, 0x00826BA8, 0x008621F1 },		// MA_FPUTS_FUNCTION,
-        { 0x00823521,	memory_und, 0x00823561, 0x008242E1, 0x0085CD04 },		// MA_FREAD_FUNCTION,
-        { 0x00823674,	memory_und, 0x008236B4, 0x00824434, 0x0085CE7E },		// MA_FWRITE_FUNCTION,
-        { 0x0082374F,	memory_und, 0x0082378F, 0x0082450F, 0x0085CF87 },		// MA_FSEEK_FUNCTION,
-        { 0x00823A30,	memory_und, 0x00823A70, 0x008247F0, 0x0085D464 },		// MA_FPRINTF_FUNCTION,
-        { 0x00826261,	memory_und, 0x008262A1, 0x00826B51, 0x00862183 },		// MA_FTELL_FUNCTION,
-        { 0x00823E86,	memory_und, 0x00823EC6, 0x00824C46, 0x0085DDDD },		// MA_FFLUSH_FUNCTION,
-        { 0x008262A2,	memory_und, 0x008262E2, 0x00826B92, 0x0085D193 },		// MA_FEOF_FUNCTION,
-        { 0x008262AD,	memory_und, 0x008262ED, 0x00826B9D, 0x0085D1C2 },		// MA_FERROR_FUNCTION,
-
-                                                                                // GV_US10,		GV_US11,		GV_EU10,		GV_EU11,		GV_STEAM
         { 0x00BA6748,	memory_und, 0x00BA6748, 0x00BA8DC8, 0x00C33100 },		// MA_MENU_MANAGER,
         { 0x0071A700,	memory_und, 0x0071A700, 0x0071AF30, 0x0073BF50 },		// MA_DRAW_TEXT_FUNCTION,
         { 0x00719610,	memory_und, 0x00719610, 0x00719E40, 0x0073ABC0 },		// MA_SET_TEXT_ALIGN_FUNCTION,

--- a/source/CGameVersionManager.h
+++ b/source/CGameVersionManager.h
@@ -27,21 +27,6 @@ namespace CLEO
         MA_CALL_UPDATE_GAME_LOGICS,
         MA_UPDATE_GAME_LOGICS_FUNCTION,
 
-        // CrtFix
-        MA_FOPEN_FUNCTION,
-        MA_FCLOSE_FUNCTION,
-        MA_FGETC_FUNCTION,
-        MA_FGETS_FUNCTION,
-        MA_FPUTS_FUNCTION,
-        MA_FREAD_FUNCTION,
-        MA_FWRITE_FUNCTION,
-        MA_FSEEK_FUNCTION,
-        MA_FPRINTF_FUNCTION,
-        MA_FTELL_FUNCTION,
-        MA_FFLUSH_FUNCTION,
-        MA_FEOF_FUNCTION,
-        MA_FERROR_FUNCTION,
-
         // MenuStatusNotifier
         MA_MENU_MANAGER,
         MA_DRAW_TEXT_FUNCTION,

--- a/source/cleo.def
+++ b/source/cleo.def
@@ -37,3 +37,4 @@ EXPORTS
 	_CLEO_GetScriptDebugMode@4				@34
 	_CLEO_SetScriptDebugMode@8				@35
 	_CLEO_Log@8								@36
+	_CLEO_ReadStringParamWriteBuffer@16		@37

--- a/tests/test_file_read_write.txt
+++ b/tests/test_file_read_write.txt
@@ -1,0 +1,205 @@
+{$CLEO .cs}
+{$USE file}
+{$USE debug}
+
+debug_on
+wait 3000
+
+var 5@ : Integer
+var 6@ : Integer
+
+copy_file "cleo\.cleo.log" {to} "cleo\.cleo_test.log"
+while true
+    if
+        // test 0A9A
+        0@ = open_file "cleo\.cleo_test.log" {mode} "r+" // read and write
+    then
+        print_formatted_now "0A9A File opened" time 1000
+        wait 1000
+    
+        // test 0A9C
+        1@ = get_file_size 0@
+        print_formatted_now "0A9C File size: %d" time 2000 1@
+        wait 2000
+    
+        // test 0A9D
+        5@ = 0xCCCCCCCC
+        0A9D: readfile 0@ size 2 to 5@
+        print_formatted_now "0A9D Read WORD %x" time 2000 5@
+        wait 2000
+
+        // test 0A9E
+        5@ = 0xAABBCCDD
+        0A9E: write_file 0@ size 2 from 5@
+        0AD5: file 0@ seek -2 from_origin SeekOrigin.Current //IF and SET
+        5@ = 0
+        0A9D: readfile 0@ size 2 to 5@
+        if
+            5@ == 0xCCDD
+        then
+            print_formatted_now "0A9E ok" time 1000
+            wait 1000
+        else
+            print_formatted_now "~r~0A9E failed~n~read: 0x%X, expected: 0xCCDD" time 5000 5@
+            wait 5000
+        end
+        
+        // test 0AD5
+        0A9D: readfile 0@ size 4 to 5@
+        if
+            0AD5: file 0@ seek -2 from_origin SeekOrigin.Current //IF and SET
+        then
+            0A9D: readfile 0@ size 4 to 6@
+            if
+                5@ <> 6@
+            then
+                print_formatted_now "0AD5 ok" time 1000
+                wait 1000
+            else
+                print_formatted_now "~r~0AD5 invalid result" time 5000
+                wait 5000
+            end
+        else
+            print_formatted_now "~r~0AD5 seek back failed" time 5000
+            wait 5000
+        end
+        
+        // test 0AD6
+        if
+            not is_end_of_file_reached 0@
+        then
+            print_formatted_now "0AD6: not EOF yet" time 1000
+            wait 1000
+        else
+            print_formatted_now "~r~0AD6: EOF reached" time 5000
+            wait 5000
+        end
+
+        // test 0AD7
+        0AD5: file 0@ seek 30 from_origin SeekOrigin.Current
+        if
+            0AD7: read_string_from_file 0@ to 1@v size 15
+        then
+            0ACE: print_help_formatted "0AD7 read string"
+            print_formatted_now "Read: %s" time 2000 1@v
+            wait 2000
+        else
+            print_formatted_now "~r~0AD7 failed" time 5000
+            wait 5000
+        end
+
+        // test 0AD8
+        if
+            0AD8: write_string_to_file 0@ {text} "test text"
+        then
+            0AD5: file 0@ seek -9 from_origin SeekOrigin.Current
+            0AD7: read_string_from_file 0@ to 1@v size 10
+            
+            if
+                1@v == "test text"
+            then
+                print_formatted_now "0AD8 ok" time 1000
+                wait 1000
+            else
+                print_formatted_now "~r~0AD8 invalid result~n~%s" time 5000 1@v
+                wait 5000
+            end
+        else
+            print_formatted_now "~r~0AD8 failed to write" time 5000
+            wait 5000
+        end
+        
+        // test 0AD9
+        0AD9: write_formatted_string_to_file 0@ {format} "%x%X%s" {args} 0xA 0xB "CD"
+        0AD5: file 0@ seek -4 from_origin SeekOrigin.Current
+        0AD7: read_string_from_file 0@ to 1@v size 5
+        if
+            1@v == "aBCD"
+        then
+            print_formatted_now "0AD9 ok" time 1000
+            wait 1000
+        else
+            print_formatted_now "~r~0AD9 invalid result~n~%s" time 5000 1@v
+            wait 5000
+        end
+        
+        // test 0ADA
+        0AD8: write_string_to_file 0@ {text} "5:17 3.1415 END"
+        0AD5: file 0@ seek -15 from_origin SeekOrigin.Current
+        if
+            0ADA: scan_file 0@ {format} "%d:%d %f" {nValues} 5@ {values} 6@ 7@ 8@
+        then
+            if and
+                5@ == 3
+                6@ == 5
+                7@ == 17
+                8@ == 3.1415
+            then
+                0AD7: read_string_from_file 0@ to 1@v size 5
+                if
+                    1@v == " END"
+                then
+                    print_formatted_now "0ADA ok" time 1000
+                    wait 1000
+                else
+                    print_formatted_now "~r~0ADA post check fail~n~%s" time 5000 1@v
+                    wait 5000
+                end
+            else
+                print_formatted_now "~r~0ADA invalid result~n~%d %d %d %f" time 5000 5@ 6@ 7@ 8@
+                wait 5000
+            end
+        else
+            print_formatted_now "~r~0ADA failed. Read args: %d" time 5000 5@
+            wait 5000
+        end
+        
+        // test 2300
+        2300: get_file_position 0@ {store_to} 5@
+        0AD8: write_string_to_file 0@ {text} "abc"
+        2300: get_file_position 0@ {store_to} 6@
+        6@ -= 5@
+        if
+            6@ == 3
+        then
+            print_formatted_now "2300 ok" time 1000
+            wait 1000
+        else
+            print_formatted_now "~r~2300 failed. Difference: %d" time 1000 6@
+            wait 1000
+        end
+        
+        // test 2301
+        0AD8: write_string_to_file 0@ {text} "test text"
+        0AD5: file 0@ seek -9 from_origin SeekOrigin.Current
+        1@ = 0
+        2@ = 0
+        3@ = 0
+        4@ = 0
+        5@ = get_var_pointer 1@
+        if
+            2301: read_block_from_file 0@ {size} 9 {buffer} 5@
+        then
+            if
+                1@v == "test text"
+            then
+                print_formatted_now "2301 ok" time 1000
+                wait 1000
+            else
+                print_formatted_now "~r~2301 invalid result~n~%s" time 5000 1@v
+                wait 5000
+            end
+        else
+            print_formatted_now "~r~2301 failed to read" time 5000
+            wait 5000
+        end
+
+        // test 0A9B
+        0A9B: close_file 0@
+    else
+        print_formatted_now "Failed to open the file" time 5000
+    end
+    
+    print_formatted_now "Finished testing file read write opcodes" time 5000
+    wait 5000
+end


### PR DESCRIPTION
Moved all file io stream opcodes to filesystem plugin.
New opcode read_block_from_file
New opcode get_file_position
Multiple bug fixes, parameters validation and error messages.
Implemented legacy mode for all file streams related opcodes.
Added test script testing all stream opcodes.

```
2300=2,get_file_position %1d% store_to %2d%
2301=3,read_block_from_file %1d% size %2d% buffer %3d%
```