### PR TITLE
CLEO testing library

### DIFF
--- a/tests/cleo_tests/FilesystemOperations/0A9A.txt
+++ b/tests/cleo_tests/FilesystemOperations/0A9A.txt
@@ -1,48 +1,41 @@
 {$CLEO .s}
-{$USE debug}
-{$USE file}
-{$USE bitwise}
-var 0@ : Integer
-var 1@ : Integer
-var 2@ : Integer
-var 3@ : Integer
-var 4@ : Integer
-var 5@ : Integer
-var 6@ : Integer
-var 7@ : Integer
-var 8@ : Integer
-var 9@ : Integer
-var 10@ : Integer
+{$INCLUDE_ONCE ../cleo_tester.txt}
 
 script_name "0A9A" // open_file
 debug_on
 
-trace "0A9A (open_file)"
-
-
-wait 0
-// try open non existing file
-if
-    // test 0A9A
-    0@ = open_file "cleo\not_a_file.txt" {mode} "r" // tested opcode
-then
-    breakpoint "~r~~h~~h~~h~0A9A (open_file), #0 FAILED! Opened non existing file?"
-else
-    trace "~g~~h~~h~0A9A (open_file), #0 PASSED"
-end
-
-
-wait 0
-// try open non existing file
-if
-    // test 0A9A
-    0@ = open_file "cleo\.cleo.log" {mode} "r" // tested opcode
-then
-    trace "~g~~h~~h~0A9A (open_file), #1 PASSED"
-    close_file 0@
-else
-    breakpoint "~r~~h~~h~~h~0A9A (open_file), #1 FAILED! Failed to open file."
-end
-
-
+test("0A9A (open_file)", @tests)
 terminate_this_custom_script
+
+
+function tests
+
+    it("should fail on a non-existing file", @test1)
+    it("should open existing file", @test2)
+
+    return true
+    
+    
+    function test1
+        if
+            0@ = open_file "cleo\not_a_file.txt" {mode} "r" // tested opcode
+        then
+            assert(false)
+        else
+            assert(true)
+        end
+    end
+    
+     function test2
+        if
+            0@ = open_file "cleo\.cleo.log" {mode} "r" // tested opcode
+        then
+            assert(true)
+            close_file 0@
+        else
+            assert(false)
+        end
+    end
+
+end
+

--- a/tests/cleo_tests/FilesystemOperations/0A9A.txt
+++ b/tests/cleo_tests/FilesystemOperations/0A9A.txt
@@ -15,7 +15,6 @@ function tests
 
     return true
     
-    
     function test1
         if
             0@ = open_file "cleo\not_a_file.txt" {mode} "r" // tested opcode

--- a/tests/cleo_tests/MemoryOperations/0A8C.txt
+++ b/tests/cleo_tests/MemoryOperations/0A8C.txt
@@ -1,180 +1,88 @@
 {$CLEO .s}
-{$USE debug}
-{$USE memory}
-var 0@ : Integer
-var 1@ : Integer
-var 2@ : Integer
-var 3@ : Integer
-var 4@ : Integer
-var 5@ : Integer
-var 6@ : Integer
-var 7@ : Integer
-var 8@ : Integer
-var 9@ : Integer
-var 10@ : Integer
+{$INCLUDE_ONCE ../cleo_tester.txt}
 
-script_name "0A8C" // write_memory
-debug_on
-
-trace "0A8C (write_memory)"
-
-wait 0
-// write 0 bytes
-get_var_pointer 2@ {store_to} 0@
-1@ = 0xcccccccc
-2@ = 0xdddddddd
-3@ = 0xeeeeeeee
-
-0A8C: write_memory {address} 0@ {size} 0 {value} 0x11223344 {vp} false // tested opcode
-
-if and
-    1@ == 0xcccccccc
-    2@ == 0xdddddddd
-    3@ == 0xeeeeeeee
-then
-    trace "~g~~h~~h~0A8C (write_memory), #0 PASSED"
-else
-    breakpoint "~r~~h~~h~~h~0A8C (write_memory), #0 FAILED!~n~cccccccc dddddddd eeeeeeee Expected~n~%08x %08x %08x Occured" 1@ 2@ 3@
-end
-
-
-wait 0
-// write 1 byte
-get_var_pointer 2@ {store_to} 0@
-1@ = 0xcccccccc
-2@ = 0xdddddddd
-3@ = 0xeeeeeeee
-
-0A8C: write_memory {address} 0@ {size} 1 {value} 0x11223344 {vp} false // tested opcode
-
-if and
-    1@ == 0xcccccccc
-    2@ == 0xdddddd44
-    3@ == 0xeeeeeeee
-then
-    trace "~g~~h~~h~0A8C (write_memory), #1 PASSED"
-else
-    breakpoint "~r~~h~~h~~h~0A8C (write_memory), #1 FAILED!~n~cccccccc dddddd44 eeeeeeee Expected~n~%08x %08x %08x Occured" 1@ 2@ 3@
-end
-
-
-wait 0
-// write 2 bytes
-get_var_pointer 2@ {store_to} 0@
-1@ = 0xcccccccc
-2@ = 0xdddddddd
-3@ = 0xeeeeeeee
-
-0A8C: write_memory {address} 0@ {size} 2 {value} 0x11223344 {vp} false // tested opcode
-
-if and
-    1@ == 0xcccccccc
-    2@ == 0xdddd3344
-    3@ == 0xeeeeeeee
-then
-    trace "~g~~h~~h~0A8C (write_memory), #2 PASSED"
-else
-    breakpoint "~r~~h~~h~~h~0A8C (write_memory), #2 FAILED!~n~cccccccc dddd3344 eeeeeeee Expected~n~%08x %08x %08x Occured" 1@ 2@ 3@
-end
-
-
-wait 0
-// write 3 bytes
-get_var_pointer 2@ {store_to} 0@
-1@ = 0xcccccccc
-2@ = 0xdddddddd
-3@ = 0xeeeeeeee
-
-0A8C: write_memory {address} 0@ {size} 3 {value} 0x11223344 {vp} false // tested opcode
-
-if and
-    1@ == 0xcccccccc
-    2@ == 0xdd444444 // memset behavior
-    3@ == 0xeeeeeeee
-then
-    trace "~g~~h~~h~0A8C (write_memory), #3 PASSED"
-else
-    breakpoint "~r~~h~~h~~h~0A8C (write_memory), #3 FAILED!~n~cccccccc dd444444 eeeeeeee Expected~n~%08x %08x %08x Occured" 1@ 2@ 3@
-end
-
-
-wait 0
-// write 4 bytes
-get_var_pointer 2@ {store_to} 0@
-1@ = 0xcccccccc
-2@ = 0xdddddddd
-3@ = 0xeeeeeeee
-
-0A8C: write_memory {address} 0@ {size} 4 {value} 0x11223344 {vp} false // tested opcode
-
-if and
-    1@ == 0xcccccccc
-    2@ == 0x11223344
-    3@ == 0xeeeeeeee
-then
-    trace "~g~~h~~h~0A8C (write_memory), #4 PASSED"
-else
-    breakpoint "~r~~h~~h~~h~0A8C (write_memory), #4 FAILED!~n~cccccccc 11223344 eeeeeeee Expected~n~%08x %08x %08x Occured" 1@ 2@ 3@
-end
-
-
-wait 0
-// write 5 bytes
-get_var_pointer 2@ {store_to} 0@
-1@ = 0xcccccccc
-2@ = 0xdddddddd
-3@ = 0xeeeeeeee
-
-0A8C: write_memory {address} 0@ {size} 5 {value} 0x11223344 {vp} false // tested opcode
-
-if and
-    1@ == 0xcccccccc
-    2@ == 0x44444444
-    3@ == 0xeeeeee44
-then
-    trace "~g~~h~~h~0A8C (write_memory), #5 PASSED"
-else
-    breakpoint "~r~~h~~h~~h~0A8C (write_memory), #5 FAILED! Expected: cccccccc, 44444444, eeeeee44 Actual: %08x %08x %08x" 1@ 2@ 3@
-end
-
-
-wait 0
-// write 7 bytes
-get_var_pointer 2@ {store_to} 0@
-1@ = 0xcccccccc
-2@ = 0xdddddddd
-3@ = 0xeeeeeeee
-
-0A8C: write_memory {address} 0@ {size} 7 {value} 0x11223344 {vp} false // tested opcode
-
-if and
-    1@ == 0xcccccccc
-    2@ == 0x44444444
-    3@ == 0xee444444
-then
-    trace "~g~~h~~h~0A8C (write_memory), #6 PASSED"
-else
-    breakpoint "~r~~h~~h~~h~0A8C (write_memory), #6 FAILED! Expected: cccccccc, 44444444, ee444444 Actual: %08x %08x %08x" 1@ 2@ 3@
-end
-
-wait 0
-
-// write float
-get_var_pointer 2@ {store_to} 0@
-1@ = 0xcccccccc
-2@ = 0xdddddddd
-3@ = 0xeeeeeeee
-4@ = 100.0
-
-0A8C: write_memory {address} 0@ {size} 4 {value} 4@ {vp} false // tested opcode
-
-if
-    2@ == 100.0
-then
-    trace "~g~~h~~h~0A8C (write_memory), #7 PASSED"
-else
-    breakpoint "~r~~h~~h~~h~0A8C (write_memory), #7 FAILED!~n~cccccccc 100.0 eeeeeeee Expected~n~%08x %f %08x Occured" 1@ 2@ 3@
-end
-
-
+script_name '0A8C'
+test("0A8C (write_memory)", @tests)
 terminate_this_custom_script
+
+
+function tests
+    before_each(@before)
+
+    it("should write 0 bytes", @test1)
+    it("should write 1 byte", @test2)
+    it("should write 2 bytes", @test3)
+    it("should write 3 bytes", @test4)
+    it("should write 4 bytes", @test5)
+    it("should write 5 bytes", @test6)
+    it("should write 7 bytes", @test7)
+    it("should write float", @test8)
+
+    return true
+    
+    :before
+        get_var_pointer 2@ {store_to} 0@
+        1@ = 0xcccccccc
+        2@ = 0xdddddddd
+        3@ = 0xeeeeeeee
+    0051: return
+
+    function test1
+        write_memory {address} 0@ {size} 0 {value} 0x11223344 {vp} false
+        assert_eq(1@, 0xcccccccc)
+        assert_eq(2@, 0xdddddddd)
+        assert_eq(3@, 0xeeeeeeee)
+    end
+    
+    function test2
+        write_memory {address} 0@ {size} 1 {value} 0x11223344 {vp} false
+        assert_eq(1@, 0xcccccccc)
+        assert_eq(2@, 0xdddddd44)
+        assert_eq(3@, 0xeeeeeeee)
+    end
+
+    function test3
+        write_memory {address} 0@ {size} 2 {value} 0x11223344 {vp} false
+        assert_eq(1@, 0xcccccccc)
+        assert_eq(2@, 0xdddd3344)
+        assert_eq(3@, 0xeeeeeeee)
+    end
+
+    function test4
+        write_memory {address} 0@ {size} 3 {value} 0x11223344 {vp} false
+        assert_eq(1@, 0xcccccccc)
+        assert_eq(2@, 0xdd444444) // memset behavior
+        assert_eq(3@, 0xeeeeeeee)
+    end
+
+    function test5
+        write_memory {address} 0@ {size} 4 {value} 0x11223344 {vp} false
+        assert_eq(1@, 0xcccccccc)
+        assert_eq(2@, 0x11223344)
+        assert_eq(3@, 0xeeeeeeee)
+    end
+
+    function test6
+        write_memory {address} 0@ {size} 5 {value} 0x11223344 {vp} false
+        assert_eq(1@, 0xcccccccc)
+        assert_eq(2@, 0x44444444)
+        assert_eq(3@, 0xeeeeee44)
+    end
+
+    function test7
+        write_memory {address} 0@ {size} 7 {value} 0x11223344 {vp} false
+        assert_eq(1@, 0xcccccccc)
+        assert_eq(2@, 0x44444444)
+        assert_eq(3@, 0xee444444)
+    end
+
+    function test8
+        4@ = 100.0
+        0A8C: write_memory {address} 0@ {size} 4 {value} 4@ {vp} false // tested opcode
+        assert_eq(1@, 0xcccccccc)
+        assert_eqf(2@, 100.0)
+        assert_eq(3@, 0xeeeeeeee)
+    end
+
+
+end

--- a/tests/cleo_tests/MemoryOperations/0A8D.txt
+++ b/tests/cleo_tests/MemoryOperations/0A8D.txt
@@ -1,142 +1,81 @@
 {$CLEO .s}
-{$USE debug}
-{$USE memory}
-var 0@ : Integer
-var 1@ : Integer
-var 2@ : Integer
-var 3@ : Integer
-var 4@ : Integer
-var 5@ : Integer
-var 6@ : Integer
-var 7@ : Integer
-var 8@ : Integer
-var 9@ : Integer
-var 10@ : Integer
+{$INCLUDE_ONCE ../cleo_tester.txt}
 
-script_name "0A8D" // read_memory
-debug_on
-
-trace "0A8D (read_memory)"
-
-wait 0
-// read 0 bytes
-0AC6: get_label_pointer @DATA {store_to} 0@
-1@ = 0xcccccccc
-2@ = 0xdddddddd
-3@ = 0xeeeeeeee
-
-0A8D: read_memory {address} 0@ {size} 0 {vp} false {result} 2@ // tested opcode
-
-if and
-    1@ == 0xcccccccc
-    2@ == 0x00000000
-    3@ == 0xeeeeeeee
-then
-    trace "~g~~h~~h~0A8D (read_memory), #0 PASSED"
-else
-    breakpoint "~r~~h~~h~~h~0A8D (read_memory), #0 FAILED!~n~cccccccc 00000000 eeeeeeee Expected~n~%08x %08x %08x Occured" 1@ 2@ 3@
-end
-
-
-wait 0
-// read 0 bytes
-0AC6: get_label_pointer @DATA {store_to} 0@
-1@ = 0xcccccccc
-2@ = 0xdddddddd
-3@ = 0xeeeeeeee
-
-0A8D: read_memory {address} 0@ {size} 1 {vp} false {result} 2@ // tested opcode
-
-if and
-    1@ == 0xcccccccc
-    2@ == 0x00000044
-    3@ == 0xeeeeeeee
-then
-    trace "~g~~h~~h~0A8D (read_memory), #1 PASSED"
-else
-    breakpoint "~r~~h~~h~~h~0A8D (read_memory), #1 FAILED!~n~cccccccc 00000044 eeeeeeee Expected~n~%08x %08x %08x Occured" 1@ 2@ 3@
-end
-
-
-wait 0
-// read 2 bytes
-0AC6: get_label_pointer @DATA {store_to} 0@
-1@ = 0xcccccccc
-2@ = 0xdddddddd
-3@ = 0xeeeeeeee
-
-0A8D: read_memory {address} 0@ {size} 2 {vp} false {result} 2@ // tested opcode
-
-if and
-    1@ == 0xcccccccc
-    2@ == 0x00003344
-    3@ == 0xeeeeeeee
-then
-    trace "~g~~h~~h~0A8D (read_memory), #2 PASSED"
-else
-    breakpoint "~r~~h~~h~~h~0A8D (read_memory), #2 FAILED!~n~cccccccc 00003344 eeeeeeee Expected~n~%08x %08x %08x Occured" 1@ 2@ 3@
-end
-
-
-wait 0
-// read 3 bytes
-0AC6: get_label_pointer @DATA {store_to} 0@
-1@ = 0xcccccccc
-2@ = 0xdddddddd
-3@ = 0xeeeeeeee
-
-0A8D: read_memory {address} 0@ {size} 3 {vp} false {result} 2@ // tested opcode
-
-if and
-    1@ == 0xcccccccc
-    2@ == 0x00223344
-    3@ == 0xeeeeeeee
-then
-    trace "~g~~h~~h~0A8D (read_memory), #3 PASSED"
-else
-    breakpoint "~r~~h~~h~~h~0A8D (read_memory), #3 FAILED!~n~cccccccc 00223344 eeeeeeee Expected~n~%08x %08x %08x Occured" 1@ 2@ 3@
-end
-
-
-wait 0
-// read 4 bytes
-0AC6: get_label_pointer @DATA {store_to} 0@
-1@ = 0xcccccccc
-2@ = 0xdddddddd
-3@ = 0xeeeeeeee
-
-0A8D: read_memory {address} 0@ {size} 4 {vp} false {result} 2@ // tested opcode
-
-if and
-    1@ == 0xcccccccc
-    2@ == 0x11223344
-    3@ == 0xeeeeeeee
-then
-    trace "~g~~h~~h~0A8D (read_memory), #4 PASSED"
-else
-    breakpoint "~r~~h~~h~~h~0A8D (read_memory), #4 FAILED!~n~cccccccc 11223344 eeeeeeee Expected~n~%08x %08x %08x Occured" 1@ 2@ 3@
-end
-
-wait 0
-// read float value
-0@ = 125.0
-2@ = 0
-get_var_pointer 0@ {store_to} 1@
-0A8D: read_memory {address} 1@ {size} 4 {vp} false {result} 2@
-
-if
-    2@ == 125.0
-then
-    trace "~g~~h~~h~0A8D (read_memory), #5 PASSED"
-else
-    breakpoint "~r~~h~~h~~h~0A8D (read_memory), #5 FAILED!~n~125.0 Expected~n~%f Occured" 2@
-end
-
+script_name '0A8D'
+test("0A8D (read_memory)", @tests)
 terminate_this_custom_script
 
+function tests
+    before_each(@prepare_tests)
 
-:DATA
-hex
-    44 33 22 11
-    "some longer testing text" 00
+    it("should read 0 bytes", @test1)
+    it("should read 1 byte", @test2)
+    it("should read 2 bytes", @test3)
+    it("should read 3 bytes", @test4)
+    it("should read 4 bytes", @test5)
+    it("should read float", @test6)
+    
+    return true
+    
+    :prepare_tests
+        0@ = get_label_pointer @DATA
+        1@ = 0xcccccccc
+        2@ = 0xdddddddd
+        3@ = 0xeeeeeeee
+    0051: return // sanny does not allow single `return` command in function context
+
+    function test1
+        2@ = read_memory {address} 0@ {size} 0 {vp} false
+
+        assert_eq(1@, 0xcccccccc)
+        assert_eq(2@, 0x00000000)
+        assert_eq(3@, 0xeeeeeeee)
+    end
+
+    function test2
+        2@ = read_memory {address} 0@ {size} 1 {vp} false
+
+        assert_eq(1@, 0xcccccccc)
+        assert_eq(2@, 0x00000044)
+        assert_eq(3@, 0xeeeeeeee)
+    end
+
+    function test3
+        2@ = read_memory {address} 0@ {size} 2 {vp} false
+
+        assert_eq(1@, 0xcccccccc)
+        assert_eq(2@, 0x00003344)
+        assert_eq(3@, 0xeeeeeeee)
+    end
+
+    function test4
+        2@ = read_memory {address} 0@ {size} 3 {vp} false
+
+        assert_eq(1@, 0xcccccccc)
+        assert_eq(2@, 0x00223344)
+        assert_eq(3@, 0xeeeeeeee)
+    end
+
+    function test5
+        2@ = read_memory {address} 0@ {size} 4 {vp} false
+
+        assert_eq(1@, 0xcccccccc)
+        assert_eq(2@, 0x11223344)
+        assert_eq(3@, 0xeeeeeeee)
+    end
+
+    function test6
+        0@ = 125.0
+        2@ = 0
+        get_var_pointer 0@ {store_to} 1@
+        2@ = read_memory {address} 1@ {size} 4 {vp} false
+
+        assert_eq(2@, 125.0)
+    end
+
+    :DATA
+    hex
+        44 33 22 11
+        "some longer testing text" 00
+    end
 end

--- a/tests/cleo_tests/MemoryOperations/0A96.txt
+++ b/tests/cleo_tests/MemoryOperations/0A96.txt
@@ -1,34 +1,20 @@
 {$CLEO .s}
-{$USE debug}
-{$USE memory}
-var 0@ : Integer
-var 1@ : Integer
-var 2@ : Integer
-var 3@ : Integer
-var 4@ : Integer
-var 5@ : Integer
-var 6@ : Integer
-var 7@ : Integer
-var 8@ : Integer
-var 9@ : Integer
-var 10@ : Integer
+{$INCLUDE_ONCE ../cleo_tester.txt}
 
 script_name "0A96" // get_ped_pointer
-debug_on
-
-trace "0A96 (get_ped_pointer)"
-
-wait 0
-get_player_char 0 {handle} 0@
-1@ = 0
-0A96: get_ped_pointer 0@ {address} 1@
-
-if
-    1@ > 0x10000 // possibly valid pointer
-then
-    trace "~g~~h~~h~0A96 (get_ped_pointer), #0 PASSED"
-else
-    breakpoint "~r~~h~~h~~h~0A96 (get_ped_pointer), #0 FAILED!~n~%d" 1@ 2@ 3@
-end
-
+test("0A96 (get_ped_pointer)", @tests)
 terminate_this_custom_script
+
+function tests
+
+    it("should return valid pointer", @test1)
+    
+    return true
+    
+    function test1
+        int handle = get_player_char 0
+        int ptr = get_ped_pointer handle
+        
+        assert_ptr(ptr)
+    end
+end

--- a/tests/cleo_tests/MemoryOperations/0A97.txt
+++ b/tests/cleo_tests/MemoryOperations/0A97.txt
@@ -1,41 +1,24 @@
 {$CLEO .s}
-{$USE debug}
-{$USE memory}
-var 0@ : Integer
-var 1@ : Integer
-var 2@ : Integer
-var 3@ : Integer
-var 4@ : Integer
-var 5@ : Integer
-var 6@ : Integer
-var 7@ : Integer
-var 8@ : Integer
-var 9@ : Integer
-var 10@ : Integer
+{$INCLUDE_ONCE ../cleo_tester.txt}
 
 script_name "0A97" // get_vehicle_pointer
-debug_on
-
-trace "0A97 (get_vehicle_pointer)"
-
-
-wait 0
-request_model 400
-load_all_models_now
-create_car 400 {xyz} 0.0 0.0 0.0 {result} 0@
-
-1@ = 0
-0A97: get_vehicle_pointer 0@ {result} 1@ // tested opcode
-
-mark_car_as_no_longer_needed 0@
-
-if
-    1@ > 0x10000 // possibly valid pointer
-then
-    trace "~g~~h~~h~0A97 (get_vehicle_pointer), #0 PASSED"
-else
-    breakpoint "~r~~h~~h~~h~0A97 (get_vehicle_pointer), #0 FAILED!~n~%d" 1@ 2@ 3@
-end
-
-
+test("0A97 (get_vehicle_pointer)", @tests)
 terminate_this_custom_script
+
+function tests
+
+    it("should return a valid pointer", @test1)
+    return true
+    
+    function test1
+        request_model 400
+        load_all_models_now
+        int handle = create_car 400 {xyz} 0.0 0.0 0.0
+
+        int ptr = 0
+        ptr = get_vehicle_pointer handle
+        mark_car_as_no_longer_needed handle
+
+        assert_ptr(ptr)
+    end
+end

--- a/tests/cleo_tests/MemoryOperations/0A98.txt
+++ b/tests/cleo_tests/MemoryOperations/0A98.txt
@@ -1,41 +1,24 @@
 {$CLEO .s}
-{$USE debug}
-{$USE memory}
-var 0@ : Integer
-var 1@ : Integer
-var 2@ : Integer
-var 3@ : Integer
-var 4@ : Integer
-var 5@ : Integer
-var 6@ : Integer
-var 7@ : Integer
-var 8@ : Integer
-var 9@ : Integer
-var 10@ : Integer
+{$INCLUDE_ONCE ../cleo_tester.txt}
 
 script_name "0A98" // get_vehicle_pointer
-debug_on
-
-trace "0A98 (get_object_pointer)"
-
-
-wait 0
-request_model 333 // golf club
-load_all_models_now
-create_object 333 {xyz} 0.0 0.0 0.0 {result} 0@
-
-1@ = 0
-0A98: get_object_pointer 0@ {result} 1@ // tested opcode
-
-mark_object_as_no_longer_needed 0@
-
-if
-    1@ > 0x10000 // possibly valid pointer
-then
-    trace "~g~~h~~h~0A98 (get_object_pointer), #0 PASSED"
-else
-    breakpoint "~r~~h~~h~~h~0A98 (get_object_pointer), #0 FAILED!~n~%d" 1@ 2@ 3@
-end
-
-
+test("0A98 (get_object_pointer)", @tests)
 terminate_this_custom_script
+
+function tests
+
+    it("should return a valid pointer", @test1)
+    return true
+
+    function test1
+        request_model 333 // golf club
+        load_all_models_now
+        int handle = create_object 333 {xyz} 0.0 0.0 0.0
+
+        int ptr = 0
+        ptr = get_object_pointer handle
+        mark_object_as_no_longer_needed handle
+
+        assert_ptr(ptr)
+    end
+end

--- a/tests/cleo_tests/MemoryOperations/0AA4.txt
+++ b/tests/cleo_tests/MemoryOperations/0AA4.txt
@@ -1,22 +1,27 @@
 {$CLEO .s}
+{$INCLUDE_ONCE ../cleo_tester.txt}
 
 script_name "0AA4"
-debug_on
-
-trace "0AA4 get_dynamic_library_procedure"
-wait 0
-
-int load_library_addr = read_memory 0x858070 4 false
-trace "Address of LoadLibrary function is %d" load_library_addr
-
-int kernel_dll_addr = call_function_return {address} load_library_addr {numParams} 1 {pop} 0 {funcParams} "kernel32.dll" // tested opcode
-if
-    // lib address can be any valid pointer, not necessarily one loaded with 0AA2 opcode
-    int sleep_addr = get_dynamic_library_procedure {procName} "Sleep" {DynamicLibrary} kernel_dll_addr
-then
-    trace "~g~~h~~h~0AA4 (get_dynamic_library_procedure), #0 PASSED"
-else
-    breakpoint "~r~~h~~h~~h~0AA4 (get_dynamic_library_procedure), #0 FAILED! Can't find procedure"
-end
-
+test("0AA4 (get_dynamic_library_procedure)", @tests)
 terminate_this_custom_script
+
+function tests
+
+    it("should return address of Sleep function from kernel32.dll", @test1)
+    return true
+    
+    function test1
+        int load_library_addr = read_memory 0x858070 4 false
+        trace "Address of LoadLibrary function is %d" load_library_addr
+
+        int kernel_dll_addr = call_function_return {address} load_library_addr {numParams} 1 {pop} 0 {funcParams} "kernel32.dll" // tested opcode
+        if
+            // lib address can be any valid pointer, not necessarily one loaded with 0AA2 opcode
+            int sleep_addr = get_dynamic_library_procedure {procName} "Sleep" {DynamicLibrary} kernel_dll_addr
+        then
+            assert(true)
+        else
+            assert(false)
+        end
+    end
+end

--- a/tests/cleo_tests/MemoryOperations/0AC6.txt
+++ b/tests/cleo_tests/MemoryOperations/0AC6.txt
@@ -1,45 +1,28 @@
 {$CLEO .s}
-{$USE debug}
-{$USE memory}
-var 0@ : Integer
-var 1@ : Integer
-var 2@ : Integer
-var 3@ : Integer
-var 4@ : Integer
-var 5@ : Integer
-var 6@ : Integer
-var 7@ : Integer
-var 8@ : Integer
-var 9@ : Integer
-var 10@ : Integer
+{$INCLUDE_ONCE ../cleo_tester.txt}
 
-script_name "0AC6" // get_vehicle_pointer
-debug_on
-
-trace "0AC6 (get_label_pointer)"
-
-
-wait 0
-1@ = 0
-0AC6: get_label_pointer @DATA {result} 1@ // tested opcode
-
-2@ = 0xCCCCCCCC
-read_memory 1@ {size} 4 {vp} false {result} 2@
-
-if and
-    1@ > 0x10000 // possibly valid pointer
-    2@ == 0x11223344
-then
-    trace "~g~~h~~h~0AC6 (get_label_pointer), #0 PASSED"
-else
-    breakpoint "~r~~h~~h~~h~0AC6 (get_label_pointer), #0 FAILED!~n~11223344 Expected~n~%08x Occured" 2@
-end
-
-
+script_name "0AC6" // get_label_pointer
+test("0AC6 (get_label_pointer)", @tests)
 terminate_this_custom_script
 
-:DATA
-hex
-    44 33 22 11
-    "some longer testing text" 00
+function tests
+
+    it("should return valid pointer", @test1)
+    return true
+    
+    function test1
+        int ptr = 0
+        ptr = get_label_pointer @DATA
+        int number = 0xCCCCCCCC
+        number = read_memory ptr {size} 4 {vp} false
+        assert_ptr(ptr)
+        assert_eq(number, 0x11223344)
+    end
+
+    :DATA
+    hex
+        44 33 22 11
+        "some longer testing text" 00
+    end
+
 end

--- a/tests/cleo_tests/MemoryOperations/0AC7.txt
+++ b/tests/cleo_tests/MemoryOperations/0AC7.txt
@@ -1,39 +1,30 @@
 {$CLEO .s}
-{$USE debug}
-{$USE memory}
-var 0@ : Integer
-var 1@ : Integer
-var 2@ : Integer
-var 3@ : Integer
-var 4@ : Integer
-var 5@ : Integer
-var 6@ : Integer
-var 7@ : Integer
-var 8@ : Integer
-var 9@ : Integer
-var 10@ : Integer
+{$INCLUDE_ONCE ../cleo_tester.txt}
 
-script_name "0AC7" // get_vehicle_pointer
-debug_on
-
-trace "0AC7 (get_var_pointer)"
-
-
-wait 0
-1@ = 0x11223344
-0AC7: get_var_pointer 1@ {result} 0@ // tested opcode
-
-2@ = 0xCCCCCCCC
-read_memory 0@ {size} 4 {vp} false {result} 2@
-
-if and
-    0@ > 0x10000 // possibly valid pointer
-    2@ == 0x11223344
-then
-    trace "~g~~h~~h~0AC7 (get_var_pointer), #0 PASSED"
-else
-    breakpoint "~r~~h~~h~~h~0AC7 (get_var_pointer), #0 FAILED!~n~11223344 Expected~n~%08x Occured" 2@
-end
-
-
+script_name "0AC7" // get_var_pointer
+test("0AC7 (get_var_pointer)", @tests)
 terminate_this_custom_script
+
+function tests
+
+    it("should return valid pointer", @test1)
+    return true
+
+    function test1
+        int val1 = 0x11223344
+        int val2 = 0xCCCCCCCC
+        int ptr = get_var_pointer val1
+        val2 = read_memory ptr {size} 4 {vp} false
+
+        assert_ptr(ptr)
+        assert_eq(val1, 0x11223344)
+        assert_eq(val2, 0x11223344)
+    end
+
+    :DATA
+    hex
+        44 33 22 11
+        "some longer testing text" 00
+    end
+
+end

--- a/tests/cleo_tests/MemoryOperations/0AC8.txt
+++ b/tests/cleo_tests/MemoryOperations/0AC8.txt
@@ -1,50 +1,40 @@
 {$CLEO .s}
-{$USE debug}
-{$USE memory}
-var 0@ : Integer
-var 1@ : Integer
-var 2@ : Integer
-var 3@ : Integer
-var 4@ : Integer
-var 5@ : Integer
-var 6@ : Integer
-var 7@ : Integer
-var 8@ : Integer
-var 9@ : Integer
-var 10@ : Integer
+{$INCLUDE_ONCE ../cleo_tester.txt}
 
 script_name "0AC8" // allocate_memory
-debug_on
-
-trace "0AC8 (allocate_memory)"
-
-
-wait 0
-0@ = 0x11223344
-0AC8: allocate_memory {size} 4 {result} 0@ // tested opcode
-
-if and
-    0@ > 0x10000 // possibly valid pointer
-    0@ <> 0x11223344
-then
-    trace "~g~~h~~h~0AC8 (allocate_memory), #0 PASSED"
-else
-    breakpoint "~r~~h~~h~~h~0AC8 (allocate_memory), #0 FAILED!~n~11223344 Expected~n~%08x Occured" 2@
-end
-
-
-wait 0
-// in CLEO5 expect to alloceted memory be prefilled with zeros
-2@ = 0xCCCCCCCC
-read_memory 0@ {size} 4 {vp} false {result} 2@
-
-if
-    2@ == 0
-then
-    trace "~g~~h~~h~0AC8 (allocate_memory), #1 PASSED"
-else
-    breakpoint "~r~~h~~h~~h~0AC8 (allocate_memory), #1 FAILED!~n~00000000 Expected~n~%08x Occured" 2@
-end
-
-
+test("0AC8 (allocate_memory)", @tests)
 terminate_this_custom_script
+
+function tests
+
+    before_each(@allocate)
+    after_each(@free)
+    
+    it("should return valid pointer", @test1)
+    it("should point to zero-filled mem in CLEO5", @test2)
+
+    return true
+
+    function test1
+        // 0@ is set in before_each callback
+        assert_ptr(0@)
+        assert_neq(0@, 0x11223344)
+    end
+    
+    function test2
+        2@ = 0xCCCCCCCC
+        2@ = read_memory 0@ {size} 4 {vp} false
+        assert_eq(2@, 0)
+    end
+
+    :allocate
+        0@ = 0x11223344
+        0@ = allocate_memory {size} 4
+    0051: return
+
+    :free
+        free_memory {address} 0@
+    0051: return
+
+
+end

--- a/tests/cleo_tests/MemoryOperations/0AC9.txt
+++ b/tests/cleo_tests/MemoryOperations/0AC9.txt
@@ -1,32 +1,21 @@
 {$CLEO .s}
-{$USE debug}
-{$USE memory}
-var 0@ : Integer
-var 1@ : Integer
-var 2@ : Integer
-var 3@ : Integer
-var 4@ : Integer
-var 5@ : Integer
-var 6@ : Integer
-var 7@ : Integer
-var 8@ : Integer
-var 9@ : Integer
-var 10@ : Integer
+{$INCLUDE_ONCE ../cleo_tester.txt}
 
 script_name "0AC9" // free_memory
-debug_on
-
-trace "0AC9 (free_memory)"
-
-
-wait 0
-0@ = 0x11223344
-allocate_memory {size} 4 {result} 0@
-
-0AC9: free_memory 0@ // tested opcode
-
-// not much to check within script. Did not crashed the game or printed error, so perhaps ok
-trace "~g~~h~~h~0AC9 (free_memory), #0 PASSED"
-
-
+test("0AC9 (free_memory)", @tests)
 terminate_this_custom_script
+
+function tests
+
+    it("should free allocated memory", @test1)
+    return true
+    
+    function test1
+        int ptr = 0x11223344
+        ptr = allocate_memory {size} 4
+        free_memory ptr
+
+        // not much to check within script. Did not crashed the game or printed error, so perhaps ok
+        assert(true)
+    end
+end

--- a/tests/cleo_tests/MemoryOperations/0AE9.txt
+++ b/tests/cleo_tests/MemoryOperations/0AE9.txt
@@ -1,38 +1,30 @@
 {$CLEO .s}
-{$USE debug}
-{$USE memory}
-var 0@ : Integer
-var 1@ : Integer
-var 2@ : Integer
-var 3@ : Integer
-var 4@ : Integer
-var 5@ : Integer
-var 6@ : Integer
-var 7@ : Integer
-var 8@ : Integer
-var 9@ : Integer
-var 10@ : Integer
+{$INCLUDE_ONCE ../cleo_tester.txt}
 
 script_name "0AE9" // pop_float
-debug_on
-
-trace "0AE9 (pop_float)"
-
-
-wait 0
-0@s = '42.5'
-get_var_pointer 0@ {result} 2@
-call_function 0x0823CEE {argCount} 1 {pop} 1 {arg} 2@ // double atof(const char *)
-
-0AE9: pop_float {result} 3@  // tested opcode
-
-if
-    3@ == 42.5
-then
-    trace "~g~~h~~h~0AE9 (pop_float), #0 PASSED"
-else
-    breakpoint "~r~~h~~h~~h~0AE9 (pop_float), #0 FAILED!~n~42.5 Expected~n~%f Occured" 3@
-end
-
-
+test("0AE9 (pop_float)", @tests)
 terminate_this_custom_script
+
+function tests
+
+    it("should pop float from stack", @test1)
+    return true
+
+
+    function test1
+        0@s = '42.5'
+        2@ = get_var_pointer 0@
+        call_function 0x0823CEE {argCount} 1 {pop} 1 {arg} 2@ // double atof(const char *)
+
+        pop_float {result} 3@
+
+        if
+            3@ == 42.5
+        then
+            assert(true)
+        else
+            assert(false)
+        end
+
+    end
+end

--- a/tests/cleo_tests/MemoryOperations/0AEA.txt
+++ b/tests/cleo_tests/MemoryOperations/0AEA.txt
@@ -1,37 +1,25 @@
 {$CLEO .s}
-{$USE debug}
-{$USE memory}
-var 0@ : Integer
-var 1@ : Integer
-var 2@ : Integer
-var 3@ : Integer
-var 4@ : Integer
-var 5@ : Integer
-var 6@ : Integer
-var 7@ : Integer
-var 8@ : Integer
-var 9@ : Integer
-var 10@ : Integer
+{$INCLUDE_ONCE ../cleo_tester.txt}
 
 script_name "0AEA" // get_ped_ref
-debug_on
-
-trace "0AEA (get_ped_ref)"
-
-
-wait 0
-get_player_char 0 {handle} 0@
-get_ped_pointer 0@ {address} 1@
-
-0AEA: get_ped_ref 1@ {result} 2@ // tested opcode
-
-if
-    0@ == 2@
-then
-    trace "~g~~h~~h~0AEA (get_ped_ref), #0 PASSED"
-else
-    breakpoint "~r~~h~~h~~h~0AEA (get_ped_ref), #0 FAILED!~n~%08x Expected~n~%08x Occured" 0@ 2@
-end
-
-
+test("0AEA (get_ped_ref)", @tests)
 terminate_this_custom_script
+
+function tests
+    it("should return ped handle for pointer", @test1)
+    return true
+    
+    function test1
+        int handle = get_player_char 0
+        int ptr = get_ped_pointer handle
+        int handle2 = get_ped_ref ptr
+
+        if
+            handle == handle2
+        then
+            assert(true)
+        else
+            assert(false)
+        end
+    end
+end

--- a/tests/cleo_tests/MemoryOperations/0AEB.txt
+++ b/tests/cleo_tests/MemoryOperations/0AEB.txt
@@ -1,41 +1,29 @@
 {$CLEO .s}
-{$USE debug}
-{$USE memory}
-var 0@ : Integer
-var 1@ : Integer
-var 2@ : Integer
-var 3@ : Integer
-var 4@ : Integer
-var 5@ : Integer
-var 6@ : Integer
-var 7@ : Integer
-var 8@ : Integer
-var 9@ : Integer
-var 10@ : Integer
+{$INCLUDE_ONCE ../cleo_tester.txt}
 
 script_name "0AEB" // get_vehicle_ref
-debug_on
+test("0AEB (get_vehicle_ref)", @tests)
+terminate_this_custom_script
 
-trace "0AEB (get_vehicle_ref)"
+function tests
+    it("should return vehicle handle for pointer", @test1)
+    return true
 
+    function test1
+        request_model 400
+        load_all_models_now
+        int handle = create_car 400 {xyz} 0.0 0.0 0.0
+        int ptr = get_vehicle_pointer handle
+        int handle2 = get_vehicle_ref ptr
+        mark_car_as_no_longer_needed handle
 
-wait 0
-request_model 400
-load_all_models_now
-create_car 400 {xyz} 0.0 0.0 0.0 {result} 0@
-get_vehicle_pointer 0@ {result} 1@
-
-0AEB: get_vehicle_ref 1@ {result} 2@ // tested opcode
-
-mark_car_as_no_longer_needed 0@
-
-if
-    0@ == 2@
-then
-    trace "~g~~h~~h~0AEA (get_vehicle_ref), #0 PASSED"
-else
-    breakpoint "~r~~h~~h~~h~0AEA (get_vehicle_ref), #0 FAILED!~n~%08x Expected~n~%08x Occured" 0@ 2@
+        if
+            handle == handle2
+        then
+            assert(true)
+        else
+            assert(false)
+        end
+    end
 end
 
-
-terminate_this_custom_script

--- a/tests/cleo_tests/MemoryOperations/0AEC.txt
+++ b/tests/cleo_tests/MemoryOperations/0AEC.txt
@@ -1,41 +1,30 @@
 {$CLEO .s}
-{$USE debug}
-{$USE memory}
-var 0@ : Integer
-var 1@ : Integer
-var 2@ : Integer
-var 3@ : Integer
-var 4@ : Integer
-var 5@ : Integer
-var 6@ : Integer
-var 7@ : Integer
-var 8@ : Integer
-var 9@ : Integer
-var 10@ : Integer
+{$INCLUDE_ONCE ../cleo_tester.txt}
 
 script_name "0AEC" // get_object_ref
-debug_on
+test("0AEC (get_object_ref)", @tests)
+terminate_this_custom_script
 
-trace "0AEC (get_object_ref)"
+function tests
+    it("should return vehicle handle for pointer", @test1)
+    return true
 
+    function test1
+        request_model 333 // golf club
+        load_all_models_now
+        int handle = create_object 333 {xyz} 0.0 0.0 0.0
+        int ptr = get_object_pointer handle
+        int handle2 = get_object_ref ptr
+        mark_object_as_no_longer_needed handle
 
-wait 0
-request_model 333 // golf club
-load_all_models_now
-create_object 333 {xyz} 0.0 0.0 0.0 {result} 0@
-get_object_pointer 0@ {result} 1@
-
-0AEC: get_object_ref 1@ {result} 2@ // tested opcode
-
-mark_object_as_no_longer_needed 0@
-
-if
-    0@ == 2@
-then
-    trace "~g~~h~~h~0AEC (get_object_ref), #0 PASSED"
-else
-    breakpoint "~r~~h~~h~~h~0AEC (get_object_ref), #0 FAILED!~n~%08x Expected~n~%08x Occured" 0@ 2@
+        if
+            handle == handle2
+        then
+            assert(true)
+        else
+            assert(false)
+        end
+    end
 end
 
 
-terminate_this_custom_script

--- a/tests/cleo_tests/cleo_tester.txt
+++ b/tests/cleo_tests/cleo_tester.txt
@@ -151,6 +151,7 @@ end
 
 /// checks if value is not 0, otherwise stops the test execution
 function assert(flag: int)
+    _cleo_tester_increment_assert
     flag <> False
     jf @_cleo_tester_fail
 end

--- a/tests/cleo_tests/cleo_tester.txt
+++ b/tests/cleo_tests/cleo_tester.txt
@@ -20,7 +20,9 @@ function _cleo_tester_write_var(index: int, value: int)
     write_memory_with_offset {address} buf {offset} index {size} 4 {value} value
 end
 
-function test(suite_name: integer, tests: int)
+/// registers new test suite (collection of unit tests)
+/// use it(...) for individual unit tests
+function test(suite_name: integer, callback: int)
     debug_on
     
     int suite_name_buf = get_label_pointer @_cleo_tester_test_name
@@ -30,10 +32,12 @@ function test(suite_name: integer, tests: int)
     _cleo_tester_write_var(VAR_BEFORE_EACH, @_cleo_tester_stub)
     _cleo_tester_write_var(VAR_AFTER_EACH, @_cleo_tester_stub)
     _cleo_tester_write_var(VAR_TEST_INDEX, 1)
-    cleo_call tests
+    cleo_call callback
 end
 
-function it(spec_name: integer, callback: integer)
+/// registers new unit test in a test suite
+/// use assert_*(...) to validate result
+function it(spec_name: integer, callback: int)
     define function run_spec
     define function inject_offset(label: int, offset: int)
 
@@ -56,7 +60,6 @@ function it(spec_name: integer, callback: integer)
     
     return true
 
-    
     function run_spec
         // this function should use 0 local variables
     
@@ -111,46 +114,53 @@ function _cleo_tester_increment_assert
     _cleo_tester_write_var(VAR_ASSERT_INDEX, index)
 end
 
+/// checks if two int values are equal, otherwise stops the test execution
 function assert_eq(val1: int, val2: int)
     _cleo_tester_increment_assert
     val1 == val2
     jf @_cleo_tester_fail
 end
 
+/// checks if two int values are not equal, otherwise stops the test execution
 function assert_neq(val1: int, val2: int)
     _cleo_tester_increment_assert
     val1 <> val2
     jf @_cleo_tester_fail
 end
 
+/// checks if two float values are equal, otherwise stops the test execution
 function assert_eqf(val1:float, val2:float)
     _cleo_tester_increment_assert
     val1 == val2
     jf @_cleo_tester_fail
 end
 
+/// checks if two float values are not equal, otherwise stops the test execution
 function assert_neqf(val1:float, val2:float)
     _cleo_tester_increment_assert
     val1 <> val2
     jf @_cleo_tester_fail
 end
 
+/// checks if value is a valid pointer, otherwise stops the test execution
 function assert_ptr(ptr: int)
     _cleo_tester_increment_assert
     ptr > 0x10000  // possibly valid pointer
     jf @_cleo_tester_fail
 end
 
+/// checks if value is not 0, otherwise stops the test execution
 function assert(flag: int)
-    _cleo_tester_increment_assert
     flag <> False
     jf @_cleo_tester_fail
 end
 
+/// registers a callback that runs before each unit test (test setup)
 function before_each(callback: int)
     _cleo_tester_write_var(VAR_BEFORE_EACH, callback)
 end
 
+/// registers a callback that runs after each unit test (test teardown)
 function after_each(callback: int)
     _cleo_tester_write_var(VAR_AFTER_EACH, callback)
 end

--- a/tests/cleo_tests/cleo_tester.txt
+++ b/tests/cleo_tests/cleo_tester.txt
@@ -1,6 +1,8 @@
 
 const VAR_TEST_INDEX = 0
 const VAR_BEFORE_EACH = 1
+const VAR_AFTER_EACH = 2
+const VAR_SPEC = 3
 
 jump @_cleo_tester_skip_fns
 
@@ -23,11 +25,15 @@ function test(suite_name: integer, tests: int)
     int suite_name_buf = get_label_pointer @_cleo_tester_test_name
     copy_memory {src} suite_name {dest} suite_name_buf {size} 255 // used in an it trace
     trace "Running %s test" suite_name
+    
+    _cleo_tester_write_var(VAR_BEFORE_EACH, @_cleo_tester_stub)
+    _cleo_tester_write_var(VAR_AFTER_EACH, @_cleo_tester_stub)
     cleo_call tests
 end
 
 function it(spec_name: integer, callback: integer)
-    define function run_spec(callback: int)
+    define function run_spec
+    define function inject_offset(label: int, offset: int)
     
     int index = _cleo_tester_read_var(VAR_TEST_INDEX)
 
@@ -37,7 +43,8 @@ function it(spec_name: integer, callback: integer)
     trace "#%d %s -- it %s" index test_name spec_name
 
     wait 0
-    run_spec(callback)
+    _cleo_tester_write_var(VAR_SPEC, callback)
+    run_spec
 
     trace "~g~~h~~h~#%d %s PASSED" index spec_name
     index++
@@ -45,32 +52,39 @@ function it(spec_name: integer, callback: integer)
     
     return true
     
-    
-    function run_spec(test_fn: int)
-        // ensure all local variables are reset before calling actual spec function
 
-        int loc = get_label_pointer @_run_test_a
-        write_memory_with_offset {address} loc {offset} 3 {size} 4 {value} test_fn
-        loc = 0
-        test_fn = 0
-        int before_each_cb = _cleo_tester_read_var(VAR_BEFORE_EACH)
-        if before_each_cb <> 0
-        then
-            loc = get_label_pointer @_run_test_b
-            write_memory_with_offset {address} loc {offset} 3 {size} 4 {value} before_each_cb
-            loc = 0
-            before_each_cb = 0
-            :_run_test_b
-            gosub 0.0 // 0.0 is always 4 bytes
-        end
-        :_run_test_a
-        jump 0.0
+    
+    function run_spec
+        // this function should use 0 local variables
+    
+        inject_offset(@_cleo_tester_before_each, VAR_BEFORE_EACH)
+        inject_offset(@_cleo_tester_after_each, VAR_AFTER_EACH)
+        inject_offset(@_cleo_tester_run, VAR_SPEC)
+        
+        :_cleo_tester_before_each
+        gosub @_cleo_tester_stub
+
+        :_cleo_tester_run
+        cleo_call @_cleo_tester_stub {numParams} 32 {params} 0@ 1@ 2@ 3@ 4@ 5@ 6@ 7@ 8@ 9@ 10@ 11@ 12@ 13@ 14@ 15@ 16@ 17@ 18@ 19@ 20@ 21@ 22@ 23@ 24@ 25@ 26@ 27@ 28@ 29@ 30@ 31@
+        
+        :_cleo_tester_after_each
+        gosub @_cleo_tester_stub
+    end
+    
+    // self-patch script code with new gosub/call offset
+    function inject_offset(label: int, var_index: int)
+        int function_offset = _cleo_tester_read_var(var_index)
+        int location = get_label_pointer label
+        write_memory_with_offset {address} location {offset - opcode + datatype} 3 {size} 4 {value} function_offset
     end
 end
 
+:_cleo_tester_stub
+return
+
 :_cleo_tester_shared_vars
 hex
-    00(12)
+    00(16) // 4 variables
 end
 :_cleo_tester_test_name
 hex
@@ -81,28 +95,49 @@ hex
     00(256)
 end
 
-function assert_eq(val1:int, val2:int)
-    if val1 <> val2
-    then
-        int test_index = _cleo_tester_read_var(VAR_TEST_INDEX)
-        int test_name = get_label_pointer @_cleo_tester_spec_name
-        breakpoint "~r~~h~~h~~h~#%d %s FAILED! %d Expected, %d Actual" test_index test_name val1 val2
-        terminate_this_custom_script
-    end
+:_cleo_tester_fail
+int test_index = _cleo_tester_read_var(VAR_TEST_INDEX)
+int test_name = get_label_pointer @_cleo_tester_spec_name
+breakpoint "~r~~h~~h~~h~#%d %s FAILED! %d Expected, %d Actual" test_index test_name {val1} 0@ {val2} 1@
+terminate_this_custom_script
+
+
+function assert_eq(val1: int, val2: int)
+    val1 == val2
+    jf @_cleo_tester_fail
+end
+
+function assert_neq(val1: int, val2: int)
+    val1 <> val2
+    jf @_cleo_tester_fail
 end
 
 function assert_eqf(val1:float, val2:float)
-    if val1 <> val2
-    then
-        int test_index = _cleo_tester_read_var(VAR_TEST_INDEX)
-        int test_name = get_label_pointer @_cleo_tester_spec_name
-        breakpoint "~r~~h~~h~~h~#%d %s FAILED! %f Expected, %f Actual" test_index test_name val1 val2
-        terminate_this_custom_script
-    end
+    val1 == val2
+    jf @_cleo_tester_fail
+end
+
+function assert_neqf(val1:float, val2:float)
+    val1 <> val2
+    jf @_cleo_tester_fail
+end
+
+function assert_ptr(ptr: int)
+    ptr > 0x10000  // possibly valid pointer
+    jf @_cleo_tester_fail
+end
+
+function assert(flag: int)
+    flag <> False
+    jf @_cleo_tester_fail
 end
 
 function before_each(callback: int)
     _cleo_tester_write_var(VAR_BEFORE_EACH, callback)
+end
+
+function after_each(callback: int)
+    _cleo_tester_write_var(VAR_AFTER_EACH, callback)
 end
 
 

--- a/tests/cleo_tests/cleo_tester.txt
+++ b/tests/cleo_tests/cleo_tester.txt
@@ -1,0 +1,108 @@
+
+const VAR_TEST_INDEX = 0
+const VAR_BEFORE_EACH = 1
+
+jump @_cleo_tester_skip_fns
+
+function _cleo_tester_read_var(index: int): int
+    int buf = get_label_pointer @_cleo_tester_shared_vars
+    index *= 4
+    int value = read_memory_with_offset {address} buf {offset} index {size} 4
+    return true value
+end
+
+function _cleo_tester_write_var(index: int, value: int)
+    int buf = get_label_pointer @_cleo_tester_shared_vars
+    index *= 4
+    write_memory_with_offset {address} buf {offset} index {size} 4 {value} value
+end
+
+function test(suite_name: integer, tests: int)
+    debug_on
+    
+    int suite_name_buf = get_label_pointer @_cleo_tester_test_name
+    copy_memory {src} suite_name {dest} suite_name_buf {size} 255 // used in an it trace
+    trace "Running %s test" suite_name
+    cleo_call tests
+end
+
+function it(spec_name: integer, callback: integer)
+    define function run_spec(callback: int)
+    
+    int index = _cleo_tester_read_var(VAR_TEST_INDEX)
+
+    int spec_name_buf = get_label_pointer @_cleo_tester_spec_name
+    copy_memory {src} spec_name {dest} spec_name_buf {size} 255 // used in a failed assert
+    int test_name = get_label_pointer @_cleo_tester_test_name
+    trace "#%d %s -- it %s" index test_name spec_name
+
+    wait 0
+    run_spec(callback)
+
+    trace "~g~~h~~h~#%d %s PASSED" index spec_name
+    index++
+    _cleo_tester_write_var(VAR_TEST_INDEX, index)
+    
+    return true
+    
+    
+    function run_spec(test_fn: int)
+        // ensure all local variables are reset before calling actual spec function
+
+        int loc = get_label_pointer @_run_test_a
+        write_memory_with_offset {address} loc {offset} 3 {size} 4 {value} test_fn
+        loc = 0
+        test_fn = 0
+        int before_each_cb = _cleo_tester_read_var(VAR_BEFORE_EACH)
+        if before_each_cb <> 0
+        then
+            loc = get_label_pointer @_run_test_b
+            write_memory_with_offset {address} loc {offset} 3 {size} 4 {value} before_each_cb
+            before_each_cb = 0
+            :_run_test_b
+            gosub 0.0 // 0.0 is always 4 bytes
+        end
+        :_run_test_a
+        jump 0.0
+    end
+end
+
+:_cleo_tester_shared_vars
+hex
+    00(12)
+end
+:_cleo_tester_test_name
+hex
+    00(256)
+end
+:_cleo_tester_spec_name
+hex
+    00(256)
+end
+
+function assert_eq(val1:int, val2:int)
+    if val1 <> val2
+    then
+        int test_index = _cleo_tester_read_var(VAR_TEST_INDEX)
+        int test_name = get_label_pointer @_cleo_tester_spec_name
+        breakpoint "~r~~h~~h~~h~#%d %s FAILED! %d Expected, %d Actual" test_index test_name val1 val2
+        terminate_this_custom_script
+    end
+end
+
+function assert_eqf(val1:float, val2:float)
+    if val1 <> val2
+    then
+        int test_index = _cleo_tester_read_var(VAR_TEST_INDEX)
+        int test_name = get_label_pointer @_cleo_tester_spec_name
+        breakpoint "~r~~h~~h~~h~#%d %s FAILED! %f Expected, %f Actual" test_index test_name val1 val2
+        terminate_this_custom_script
+    end
+end
+
+function before_each(callback: int)
+    _cleo_tester_write_var(VAR_BEFORE_EACH, callback)
+end
+
+
+:_cleo_tester_skip_fns

--- a/tests/cleo_tests/cleo_tester.txt
+++ b/tests/cleo_tests/cleo_tester.txt
@@ -3,6 +3,7 @@ const VAR_TEST_INDEX = 0
 const VAR_BEFORE_EACH = 1
 const VAR_AFTER_EACH = 2
 const VAR_SPEC = 3
+const VAR_ASSERT_INDEX = 4
 
 jump @_cleo_tester_skip_fns
 
@@ -24,34 +25,36 @@ function test(suite_name: integer, tests: int)
     
     int suite_name_buf = get_label_pointer @_cleo_tester_test_name
     copy_memory {src} suite_name {dest} suite_name_buf {size} 255 // used in an it trace
-    trace "Running %s test" suite_name
+    trace "Testing %s" suite_name
     
     _cleo_tester_write_var(VAR_BEFORE_EACH, @_cleo_tester_stub)
     _cleo_tester_write_var(VAR_AFTER_EACH, @_cleo_tester_stub)
+    _cleo_tester_write_var(VAR_TEST_INDEX, 1)
     cleo_call tests
 end
 
 function it(spec_name: integer, callback: integer)
     define function run_spec
     define function inject_offset(label: int, offset: int)
-    
+
     int index = _cleo_tester_read_var(VAR_TEST_INDEX)
 
     int spec_name_buf = get_label_pointer @_cleo_tester_spec_name
     copy_memory {src} spec_name {dest} spec_name_buf {size} 255 // used in a failed assert
     int test_name = get_label_pointer @_cleo_tester_test_name
-    trace "#%d %s -- it %s" index test_name spec_name
+    trace "Test #%d %s" index spec_name
 
     wait 0
     _cleo_tester_write_var(VAR_SPEC, callback)
+    _cleo_tester_write_var(VAR_ASSERT_INDEX, 0)
+    
     run_spec
 
-    trace "~g~~h~~h~#%d %s PASSED" index spec_name
+    trace "~g~~h~~h~Test #%d PASSED" index
     index++
     _cleo_tester_write_var(VAR_TEST_INDEX, index)
     
     return true
-    
 
     
     function run_spec
@@ -84,7 +87,7 @@ return
 
 :_cleo_tester_shared_vars
 hex
-    00(16) // 4 variables
+    00(20) // 5 variables
 end
 :_cleo_tester_test_name
 hex
@@ -98,36 +101,48 @@ end
 :_cleo_tester_fail
 int test_index = _cleo_tester_read_var(VAR_TEST_INDEX)
 int test_name = get_label_pointer @_cleo_tester_spec_name
-breakpoint "~r~~h~~h~~h~#%d %s FAILED! %d Expected, %d Actual" test_index test_name {val1} 0@ {val2} 1@
+int assert_index = _cleo_tester_read_var(VAR_ASSERT_INDEX)
+breakpoint "~r~~h~~h~~h~Test #%d Assert #%d FAILED! %d Expected, %d Actual" test_index assert_index {val1} 0@ {val2} 1@
 terminate_this_custom_script
 
+function _cleo_tester_increment_assert
+    int index = _cleo_tester_read_var(VAR_ASSERT_INDEX)
+    index++
+    _cleo_tester_write_var(VAR_ASSERT_INDEX, index)
+end
 
 function assert_eq(val1: int, val2: int)
+    _cleo_tester_increment_assert
     val1 == val2
     jf @_cleo_tester_fail
 end
 
 function assert_neq(val1: int, val2: int)
+    _cleo_tester_increment_assert
     val1 <> val2
     jf @_cleo_tester_fail
 end
 
 function assert_eqf(val1:float, val2:float)
+    _cleo_tester_increment_assert
     val1 == val2
     jf @_cleo_tester_fail
 end
 
 function assert_neqf(val1:float, val2:float)
+    _cleo_tester_increment_assert
     val1 <> val2
     jf @_cleo_tester_fail
 end
 
 function assert_ptr(ptr: int)
+    _cleo_tester_increment_assert
     ptr > 0x10000  // possibly valid pointer
     jf @_cleo_tester_fail
 end
 
 function assert(flag: int)
+    _cleo_tester_increment_assert
     flag <> False
     jf @_cleo_tester_fail
 end

--- a/tests/cleo_tests/cleo_tester.txt
+++ b/tests/cleo_tests/cleo_tester.txt
@@ -58,6 +58,7 @@ function it(spec_name: integer, callback: integer)
         then
             loc = get_label_pointer @_run_test_b
             write_memory_with_offset {address} loc {offset} 3 {size} 4 {value} before_each_cb
+            loc = 0
             before_each_cb = 0
             :_run_test_b
             gosub 0.0 // 0.0 is always 4 bytes


### PR DESCRIPTION
Goals: 
* Focus on important things when writing unit tests. 
* Standardize test structure. 

Public API:

- `test(name: string, callback: int)`  -- creates new test suite (collection of unit tests)
- `it(expectation: string, callback: int)` -- creates new individual test focusing on testing one thing
- `before_each(callback: int)` -- registers a callback that runs before each unit test (test setup)
- `after_each(callback: int)` -- registers a callback that runs after each unit test (test teardown)
- `assert_eq(val1: int, val2: int)` - checks if two int values are equal, otherwise stops the test execution
- `assert_eqf(val1: int, val2: int)` - same as above, but for floats
- `assert_neq(val1: int, val2: int)` - checks if two int values are not equal, otherwise stops the test execution
- `assert_neqf(val1: int, val2: int)` - same as above, but for floats
- `assert(val: int)` - checks if value is not 0, otherwise stops the test execution
- `assert_ptr(val: int)` - checks if value is a valid pointer, otherwise stops the test execution

Simple example:

```
{$CLEO}
test('test suite', @tests)
terminate_this_custom_script

function tests
  it('should be true', @test1)
  it('should be false', @test2)
  return true

  function test1
   assert_eq(true, true)
  end
  function test2
   assert_eq(false, false)
  end
end
```
