### PR TITLE
String args support for legacy opcodes

### DIFF
--- a/cleo_sdk/CLEO_Utils.h
+++ b/cleo_sdk/CLEO_Utils.h
@@ -323,14 +323,14 @@ namespace CLEO
 
         if (str != nullptr && (size_t)str <= MinValidAddress)
         {
-            SHOW_ERROR("Invalid '0x%X' source pointer of output string argument #%d in script %s \nScript suspended.", str, CLEO_GetParamsHandledCount(), ScriptInfoStr(thread).c_str());
+            SHOW_ERROR("Invalid '0x%X' source pointer of output string argument #%d in script %s \nScript suspended.", str, CLEO_GetParamsHandledCount() + 1, ScriptInfoStr(thread).c_str());
             thread->Suspend();
             return false;
         }
 
         if (!_paramWasString(true))
         {
-            SHOW_ERROR("Output argument #%d expected to be variable string, got %s in script %s\nScript suspended.", CLEO_GetParamsHandledCount(), ToKindStr(_lastParamType, _lastParamArrayType), ScriptInfoStr(thread).c_str());
+            SHOW_ERROR("Output argument #%d expected to be variable string, got %s in script %s\nScript suspended.", CLEO_GetParamsHandledCount() + 1, ToKindStr(_lastParamType, _lastParamArrayType), ScriptInfoStr(thread).c_str());
             thread->Suspend();
             return false;
         }
@@ -341,7 +341,7 @@ namespace CLEO
 
             if ((size_t)ptr <= MinValidAddress)
             {
-                SHOW_ERROR("Invalid '0x%X' pointer of output string argument #%d in script %s \nScript suspended.", ptr, CLEO_GetParamsHandledCount(), ScriptInfoStr(thread).c_str());
+                SHOW_ERROR("Invalid '0x%X' pointer of output string argument #%d in script %s \nScript suspended.", ptr, CLEO_GetParamsHandledCount() + 1, ScriptInfoStr(thread).c_str());
                 thread->Suspend();
                 return false;
             }
@@ -466,6 +466,6 @@ namespace CLEO
 
     #define OPCODE_WRITE_PARAM_STRING(value) if(!_writeParamText(thread, value)) { return OpcodeResult::OR_INTERRUPT; }
 
-    #define OPCODE_WRITE_PARAM_PTR(value) _writeParamPtr(thread, value); \
+    #define OPCODE_WRITE_PARAM_PTR(value) _writeParamPtr(thread, (void*)value); \
         if (!_paramWasInt(true)) { SHOW_ERROR("Output argument #%d expected to be integer, got %s in script %s\nScript suspended.", CLEO_GetParamsHandledCount(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
 }

--- a/source/CCustomOpcodeSystem.cpp
+++ b/source/CCustomOpcodeSystem.cpp
@@ -1731,8 +1731,8 @@ namespace CLEO
 	//0ADF=2,add_dynamic_GXT_entry %1d% text %2d%
 	OpcodeResult __stdcall opcode_0ADF(CRunningScript *thread)
 	{
-		char gxtLabel[9] = { 0 }; // 8 + terminator character
-		auto gxt = OPCODE_READ_PARAM_STRING_BUFF(gxtLabel, 8);
+		char gxtLabel[8] = { 0 }; // 7 + terminator character
+		auto gxt = OPCODE_READ_PARAM_STRING_BUFF(gxtLabel, 7);
 		auto txt = OPCODE_READ_PARAM_STRING();
 
 		GetInstance().TextManager.AddFxt(gxt, txt);

--- a/source/CCustomOpcodeSystem.cpp
+++ b/source/CCustomOpcodeSystem.cpp
@@ -11,7 +11,6 @@
 #include <sstream>
 #include <forward_list>
 
-#define OPCODE_VALIDATE_STR_ARG_READ(x) if((void*)x == nullptr) { SHOW_ERROR("%s in script %s \nScript suspended.", CCustomOpcodeSystem::lastErrorMsg.c_str(), ((CCustomScript*)thread)->GetInfoStr().c_str()); return thread->Suspend(); }
 #define OPCODE_VALIDATE_STR_ARG_WRITE(x) if((void*)x == nullptr) { SHOW_ERROR("%s in script %s \nScript suspended.", CCustomOpcodeSystem::lastErrorMsg.c_str(), ((CCustomScript*)thread)->GetInfoStr().c_str()); return thread->Suspend(); }
 #define OPCODE_READ_FORMATTED_STRING(thread, buf, bufSize, format) if(ReadFormattedString(thread, buf, bufSize, format) == -1) { SHOW_ERROR("%s in script %s \nScript suspended.", CCustomOpcodeSystem::lastErrorMsg.c_str(), ((CCustomScript*)thread)->GetInfoStr().c_str()); return thread->Suspend(); }
 
@@ -786,7 +785,7 @@ namespace CLEO
 				{
 					argumentIsStr[i] = true;
 
-					auto str = ReadStringParam(thread); OPCODE_VALIDATE_STR_ARG_READ(str)
+					auto str = OPCODE_READ_PARAM_STRING();
 					stringParams.emplace_front(str);
 					arg->pcParam = stringParams.front().data();
 				}
@@ -883,7 +882,7 @@ namespace CLEO
 	//0A92=-1,create_custom_thread %1d%
 	OpcodeResult __stdcall opcode_0A92(CRunningScript *thread)
 	{
-		auto path = ReadStringParam(thread); OPCODE_VALIDATE_STR_ARG_READ(path)
+		auto path = OPCODE_READ_PARAM_STRING();
 
 		auto filename = reinterpret_cast<CCustomScript*>(thread)->ResolvePath(path, DIR_CLEO); // legacy: default search location is game\cleo directory
 		TRACE("[0A92] Starting new custom script %s from thread named %s", filename.c_str(), thread->GetName().c_str());
@@ -923,7 +922,7 @@ namespace CLEO
 	//0A94=-1,create_custom_mission %1d%
 	OpcodeResult __stdcall opcode_0A94(CRunningScript *thread)
 	{
-		auto path = ReadStringParam(thread); OPCODE_VALIDATE_STR_ARG_READ(path)
+		auto path = OPCODE_READ_PARAM_STRING();
 
 		auto filename = reinterpret_cast<CCustomScript*>(thread)->ResolvePath(path, DIR_CLEO); // legacy: default search location is game\cleo directory
 		filename += ".cm"; // add custom mission extension
@@ -989,7 +988,7 @@ namespace CLEO
 	//0AAC=2,  %2d% = load_audiostream %1d%  // IF and SET
 	OpcodeResult __stdcall opcode_0AAC(CRunningScript *thread)
 	{
-		auto path = ReadStringParam(thread); OPCODE_VALIDATE_STR_ARG_READ(path)
+		auto path = OPCODE_READ_PARAM_STRING();
 		auto filename = reinterpret_cast<CCustomScript*>(thread)->ResolvePath(path);
 
 		auto stream = GetInstance().SoundSystem.LoadStream(filename.c_str());
@@ -1374,7 +1373,7 @@ namespace CLEO
 	//0ABA=1,end_custom_thread_named %1d%
 	OpcodeResult __stdcall opcode_0ABA(CRunningScript *thread)
 	{
-		auto threadName = ReadStringParam(thread); OPCODE_VALIDATE_STR_ARG_READ(threadName)
+		auto threadName = OPCODE_READ_PARAM_STRING();
 
 		auto deleted_thread = (CCustomScript*)GetInstance().ScriptEngine.FindScriptNamed(threadName, false, true, 0);
 		if (deleted_thread)
@@ -1452,7 +1451,7 @@ namespace CLEO
 	//0AC1=2,%2d% = load_audiostream_with_3d_support %1d% //IF and SET
 	OpcodeResult __stdcall opcode_0AC1(CRunningScript *thread)
 	{
-		auto path = ReadStringParam(thread); OPCODE_VALIDATE_STR_ARG_READ(path)
+		auto path = OPCODE_READ_PARAM_STRING();
 
 		auto stream = GetInstance().SoundSystem.LoadStream(path, true);
 		*thread << stream;
@@ -1512,7 +1511,7 @@ namespace CLEO
 	//0ACA=1,show_text_box %1d%
 	OpcodeResult __stdcall opcode_0ACA(CRunningScript *thread)
 	{
-		auto text = ReadStringParam(thread); OPCODE_VALIDATE_STR_ARG_READ(text)
+		auto text = OPCODE_READ_PARAM_STRING();
 		PrintHelp(text);
 		return OR_CONTINUE;
 	}
@@ -1520,9 +1519,9 @@ namespace CLEO
 	//0ACB=3,show_styled_text %1d% time %2d% style %3d%
 	OpcodeResult __stdcall opcode_0ACB(CRunningScript *thread)
 	{
-		auto text = ReadStringParam(thread); OPCODE_VALIDATE_STR_ARG_READ(text)
-		DWORD time; *thread >> time;
-		DWORD style; *thread >> style;
+		auto text = OPCODE_READ_PARAM_STRING();
+		auto time = OPCODE_READ_PARAM_INT();
+		auto style = OPCODE_READ_PARAM_INT();
 
 		PrintBig(text, time, style);
 		return OR_CONTINUE;
@@ -1531,8 +1530,8 @@ namespace CLEO
 	//0ACC=2,show_text_lowpriority %1d% time %2d%
 	OpcodeResult __stdcall opcode_0ACC(CRunningScript *thread)
 	{
-		auto text = ReadStringParam(thread); OPCODE_VALIDATE_STR_ARG_READ(text)
-		DWORD time; *thread >> time;
+		auto text = OPCODE_READ_PARAM_STRING();
+		auto time = OPCODE_READ_PARAM_INT();
 
 		Print(text, time);
 		return OR_CONTINUE;
@@ -1541,8 +1540,8 @@ namespace CLEO
 	//0ACD=2,show_text_highpriority %1d% time %2d%
 	OpcodeResult __stdcall opcode_0ACD(CRunningScript *thread)
 	{
-		auto text = ReadStringParam(thread); OPCODE_VALIDATE_STR_ARG_READ(text)
-		DWORD time; *thread >> time;
+		auto text = OPCODE_READ_PARAM_STRING();
+		auto time = OPCODE_READ_PARAM_INT();
 
 		PrintNow(text, time);
 		return OR_CONTINUE;
@@ -1551,7 +1550,7 @@ namespace CLEO
 	//0ACE=-1,show_formatted_text_box %1d%
 	OpcodeResult __stdcall opcode_0ACE(CRunningScript *thread)
 	{
-		auto format = ReadStringParam(thread); OPCODE_VALIDATE_STR_ARG_READ(format)
+		auto format = OPCODE_READ_PARAM_STRING();
 		char text[MAX_STR_LEN]; OPCODE_READ_FORMATTED_STRING(thread, text, sizeof(text), format)
 
 		PrintHelp(text);
@@ -1561,9 +1560,9 @@ namespace CLEO
 	//0ACF=-1,show_formatted_styled_text %1d% time %2d% style %3d%
 	OpcodeResult __stdcall opcode_0ACF(CRunningScript *thread)
 	{
-		auto format = ReadStringParam(thread); OPCODE_VALIDATE_STR_ARG_READ(format)
-		DWORD time; *thread >> time;
-		DWORD style; *thread >> style;
+		auto format = OPCODE_READ_PARAM_STRING();
+		auto time = OPCODE_READ_PARAM_INT();
+		auto style = OPCODE_READ_PARAM_INT();
 		char text[MAX_STR_LEN]; OPCODE_READ_FORMATTED_STRING(thread, text, sizeof(text), format)
 
 		PrintBig(text, time, style);
@@ -1573,8 +1572,8 @@ namespace CLEO
 	//0AD0=-1,show_formatted_text_lowpriority %1d% time %2d%
 	OpcodeResult __stdcall opcode_0AD0(CRunningScript *thread)
 	{
-		auto format = ReadStringParam(thread); OPCODE_VALIDATE_STR_ARG_READ(format)
-		DWORD time; *thread >> time;
+		auto format = OPCODE_READ_PARAM_STRING();
+		auto time = OPCODE_READ_PARAM_INT();
 		char text[MAX_STR_LEN]; OPCODE_READ_FORMATTED_STRING(thread, text, sizeof(text), format)
 
 		Print(text, time);
@@ -1584,8 +1583,8 @@ namespace CLEO
 	//0AD1=-1,show_formatted_text_highpriority %1d% time %2d%
 	OpcodeResult __stdcall opcode_0AD1(CRunningScript *thread)
 	{
-		auto format = ReadStringParam(thread); OPCODE_VALIDATE_STR_ARG_READ(format)
-		DWORD time; *thread >> time;
+		auto format = OPCODE_READ_PARAM_STRING();
+		auto time = OPCODE_READ_PARAM_INT();
 		char text[MAX_STR_LEN]; OPCODE_READ_FORMATTED_STRING(thread, text, sizeof(text), format)
 
 		PrintNow(text, time);
@@ -1619,7 +1618,7 @@ namespace CLEO
 	OpcodeResult __stdcall opcode_0AD3(CRunningScript *thread)
 	{
 		auto resultArg = GetStringParamWriteBuffer(thread); OPCODE_VALIDATE_STR_ARG_WRITE(resultArg.data)
-		auto format = ReadStringParam(thread); OPCODE_VALIDATE_STR_ARG_READ(format)
+		auto format = OPCODE_READ_PARAM_STRING();
 		char text[MAX_STR_LEN]; OPCODE_READ_FORMATTED_STRING(thread, text, sizeof(text), format)
 
 		WriteStringParam(resultArg, text);
@@ -1629,9 +1628,8 @@ namespace CLEO
 	//0AD4=-1,%3d% = scan_string %1d% format %2d%  //IF and SET
 	OpcodeResult __stdcall opcode_0AD4(CRunningScript *thread)
 	{
-		auto src = ReadStringParam(thread); OPCODE_VALIDATE_STR_ARG_READ(src)
-		char fmt[MAX_STR_LEN];
-		auto format = ReadStringParam(thread, fmt, sizeof(fmt)); OPCODE_VALIDATE_STR_ARG_READ(format)
+		auto src = OPCODE_READ_PARAM_STRING();
+		char format[MAX_STR_LEN]; OPCODE_READ_PARAM_STRING_BUFF(format, MAX_STR_LEN);
 
 		auto resultType = thread->PeekDataType();
 		if (!IsVariable(resultType) && IsVarString(resultType))
@@ -1689,7 +1687,7 @@ namespace CLEO
 	//0ADC=1, test_cheat %1d%
 	OpcodeResult __stdcall opcode_0ADC(CRunningScript *thread)
 	{
-		auto text = ReadStringParam(thread); OPCODE_VALIDATE_STR_ARG_READ(text)
+		auto text = OPCODE_READ_PARAM_STRING();
 		SetScriptCondResult(thread, TestCheat(text));
 		return OR_CONTINUE;
 	}
@@ -1733,7 +1731,7 @@ namespace CLEO
 	//0ADF=2,add_dynamic_GXT_entry %1d% text %2d%
 	OpcodeResult __stdcall opcode_0ADF(CRunningScript *thread)
 	{
-		char gxtLabel[9] = {0}; // 8 + terminator character
+		char gxtLabel[9] = { 0 }; // 8 + terminator character
 		auto gxt = OPCODE_READ_PARAM_STRING_BUFF(gxtLabel, 8);
 		auto txt = OPCODE_READ_PARAM_STRING();
 
@@ -1744,7 +1742,7 @@ namespace CLEO
 	//0AE0=1,remove_dynamic_GXT_entry %1d%
 	OpcodeResult __stdcall opcode_0AE0(CRunningScript *thread)
 	{
-		auto gxt = ReadStringParam(thread); OPCODE_VALIDATE_STR_ARG_READ(gxt)
+		auto gxt = OPCODE_READ_PARAM_STRING();
 
 		GetInstance().TextManager.RemoveFxt(gxt);
 		return OR_CONTINUE;
@@ -1890,8 +1888,8 @@ namespace CLEO
 	OpcodeResult __stdcall opcode_0AED(CRunningScript *thread)
 	{
 		// this opcode is useless now
-		float val; *thread >> val;
-		auto format = ReadStringParam(thread); OPCODE_VALIDATE_STR_ARG_READ(format)
+		auto val = OPCODE_READ_PARAM_FLOAT();
+		auto format = OPCODE_READ_PARAM_STRING();
 		auto resultArg = GetStringParamWriteBuffer(thread); OPCODE_VALIDATE_STR_ARG_WRITE(resultArg.data)
 
 		sprintf_s(resultArg.data, resultArg.size, format, val);

--- a/source/CCustomOpcodeSystem.cpp
+++ b/source/CCustomOpcodeSystem.cpp
@@ -823,13 +823,13 @@ namespace CLEO
 				auto paramType = *(eDataType*)arg;
 				if (IsVarString(paramType))
 				{
-					WriteStringParam(thread, arguments[i].pcParam);
+					OPCODE_WRITE_PARAM_STRING(arguments[i].pcParam);
 				} 
 				else if (IsVariable(paramType))
 				{
 					if (argumentIsStr[i]) // source was string, write it into provided buffer ptr
 					{
-						auto ok = WriteStringParam(thread, arguments[i].pcParam); OPCODE_VALIDATE_STR_ARG_WRITE(ok)
+						OPCODE_WRITE_PARAM_STRING(arguments[i].pcParam);
 					}
 					else
 						*thread << arguments[i].dwParam;

--- a/source/CCustomOpcodeSystem.cpp
+++ b/source/CCustomOpcodeSystem.cpp
@@ -1715,26 +1715,29 @@ namespace CLEO
 	//0ADE=2,%2d% = text_by_GXT_entry %1d%
 	OpcodeResult __stdcall opcode_0ADE(CRunningScript *thread)
 	{
-		auto gxt = ReadStringParam(thread); OPCODE_VALIDATE_STR_ARG_READ(gxt)
+		auto gxt = OPCODE_READ_PARAM_STRING();
 
-		if (*thread->GetBytePointer() >= 1 && *thread->GetBytePointer() <= 8)
-			*thread << GetInstance().TextManager.Get(gxt);
+		auto txt = GetInstance().TextManager.Get(gxt);
+
+		if (IsVarString(thread->PeekDataType()))
+		{
+			OPCODE_WRITE_PARAM_STRING(txt);
+		}
 		else
 		{
-			auto ok = WriteStringParam(thread, GetInstance().TextManager.Get(gxt)); OPCODE_VALIDATE_STR_ARG_WRITE(ok)
+			OPCODE_WRITE_PARAM_PTR(txt); // address of the text
 		}
-
 		return OR_CONTINUE;
 	}
 
 	//0ADF=2,add_dynamic_GXT_entry %1d% text %2d%
 	OpcodeResult __stdcall opcode_0ADF(CRunningScript *thread)
 	{
-		char gxtLabel[8]; // 7 + terminator character
-		auto gxtOk = ReadStringParam(thread, gxtLabel, sizeof(gxtLabel)); OPCODE_VALIDATE_STR_ARG_READ(gxtOk)
-		auto text = ReadStringParam(thread); OPCODE_VALIDATE_STR_ARG_READ(text)
+		char gxtLabel[9] = {0}; // 8 + terminator character
+		auto gxt = OPCODE_READ_PARAM_STRING_BUFF(gxtLabel, 8);
+		auto txt = OPCODE_READ_PARAM_STRING();
 
-		GetInstance().TextManager.AddFxt(gxtLabel, text);
+		GetInstance().TextManager.AddFxt(gxt, txt);
 		return OR_CONTINUE;
 	}
 

--- a/source/CCustomOpcodeSystem.h
+++ b/source/CCustomOpcodeSystem.h
@@ -43,13 +43,9 @@ namespace CLEO
 
         static bool RegisterOpcode(WORD opcode, CustomOpcodeHandler callback);
 
-        static OpcodeResult CallFunctionGeneric(WORD opcode, CRunningScript* thread, bool thisCall, bool returnArg);
         static OpcodeResult CleoReturnGeneric(WORD opcode, CRunningScript* thread, bool returnArgs = false, DWORD returnArgCount = 0, bool strictArgCount = true);
 
     private:
-        friend OpcodeResult __stdcall opcode_0AA2(CRunningScript *pScript);
-        friend OpcodeResult __stdcall opcode_0AA3(CRunningScript *pScript);
-
         typedef OpcodeResult(__thiscall* _OpcodeHandler)(CRunningScript* thread, WORD opcode);
 
         static const size_t OriginalOpcodeHandlersCount = (LastOriginalOpcode / 100) + 1; // 100 opcodes peer handler

--- a/source/CScriptEngine.cpp
+++ b/source/CScriptEngine.cpp
@@ -1181,6 +1181,8 @@ namespace CLEO
 
                 return true;
             }
+
+            return false;
         };
 
         // standard scripts

--- a/source/CScriptEngine.cpp
+++ b/source/CScriptEngine.cpp
@@ -140,7 +140,7 @@ namespace CLEO
             buffLen = 0x7FFFFFFF; // unknown - unlimited
 
         auto paramType = thread->PeekDataType();
-        auto arrayType = IsArray(_lastParamType) ? thread->PeekArrayDataType() : eArrayDataType::ADT_NONE;
+        auto arrayType = IsArray(paramType) ? thread->PeekArrayDataType() : eArrayDataType::ADT_NONE;
 
         auto isVariableInt = IsVariable(paramType) && (arrayType == eArrayDataType::ADT_NONE || arrayType == eArrayDataType::ADT_INT);
 

--- a/source/CScriptEngine.cpp
+++ b/source/CScriptEngine.cpp
@@ -892,7 +892,12 @@ namespace CLEO
         inj.MemoryReadOffset(addr.address + 1, ProcessScript);
         inj.ReplaceFunction(HOOK_ProcessScript, addr);
 
-        inj.InjectFunction(&GetScriptStringParam, gvm.TranslateMemoryAddress(MA_GET_SCRIPT_STRING_PARAM_FUNCTION));
+        inj.InjectFunction(GetScriptStringParam, gvm.TranslateMemoryAddress(MA_GET_SCRIPT_STRING_PARAM_FUNCTION));
+        // setup ScrLog plugin to not patch it again
+        auto scrLogConfig = FS::absolute("scrlog.ini");
+        if (FS::is_regular_file(scrLogConfig)) WritePrivateProfileString("CONFIG", "HOOK_COLLECT_STRING", "FALSE", scrLogConfig.string().c_str());
+        scrLogConfig = FS::absolute("scripts\\scrlog.ini");
+        if (FS::is_regular_file(scrLogConfig)) WritePrivateProfileString("CONFIG", "HOOK_COLLECT_STRING", "FALSE", scrLogConfig.string().c_str());
 
         scriptSprites = gvm.TranslateMemoryAddress(MA_SCRIPT_SPRITE_ARRAY);
         scriptDraws = gvm.TranslateMemoryAddress(MA_SCRIPT_DRAW_ARRAY);

--- a/source/CScriptEngine.cpp
+++ b/source/CScriptEngine.cpp
@@ -16,7 +16,6 @@ namespace CLEO
     DWORD FUNC_SetScriptParams;
     DWORD FUNC_SetScriptCondResult;
     DWORD FUNC_GetScriptParamPointer1;
-    DWORD FUNC_GetScriptStringParam;
     DWORD FUNC_GetScriptParamPointer2;
 
     void(__thiscall * AddScriptToQueue)(CRunningScript *, CRunningScript **queue);
@@ -28,7 +27,6 @@ namespace CLEO
     void(__thiscall * SetScriptParams)(CRunningScript *, int count);
     void(__thiscall * SetScriptCondResult)(CRunningScript *, bool);
     SCRIPT_VAR *	(__thiscall * GetScriptParamPointer1)(CRunningScript *);
-    void(__thiscall * GetScriptStringParam)(CRunningScript *, char* buf, BYTE len);
     SCRIPT_VAR *	(__thiscall * GetScriptParamPointer2)(CRunningScript *, int __unused__);
 
 	void RunScriptDeleteDelegate(CRunningScript *script);
@@ -131,15 +129,86 @@ namespace CLEO
         return (SCRIPT_VAR*)((size_t)result + pScript->GetBasePointer());
     }
 
-    void __fastcall _GetScriptStringParam(CRunningScript *pScript, int dummy, char *buf, int len)
+    char* __fastcall GetScriptStringParam(CRunningScript* thread, int dummy, char* buff, int buffLen)
     {
-        _asm
+        if (buff == nullptr || buffLen == 0)
+            return buff;
+
+        if (buffLen > 0)
+            ZeroMemory(buff, buffLen);
+        else
+            buffLen = 0x7FFFFFFF; // unknown - unlimited
+
+        auto paramType = thread->PeekDataType();
+        auto arrayType = IsArray(_lastParamType) ? thread->PeekArrayDataType() : eArrayDataType::ADT_NONE;
+
+        auto isVariableInt = IsVariable(paramType) && (arrayType == eArrayDataType::ADT_NONE || arrayType == eArrayDataType::ADT_INT);
+
+        // integer address to text buffer
+        if (IsImmInteger(paramType) || isVariableInt)
         {
-            mov ecx, pScript
-            push len
-            push buf
-            call FUNC_GetScriptStringParam
+            GetScriptParams(thread, 1);
+
+            if (opcodeParams[0].dwParam <= CCustomOpcodeSystem::MinValidAddress)
+            {
+                LOG_WARNING(thread, "Invalid '0x%X' pointer of input string argument #%d in script %s", opcodeParams[0].dwParam, CLEO_GetParamsHandledCount(), ScriptInfoStr(thread).c_str());
+                return nullptr; // error
+            }
+
+            auto len = min((int)strlen(opcodeParams[0].pcParam), buffLen);
+            memcpy(buff, opcodeParams[0].pcParam, len);
+            if (len < buffLen) buff[len] = '\0'; // add terminator if possible
+            return buff;
         }
+        else if (paramType == DT_VARLEN_STRING)
+        {
+            thread->IncPtr(1); // already processed paramType
+
+            DWORD length = *thread->GetBytePointer(); // as unsigned byte!
+            thread->IncPtr(1); // length info
+
+            char* str = (char*)thread->GetBytePointer();
+            thread->IncPtr(length); // text data
+
+            auto len = min((int)length, buffLen);
+            memcpy(buff, str, len);
+            if (len < buffLen) buff[len] = '\0'; // add terminator if possible
+            return buff;
+        }
+        else if (IsVarString(paramType))
+        {
+            switch (paramType)
+            {
+                // short string variable
+                case DT_VAR_TEXTLABEL:
+                case DT_LVAR_TEXTLABEL:
+                case DT_VAR_TEXTLABEL_ARRAY:
+                case DT_LVAR_TEXTLABEL_ARRAY:
+                {
+                    auto len = min((int)strnlen(opcodeParams[0].pcParam, 8), buffLen);
+                    memcpy(buff, opcodeParams[0].pcParam, len);
+                    if (len < buffLen) buff[len] = '\0'; // add terminator if possible
+                    return buff;
+                }
+
+                // long string variable
+                case DT_VAR_STRING:
+                case DT_LVAR_STRING:
+                case DT_VAR_STRING_ARRAY:
+                case DT_LVAR_STRING_ARRAY:
+                {
+                    auto len = min((int)strnlen(opcodeParams[0].pcParam, 16), buffLen);
+                    memcpy(buff, opcodeParams[0].pcParam, len);
+                    if (len < buffLen) buff[len] = '\0'; // add terminator if possible
+                    return buff;
+                }
+            }
+        }
+
+        // unsupported param type
+        GetScriptParams(thread, 1); // skip unhandled param
+        LOG_WARNING(thread, "Argument #%d expected to be string, got %s in script %s", CLEO_GetParamsHandledCount(), ToKindStr(paramType, arrayType), ScriptInfoStr(thread).c_str());
+        return nullptr; // error
     }
 
     SCRIPT_VAR * __fastcall _GetScriptParamPointer2(CRunningScript *pScript, int dummy, int unused)
@@ -765,7 +834,6 @@ namespace CLEO
         FUNC_SetScriptParams = gvm.TranslateMemoryAddress(MA_SET_SCRIPT_PARAMS_FUNCTION);
         FUNC_SetScriptCondResult = gvm.TranslateMemoryAddress(MA_SET_SCRIPT_COND_RESULT_FUNCTION);
         FUNC_GetScriptParamPointer1 = gvm.TranslateMemoryAddress(MA_GET_SCRIPT_PARAM_POINTER1_FUNCTION);
-        FUNC_GetScriptStringParam = gvm.TranslateMemoryAddress(MA_GET_SCRIPT_STRING_PARAM_FUNCTION);
         FUNC_GetScriptParamPointer2 = gvm.TranslateMemoryAddress(MA_GET_SCRIPT_PARAM_POINTER2_FUNCTION);
 
         AddScriptToQueue = reinterpret_cast<void(__thiscall*)(CRunningScript*, CRunningScript**)>(_AddScriptToQueue);
@@ -777,7 +845,6 @@ namespace CLEO
         SetScriptParams = reinterpret_cast<void(__thiscall*)(CRunningScript*, int)>(_SetScriptParams);
         SetScriptCondResult = reinterpret_cast<void(__thiscall*)(CRunningScript*, bool)>(_SetScriptCondResult);
         GetScriptParamPointer1 = reinterpret_cast<SCRIPT_VAR * (__thiscall*)(CRunningScript*)>(_GetScriptParamPointer1);
-        GetScriptStringParam = reinterpret_cast<void(__thiscall*)(CRunningScript*, char*, BYTE)>(_GetScriptStringParam);
         GetScriptParamPointer2 = reinterpret_cast<SCRIPT_VAR * (__thiscall*)(CRunningScript*, int)>(_GetScriptParamPointer2);
 
         SaveScmData = gvm.TranslateMemoryAddress(MA_SAVE_SCM_DATA_FUNCTION);
@@ -795,6 +862,8 @@ namespace CLEO
         auto addr = gvm.TranslateMemoryAddress(MA_CALL_PROCESS_SCRIPT);
         inj.MemoryReadOffset(addr.address + 1, ProcessScript);
         inj.ReplaceFunction(HOOK_ProcessScript, addr);
+
+        inj.InjectFunction(&GetScriptStringParam, gvm.TranslateMemoryAddress(MA_GET_SCRIPT_STRING_PARAM_FUNCTION));
 
         scriptSprites = gvm.TranslateMemoryAddress(MA_SCRIPT_SPRITE_ARRAY);
         scriptDraws = gvm.TranslateMemoryAddress(MA_SCRIPT_DRAW_ARRAY);

--- a/source/CScriptEngine.h
+++ b/source/CScriptEngine.h
@@ -154,8 +154,9 @@ namespace CLEO
     extern void(__thiscall * SetScriptParams)(CRunningScript *, int count);
     extern void(__thiscall * SetScriptCondResult)(CRunningScript *, bool);
     extern SCRIPT_VAR * (__thiscall * GetScriptParamPointer1)(CRunningScript *);
-    extern void(__thiscall * GetScriptStringParam)(CRunningScript *, char* buf, BYTE len);
     extern SCRIPT_VAR * (__thiscall * GetScriptParamPointer2)(CRunningScript *, int __unused__);
+
+    char* __fastcall GetScriptStringParam(CRunningScript* thread, int dummy, char* buff, int buffLen);
 
     inline SCRIPT_VAR * GetScriptParamPointer(CRunningScript *thread)
     {


### PR DESCRIPTION
test script:
```
{$CLEO .cs}
nop

wait 6000

0109: add_score 0 money 10
00BA: print_big 'BJ_05' time 2000 style 4
wait 2000

0109: add_score 0 money 10
0@s = 'UNITY'
00BA: print_big 0@s time 2000 style 4
wait 2000

0109: add_score 0 money 10
0@v = "SASO"
00BA: print_big 0@v time 2000 style 4
wait 2000

0109: add_score 0 money 10
allocate_memory 64 store_to 0@
0AD3: string_format 0@ format "%s" args "STAR"
00BA: print_big 0@ time 2000 style 4
wait 2000

terminate_this_custom_script
```