### PR TITLE
Fixed opcodes 0A8D, 2401, 2402 types invalid data type restrictions.

### DIFF
--- a/cleo_plugins/MemoryOperations/MemoryOperations.cpp
+++ b/cleo_plugins/MemoryOperations/MemoryOperations.cpp
@@ -185,11 +185,11 @@ public:
         const void* source;
         auto paramType = thread->PeekDataType();
         bool sourceText = false;
-        if (IsVariable(paramType))
+        if (IsVariable(paramType) || IsVarString(paramType))
         {
             source = CLEO_GetPointerToScriptVariable(thread);
         }
-        else if (IsImmString(paramType) || IsVarString(paramType))
+        else if (IsImmString(paramType))
         {
             static char buffer[MAX_STR_LEN];
 
@@ -286,7 +286,7 @@ public:
             memcpy(&value, address, size);
         }
 
-        OPCODE_WRITE_PARAM_UINT(value);
+        OPCODE_WRITE_PARAM_ANY(value);
         return OR_CONTINUE;
     }
 
@@ -662,7 +662,7 @@ public:
         {
             if (size == 0)
             {
-                OPCODE_WRITE_PARAM_INT(0);
+                OPCODE_WRITE_PARAM_ANY(0);
                 return OR_CONTINUE; // done
             }
 
@@ -674,7 +674,7 @@ public:
             }
             if (size > 0) memcpy(&result, (void*)(ptr + offset), size);
 
-            OPCODE_WRITE_PARAM_INT(result);
+            OPCODE_WRITE_PARAM_ANY(result);
             return OR_CONTINUE;
         }
         else if (IsVarString(resultType))
@@ -716,7 +716,7 @@ public:
                 size = sizeof(DWORD);
             }
 
-            auto value = OPCODE_READ_PARAM_INT();
+            auto value = OPCODE_READ_PARAM_ANY();
             memcpy(ptr + offset, &value, size);
 
             return OR_CONTINUE;

--- a/cleo_plugins/MemoryOperations/MemoryOperations.cpp
+++ b/cleo_plugins/MemoryOperations/MemoryOperations.cpp
@@ -286,7 +286,7 @@ public:
             memcpy(&value, address, size);
         }
 
-        OPCODE_WRITE_PARAM_ANY(value);
+        OPCODE_WRITE_PARAM_ANY32(value);
         return OR_CONTINUE;
     }
 
@@ -662,7 +662,7 @@ public:
         {
             if (size == 0)
             {
-                OPCODE_WRITE_PARAM_ANY(0);
+                OPCODE_WRITE_PARAM_ANY32(0);
                 return OR_CONTINUE; // done
             }
 
@@ -674,7 +674,7 @@ public:
             }
             if (size > 0) memcpy(&result, (void*)(ptr + offset), size);
 
-            OPCODE_WRITE_PARAM_ANY(result);
+            OPCODE_WRITE_PARAM_ANY32(result);
             return OR_CONTINUE;
         }
         else if (IsVarString(resultType))
@@ -716,7 +716,7 @@ public:
                 size = sizeof(DWORD);
             }
 
-            auto value = OPCODE_READ_PARAM_ANY();
+            auto value = OPCODE_READ_PARAM_ANY32();
             memcpy(ptr + offset, &value, size);
 
             return OR_CONTINUE;

--- a/cleo_sdk/CLEO_Utils.h
+++ b/cleo_sdk/CLEO_Utils.h
@@ -421,7 +421,7 @@ namespace CLEO
         if (!IsLegacyScript(thread) && !_paramWasFloat()) { SHOW_ERROR("Input argument #%d expected to be float, got %s in script %s\nScript suspended.", CLEO_GetParamsHandledCount(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
 
     #define OPCODE_READ_PARAM_ANY32() _readParam(thread).dwParam; \
-        if (!_paramWasInt() && !_paramWasFloat()) { SHOW_ERROR("Input argument #%d expected to be simple-type, got %s in script %s\nScript suspended.", CLEO_GetParamsHandledCount(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
+        if (!_paramWasInt() && !_paramWasFloat()) { SHOW_ERROR("Input argument #%d expected to be int or float, got %s in script %s\nScript suspended.", CLEO_GetParamsHandledCount(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
 
     #define OPCODE_READ_PARAM_STRING(_varName) char _buff_##_varName[MAX_STR_LEN + 1]; const char* ##_varName = _readParamText(thread, _buff_##_varName, MAX_STR_LEN + 1); if(!_paramWasString()) { return OpcodeResult::OR_INTERRUPT; }
 

--- a/cleo_sdk/CLEO_Utils.h
+++ b/cleo_sdk/CLEO_Utils.h
@@ -31,7 +31,7 @@ namespace CLEO
     OPCODE_READ_PARAM_INT()
     OPCODE_READ_PARAM_UINT()
     OPCODE_READ_PARAM_FLOAT()
-    OPCODE_READ_PARAM_ANY() // any regular single-slot variable (practically integers and floats)
+    OPCODE_READ_PARAM_ANY32() // any regular single-slot variable (practically integers and floats)
     OPCODE_READ_PARAM_STRING(varName) // reads param and creates const char* variable named 'varName' with pointer to null-terminated string
     OPCODE_READ_PARAM_STRING_LEN(varName, maxLength) // same as above, but text length is clamped to maxLength
     OPCODE_READ_PARAM_FILEPATH(varName) // reads param and creates const char* variable named 'varName' with pointer to resolved, null-terminated, filepath
@@ -52,7 +52,7 @@ namespace CLEO
     OPCODE_WRITE_PARAM_INT(value)
     OPCODE_WRITE_PARAM_UINT(value)
     OPCODE_WRITE_PARAM_FLOAT(value)
-    OPCODE_WRITE_PARAM_ANY(value) // any regular single-slot variable (practically integers and floats)
+    OPCODE_WRITE_PARAM_ANY32(value) // any regular single-slot variable (practically integers and floats)
     OPCODE_WRITE_PARAM_STRING(value)
     OPCODE_WRITE_PARAM_PTR(value) // memory address
     */
@@ -420,7 +420,7 @@ namespace CLEO
     #define OPCODE_READ_PARAM_FLOAT() _readParamFloat(thread).fParam; \
         if (!IsLegacyScript(thread) && !_paramWasFloat()) { SHOW_ERROR("Input argument #%d expected to be float, got %s in script %s\nScript suspended.", CLEO_GetParamsHandledCount(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
 
-    #define OPCODE_READ_PARAM_ANY() _readParam(thread).dwParam; \
+    #define OPCODE_READ_PARAM_ANY32() _readParam(thread).dwParam; \
         if (!_paramWasInt() && !_paramWasFloat()) { SHOW_ERROR("Input argument #%d expected to be simple-type, got %s in script %s\nScript suspended.", CLEO_GetParamsHandledCount(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
 
     #define OPCODE_READ_PARAM_STRING(_varName) char _buff_##_varName[MAX_STR_LEN + 1]; const char* ##_varName = _readParamText(thread, _buff_##_varName, MAX_STR_LEN + 1); if(!_paramWasString()) { return OpcodeResult::OR_INTERRUPT; }
@@ -479,7 +479,7 @@ namespace CLEO
     #define OPCODE_WRITE_PARAM_UINT(value) _writeParam(thread, value); \
         if (!_paramWasInt(true)) { SHOW_ERROR("Output argument #%d expected to be variable int, got %s in script %s\nScript suspended.", CLEO_GetParamsHandledCount(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
 
-    #define OPCODE_WRITE_PARAM_ANY(value) _writeParam(thread, value); \
+    #define OPCODE_WRITE_PARAM_ANY32(value) _writeParam(thread, value); \
         if (!_paramWasInt(true) && !_paramWasFloat(true)) { SHOW_ERROR("Output argument #%d expected to be int or float variable, got %s in script %s\nScript suspended.", CLEO_GetParamsHandledCount(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
 
     #define OPCODE_WRITE_PARAM_FLOAT(value) _writeParam(thread, value); \

--- a/cleo_sdk/CLEO_Utils.h
+++ b/cleo_sdk/CLEO_Utils.h
@@ -480,7 +480,7 @@ namespace CLEO
         if (!_paramWasInt(true)) { SHOW_ERROR("Output argument #%d expected to be variable int, got %s in script %s\nScript suspended.", CLEO_GetParamsHandledCount(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
 
     #define OPCODE_WRITE_PARAM_ANY(value) _writeParam(thread, value); \
-        if (!_paramWasInt(true) && !_paramWasFloat(true)) { SHOW_ERROR("Output argument #%d expected to be simple-type variable, got %s in script %s\nScript suspended.", CLEO_GetParamsHandledCount(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
+        if (!_paramWasInt(true) && !_paramWasFloat(true)) { SHOW_ERROR("Output argument #%d expected to be int or float variable, got %s in script %s\nScript suspended.", CLEO_GetParamsHandledCount(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
 
     #define OPCODE_WRITE_PARAM_FLOAT(value) _writeParam(thread, value); \
         if (!IsLegacyScript(thread) && !_paramWasFloat(true)) { SHOW_ERROR("Output argument #%d expected to be variable float, got %s in script %s\nScript suspended.", CLEO_GetParamsHandledCount(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }

--- a/cleo_sdk/CLEO_Utils.h
+++ b/cleo_sdk/CLEO_Utils.h
@@ -31,7 +31,7 @@ namespace CLEO
     OPCODE_READ_PARAM_INT()
     OPCODE_READ_PARAM_UINT()
     OPCODE_READ_PARAM_FLOAT()
-    OPCODE_READ_PARAM_ANY32() // any regular single-slot variable (practically integers and floats)
+    OPCODE_READ_PARAM_ANY32() // get raw data of simple-type value (practically integers and floats)
     OPCODE_READ_PARAM_STRING(varName) // reads param and creates const char* variable named 'varName' with pointer to null-terminated string
     OPCODE_READ_PARAM_STRING_LEN(varName, maxLength) // same as above, but text length is clamped to maxLength
     OPCODE_READ_PARAM_FILEPATH(varName) // reads param and creates const char* variable named 'varName' with pointer to resolved, null-terminated, filepath
@@ -52,7 +52,7 @@ namespace CLEO
     OPCODE_WRITE_PARAM_INT(value)
     OPCODE_WRITE_PARAM_UINT(value)
     OPCODE_WRITE_PARAM_FLOAT(value)
-    OPCODE_WRITE_PARAM_ANY32(value) // any regular single-slot variable (practically integers and floats)
+    OPCODE_WRITE_PARAM_ANY32(value) // write raw data into simple-type variable (practically integers and floats)
     OPCODE_WRITE_PARAM_STRING(value)
     OPCODE_WRITE_PARAM_PTR(value) // memory address
     */

--- a/cleo_sdk/CLEO_Utils.h
+++ b/cleo_sdk/CLEO_Utils.h
@@ -31,6 +31,7 @@ namespace CLEO
     OPCODE_READ_PARAM_INT()
     OPCODE_READ_PARAM_UINT()
     OPCODE_READ_PARAM_FLOAT()
+    OPCODE_READ_PARAM_ANY() // any regular simple-type variable (integers and floats)
     OPCODE_READ_PARAM_STRING(varName) // reads param and creates const char* variable named 'varName' with pointer to null-terminated string
     OPCODE_READ_PARAM_STRING_LEN(varName, maxLength) // same as above, but text length is clamped to maxLength
     OPCODE_READ_PARAM_FILEPATH(varName) // reads param and creates const char* variable named 'varName' with pointer to resolved, null-terminated, filepath
@@ -51,6 +52,7 @@ namespace CLEO
     OPCODE_WRITE_PARAM_INT(value)
     OPCODE_WRITE_PARAM_UINT(value)
     OPCODE_WRITE_PARAM_FLOAT(value)
+    OPCODE_WRITE_PARAM_ANY(value) // any regular simple-type variable (integers and floats)
     OPCODE_WRITE_PARAM_STRING(value)
     OPCODE_WRITE_PARAM_PTR(value) // memory address
     */
@@ -418,6 +420,9 @@ namespace CLEO
     #define OPCODE_READ_PARAM_FLOAT() _readParamFloat(thread).fParam; \
         if (!IsLegacyScript(thread) && !_paramWasFloat()) { SHOW_ERROR("Input argument #%d expected to be float, got %s in script %s\nScript suspended.", CLEO_GetParamsHandledCount(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
 
+    #define OPCODE_READ_PARAM_ANY() _readParam(thread).dwParam; \
+        if (!_paramWasInt() && !_paramWasFloat()) { SHOW_ERROR("Input argument #%d expected to be simple-type, got %s in script %s\nScript suspended.", CLEO_GetParamsHandledCount(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
+
     #define OPCODE_READ_PARAM_STRING(_varName) char _buff_##_varName[MAX_STR_LEN + 1]; const char* ##_varName = _readParamText(thread, _buff_##_varName, MAX_STR_LEN + 1); if(!_paramWasString()) { return OpcodeResult::OR_INTERRUPT; }
 
     #define OPCODE_READ_PARAM_STRING_LEN(_varName, _maxLen) char _buff_##_varName[_maxLen + 1]; const char* ##_varName = _readParamText(thread, _buff_##_varName, _maxLen + 1); if(##_varName != nullptr) ##_varName = _buff_##_varName; if(!_paramWasString()) { return OpcodeResult::OR_INTERRUPT; }
@@ -473,6 +478,9 @@ namespace CLEO
 
     #define OPCODE_WRITE_PARAM_UINT(value) _writeParam(thread, value); \
         if (!_paramWasInt(true)) { SHOW_ERROR("Output argument #%d expected to be variable int, got %s in script %s\nScript suspended.", CLEO_GetParamsHandledCount(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
+
+    #define OPCODE_WRITE_PARAM_ANY(value) _writeParam(thread, value); \
+        if (!_paramWasInt(true) && !_paramWasFloat(true)) { SHOW_ERROR("Output argument #%d expected to be simple-type variable, got %s in script %s\nScript suspended.", CLEO_GetParamsHandledCount(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
 
     #define OPCODE_WRITE_PARAM_FLOAT(value) _writeParam(thread, value); \
         if (!IsLegacyScript(thread) && !_paramWasFloat(true)) { SHOW_ERROR("Output argument #%d expected to be variable float, got %s in script %s\nScript suspended.", CLEO_GetParamsHandledCount(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }

--- a/cleo_sdk/CLEO_Utils.h
+++ b/cleo_sdk/CLEO_Utils.h
@@ -31,7 +31,7 @@ namespace CLEO
     OPCODE_READ_PARAM_INT()
     OPCODE_READ_PARAM_UINT()
     OPCODE_READ_PARAM_FLOAT()
-    OPCODE_READ_PARAM_ANY() // any regular simple-type variable (integers and floats)
+    OPCODE_READ_PARAM_ANY() // any regular single-slot variable (practically integers and floats)
     OPCODE_READ_PARAM_STRING(varName) // reads param and creates const char* variable named 'varName' with pointer to null-terminated string
     OPCODE_READ_PARAM_STRING_LEN(varName, maxLength) // same as above, but text length is clamped to maxLength
     OPCODE_READ_PARAM_FILEPATH(varName) // reads param and creates const char* variable named 'varName' with pointer to resolved, null-terminated, filepath
@@ -52,7 +52,7 @@ namespace CLEO
     OPCODE_WRITE_PARAM_INT(value)
     OPCODE_WRITE_PARAM_UINT(value)
     OPCODE_WRITE_PARAM_FLOAT(value)
-    OPCODE_WRITE_PARAM_ANY(value) // any regular simple-type variable (integers and floats)
+    OPCODE_WRITE_PARAM_ANY(value) // any regular single-slot variable (practically integers and floats)
     OPCODE_WRITE_PARAM_STRING(value)
     OPCODE_WRITE_PARAM_PTR(value) // memory address
     */


### PR DESCRIPTION
Tweaked 0A8C to restore original behavior of obtaining data from neighbor variables.