### PR TITLE
Opcode string params handling tweaked

### DIFF
--- a/cleo_plugins/IniFiles/IniFiles.cpp
+++ b/cleo_plugins/IniFiles/IniFiles.cpp
@@ -144,7 +144,7 @@ public:
 		0AF5=4,write_string %1s% to_ini_file %2s% section %3s% key %4s%
 		****************************************************************/
 	{
-		char strValue[MAX_STR_LEN]; OPCODE_READ_PARAM_STRING_BUFF(strValue, sizeof(strValue));
+		auto strValue = OPCODE_READ_PARAM_STRING();
 		auto path = OPCODE_READ_PARAM_FILEPATH();
 		OPCODE_READ_PARAM_STRING_BUFF(section, sizeof(section));
 		OPCODE_READ_PARAM_STRING_BUFF(key, sizeof(key));

--- a/cleo_sdk/CLEO.h
+++ b/cleo_sdk/CLEO.h
@@ -58,13 +58,13 @@ enum eDataType : BYTE
 	DT_FLOAT, // literal float 32
 	DT_VAR_ARRAY, // globalArr $(,)
 	DT_LVAR_ARRAY, // localArr @(,)
-	DT_TEXTLABEL, // literal sstring ''
+	DT_TEXTLABEL, // literal string up to 7 chars
 	DT_VAR_TEXTLABEL, // globalVarSString s$
 	DT_LVAR_TEXTLABEL, // localVarSString @s
 	DT_VAR_TEXTLABEL_ARRAY, // globalVarSStringArr s$(,)
 	DT_LVAR_TEXTLABEL_ARRAY, // localVarSStringArr @s(,)
 	DT_VARLEN_STRING, // literal vstring ""
-	DT_STRING,
+	DT_STRING, // literal string up to 15 chars
 	DT_VAR_STRING, // globalVarVString v$
 	DT_LVAR_STRING, // localVarVString @v
 	DT_VAR_STRING_ARRAY, // globalVarStringArr v$(,)
@@ -486,17 +486,18 @@ SCRIPT_VAR* WINAPI CLEO_GetOpcodeParamsArray(); // get pointer to 'SCRIPT_VAR[32
 BYTE WINAPI CLEO_GetParamsHandledCount(); // number of already read/written opcode parameters since current opcode handler was called
 
 // param read
-SCRIPT_VAR* WINAPI CLEO_GetPointerToScriptVariable(CRunningScript* thread); // get pointer to the variable data. Advances script to next param
+SCRIPT_VAR* WINAPI CLEO_GetPointerToScriptVariable(CRunningScript* thread); // get pointer to the variable's data, nullptr if parameter is not variable. Advances script to next param
 void WINAPI CLEO_RetrieveOpcodeParams(CRunningScript* thread, int count); // read multiple params. Stored in opcodeParams array
 DWORD WINAPI CLEO_GetIntOpcodeParam(CRunningScript* thread);
 float WINAPI CLEO_GetFloatOpcodeParam(CRunningScript* thread);
-LPSTR WINAPI CLEO_ReadStringOpcodeParam(CRunningScript* thread, char* buf = nullptr, int bufSize = 0); // returns null terminated string, nullptr on fail
-LPSTR WINAPI CLEO_ReadStringPointerOpcodeParam(CRunningScript* thread, char* buf = nullptr, int bufSize = 0); // exactly same as CLEO_ReadStringOpcodeParam
+LPSTR WINAPI CLEO_ReadStringOpcodeParam(CRunningScript* thread, char* buf = nullptr, int bufSize = 0); // writes null terminated string into buffer. If no buffer provided then internal one is used. Returns pointer to the result buffer or nullptr on fail
+LPSTR WINAPI CLEO_ReadStringPointerOpcodeParam(CRunningScript* thread, char* buf = nullptr, int bufSize = 0); // writes null terminated string into buffer. Whenever possible returns pointer to the original, null terminated, source string (might be longer than provided buffer). Returns nullptr on fail.
 void WINAPI CLEO_ReadStringParamWriteBuffer(CRunningScript* thread, char** outBuf, int* outBufSize, DWORD* outNeedsTerminator); // get info about the string opcode param, so it can be written latter. If outNeedsTerminator is not 0 then whole bufSize can be used as text characters. Advances script to next param
 char* WINAPI CLEO_ReadParamsFormatted(CRunningScript* thread, const char* format, char* buf = nullptr, int bufSize = 0); // consumes all var-arg params and terminator
 // get param value without advancing the script
 DWORD WINAPI CLEO_PeekIntOpcodeParam(CRunningScript* thread);
 float WINAPI CLEO_PeekFloatOpcodeParam(CRunningScript* thread);
+SCRIPT_VAR* WINAPI CLEO_PeekPointerToScriptVariable(CRunningScript* thread); // get pointer to the variable's data, nullptr if parameter is not variable
 
 // param skip without reading
 void WINAPI CLEO_SkipOpcodeParams(CRunningScript* thread, int count);

--- a/source/CCustomOpcodeSystem.cpp
+++ b/source/CCustomOpcodeSystem.cpp
@@ -1821,19 +1821,108 @@ extern "C"
 		*thread << value;
 	}
 
-	LPSTR WINAPI CLEO_ReadStringOpcodeParam(CLEO::CRunningScript* thread, char *buf, int size)
+	LPSTR WINAPI CLEO_ReadStringOpcodeParam(CLEO::CRunningScript* thread, char *buf, int bufSize)
 	{
-		return CLEO_ReadStringPointerOpcodeParam(thread, buf, size); // always support all string param types
-	}
+		static char internal_buf[MAX_STR_LEN];
+		if (!buf) { buf = internal_buf; bufSize = MAX_STR_LEN; }
 
-	LPSTR WINAPI CLEO_ReadStringPointerOpcodeParam(CLEO::CRunningScript* thread, char *buf, int size)
-	{
-		auto result = ReadStringParam(thread, buf, size);
-
+		auto result = ReadStringParam(thread, buf, bufSize);
 		if (result == nullptr)
 			LOG_WARNING(thread, "%s in script %s", CCustomOpcodeSystem::lastErrorMsg.c_str(), ((CCustomScript*)thread)->GetInfoStr().c_str());
 
 		return result;
+	}
+
+	LPSTR WINAPI CLEO_ReadStringPointerOpcodeParam(CLEO::CRunningScript* thread, char *buf, int bufSize)
+	{
+		static char internal_buf[MAX_STR_LEN];
+
+		// obtain pointer to the source, null terminated, string data if available
+		char* source = nullptr;
+		auto paramType = thread->PeekDataType();
+		auto arrayType = IsArray(paramType) ? thread->PeekArrayDataType() : eArrayDataType::ADT_NONE;
+		auto isVariableInt = IsVariable(paramType) && (arrayType == eArrayDataType::ADT_NONE || arrayType == eArrayDataType::ADT_INT);
+
+		if (IsImmInteger(paramType) || isVariableInt)
+		{
+			source = (char*)CLEO_PeekIntOpcodeParam(thread); // integer address to text buffer
+
+			if ((size_t)source <= CCustomOpcodeSystem::MinValidAddress)
+			{
+				LOG_WARNING(thread, "Invalid '0x%X' pointer of input string argument #%d in script %s", opcodeParams[0].dwParam, CLEO_GetParamsHandledCount() + 1, ScriptInfoStr(thread).c_str());
+				return nullptr; // error
+			}
+		}
+		else if(IsImmString(paramType))
+		{
+			switch (paramType)
+			{
+				// always terminated in-code strings
+				case DT_TEXTLABEL:
+				case DT_STRING:
+					source = (char*)(thread->GetBytePointer() + sizeof(eDataType)); // skip type info, go to data
+						break;
+
+				case DT_VARLEN_STRING: // never terminated in-code string
+				default:
+					break;
+			}
+		}
+		else if(IsVarString(paramType))
+		{
+			auto str = (char*)CLEO_PeekPointerToScriptVariable(thread);
+			if(str != nullptr)
+			{
+				switch (paramType)
+				{
+					// short string variable
+					case DT_VAR_TEXTLABEL:
+					case DT_LVAR_TEXTLABEL:
+					case DT_VAR_TEXTLABEL_ARRAY:
+					case DT_LVAR_TEXTLABEL_ARRAY:
+						if(strnlen_s(str, 8) < 8) // if all space used by text then there is no terminator
+							source = str;
+						break;
+
+					// long string variable
+					case DT_VAR_STRING:
+					case DT_LVAR_STRING:
+					case DT_VAR_STRING_ARRAY:
+					case DT_LVAR_STRING_ARRAY:
+						if (strnlen_s(str, 16) < 16) // if all space used by text then there is no terminator
+							source = str;
+						break;
+
+					default:
+						break;
+				}
+			}
+		}
+
+		if (source != nullptr && buf == nullptr)
+		{
+			// no need to copy data, as user can not access the internal buffer anyway
+			CLEO_SkipOpcodeParams(thread, 1);
+			return source;
+		}
+		
+		if (buf == nullptr)
+		{
+			buf = internal_buf;
+
+			if (bufSize == 0) bufSize = sizeof(internal_buf);
+			else bufSize = min(bufSize, sizeof(internal_buf)); // user requested size limit
+		}
+
+		// read data into buffer
+		auto result = ReadStringParam(thread, buf, bufSize);
+		if (result == nullptr)
+		{
+			LOG_WARNING(thread, "%s in script %s", CCustomOpcodeSystem::lastErrorMsg.c_str(), ((CCustomScript*)thread)->GetInfoStr().c_str());
+			return nullptr;
+		}
+
+		return (source != nullptr) ? source : result;
 	}
 
 	void WINAPI CLEO_ReadStringParamWriteBuffer(CLEO::CRunningScript* thread, char** outBuf, int* outBufSize, DWORD* outNeedsTerminator)
@@ -1885,6 +1974,21 @@ extern "C"
 		thread->CurrentIP = ip;
 		GetInstance().OpcodeSystem.handledParamCount = count;
 		opcodeParams[0] = param;
+
+		return result;
+	}
+
+	SCRIPT_VAR* WINAPI CLEO_PeekPointerToScriptVariable(CLEO::CRunningScript* thread)
+	{
+		// store state
+		auto ip = thread->CurrentIP;
+		auto count = GetInstance().OpcodeSystem.handledParamCount;
+
+		auto result = GetScriptParamPointer(thread);
+
+		// restore state
+		thread->CurrentIP = ip;
+		GetInstance().OpcodeSystem.handledParamCount = count;
 
 		return result;
 	}

--- a/source/cleo.def
+++ b/source/cleo.def
@@ -42,8 +42,9 @@ EXPORTS
 	_CLEO_GetParamsHandledCount@0			@39
 	_CLEO_PeekIntOpcodeParam@4				@40
 	_CLEO_PeekFloatOpcodeParam@4			@41
-	_CLEO_GetScriptByName@16				@42
-	_CLEO_GetScriptByFilename@8				@43
-	_CLEO_GetScriptFilename@4				@44
-	_CLEO_GetScriptWorkDir@4				@45
-	_CLEO_SetScriptWorkDir@8				@46
+	_CLEO_PeekPointerToScriptVariable@4		@42
+	_CLEO_GetScriptByName@16				@43
+	_CLEO_GetScriptByFilename@8				@44
+	_CLEO_GetScriptFilename@4				@45
+	_CLEO_GetScriptWorkDir@4				@46
+	_CLEO_SetScriptWorkDir@8				@47


### PR DESCRIPTION
Restored original behavior of CLEO_ReadStringPointerOpcodeParam sdk export.
Restored separated internal buffers for CLEO_ReadStringOpcodeParam and CLEO_ReadStringPointerOpcodeParam sdk exports. Updated opcode param string read util macro to reflect old CLEO general approach and try to use raw source text data whenever possible. 
Optimized out unnecessary text copying to internal buffer.

Fixes problem with RZML Trainer