### PR TITLE
Enabled CLEO_GetScriptFilename to return info from inactive threads.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
   - new opcode **2405 ([is_script_running](https://library.sannybuilder.com/#/sa/memory/2405))**
   - new opcode **2406 ([get_script_struct_from_filename](https://library.sannybuilder.com/#/sa/memory/2406))**
   - new opcode **2407 ([is_memory_equal](https://library.sannybuilder.com/#/sa/memory/2407))**
+  - new opcode **2408 ([terminate_script](https://library.sannybuilder.com/#/sa/memory/2408))**
 - new [Text](https://github.com/cleolibrary/CLEO5/tree/master/cleo_plugins/Text) plugin
   - text related opcodes moved from CLEO core into separated plugin
   - new opcode **2600 ([is_text_empty](https://library.sannybuilder.com/#/sa/text/2600))**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,8 @@
   - CLEO_ReadStringParamWriteBuffer
   - CLEO_GetOpcodeParamsArray
   - CLEO_GetParamsHandledCount
+  - CLEO_IsScriptRunning
+  - CLEO_TerminateScript
   - CLEO_GetScriptVersion
   - CLEO_GetScriptInfoStr
   - CLEO_GetScriptFilename

--- a/cleo_plugins/MemoryOperations/MemoryOperations.cpp
+++ b/cleo_plugins/MemoryOperations/MemoryOperations.cpp
@@ -800,9 +800,9 @@ public:
     {
         auto address = (CLEO::CScriptThread*)OPCODE_READ_PARAM_INT();
 
-        auto name = CLEO_GetScriptFilename(address);
+        auto running = CLEO_IsScriptRunning(address);
 
-        OPCODE_CONDITION_RESULT(name != nullptr);
+        OPCODE_CONDITION_RESULT(running);
         return OR_CONTINUE;
     }
 

--- a/cleo_plugins/MemoryOperations/MemoryOperations.cpp
+++ b/cleo_plugins/MemoryOperations/MemoryOperations.cpp
@@ -44,6 +44,8 @@ public:
 
         CLEO_RegisterOpcode(0x0AAA, opcode_0AAA); // get_script_struct_named
 
+        CLEO_RegisterOpcode(0x0ABA, opcode_0ABA); // terminate_all_custom_scripts_with_this_name
+
         CLEO_RegisterOpcode(0x0AC6, opcode_0AC6); // get_label_pointer
         CLEO_RegisterOpcode(0x0AC7, opcode_0AC7); // get_var_pointer
         CLEO_RegisterOpcode(0x0AC8, opcode_0AC8); // allocate_memory
@@ -62,6 +64,7 @@ public:
         CLEO_RegisterOpcode(0x2405, opcode_2405); // is_script_running
         CLEO_RegisterOpcode(0x2406, opcode_2406); // get_script_struct_from_filename
         CLEO_RegisterOpcode(0x2407, opcode_2407); // is_memory_equal
+        CLEO_RegisterOpcode(0x2408, opcode_2408); // terminate_script
         
 
         // register event callbacks
@@ -498,6 +501,27 @@ public:
         return OR_CONTINUE;
     }
 
+    //0ABA=1,terminate_all_custom_scripts_with_this_name %1d%
+    static OpcodeResult __stdcall opcode_0ABA(CLEO::CRunningScript* thread)
+    {
+        OPCODE_READ_PARAM_STRING(threadName);
+
+        bool terminateCurrent = false;
+        while (true)
+        {
+            auto found = CLEO_GetScriptByName(threadName, false, true, 0);
+            if (found == nullptr)
+                break;
+
+            if (found == thread)
+                terminateCurrent = true;
+
+            CLEO_TerminateScript(found);
+        }
+
+        return terminateCurrent ? OR_INTERRUPT : OR_CONTINUE;
+    }
+
     //0AC6=2,get_label_pointer %1d% store_to %2d%
     static OpcodeResult __stdcall opcode_0AC6(CLEO::CRunningScript* thread)
     {
@@ -798,7 +822,7 @@ public:
     //2405=1,  is_script_running %1d%
     static OpcodeResult __stdcall opcode_2405(CLEO::CScriptThread* thread)
     {
-        auto address = (CLEO::CScriptThread*)OPCODE_READ_PARAM_INT();
+        auto address = (CLEO::CScriptThread*)OPCODE_READ_PARAM_INT(); // allow invalid pointers too
 
         auto running = CLEO_IsScriptRunning(address);
 
@@ -840,6 +864,16 @@ public:
 
         OPCODE_CONDITION_RESULT(result == 0);
         return OR_CONTINUE;
+    }
+
+    //2408=1,terminate_script %1d%
+    static OpcodeResult __stdcall opcode_2408(CLEO::CScriptThread* thread)
+    {
+        auto address = (CLEO::CScriptThread*)OPCODE_READ_PARAM_PTR();
+
+        CLEO_TerminateScript(address);
+
+        return (address == thread) ? OR_INTERRUPT : OR_CONTINUE;
     }
 } Memory;
 

--- a/cleo_sdk/CLEO.h
+++ b/cleo_sdk/CLEO.h
@@ -467,6 +467,7 @@ void WINAPI CLEO_RegisterCallback(eCallbackId id, void* func);
 
 
 // script utils
+BOOL WINAPI CLEO_IsScriptRunning(const CRunningScript* thread); // check if script is active
 void WINAPI CLEO_GetScriptInfoStr(CRunningScript* thread, bool currLineInfo, char* buf, DWORD bufSize); // short text for displaying in error\log messages
 void WINAPI CLEO_GetScriptParamInfoStr(int idexOffset, char* buf, DWORD bufSize); // short text with current+offset opcode parameter info (index and name if available)
 eCLEO_Version WINAPI CLEO_GetScriptVersion(const CRunningScript* thread); // compatibility mode

--- a/cleo_sdk/CLEO.h
+++ b/cleo_sdk/CLEO.h
@@ -478,6 +478,7 @@ void WINAPI CLEO_SetScriptWorkDir(CRunningScript* thread, const char* path);
 
 void WINAPI CLEO_SetThreadCondResult(CRunningScript* thread, BOOL result);
 void WINAPI CLEO_ThreadJumpAtLabelPtr(CRunningScript* thread, int labelPtr);
+void WINAPI CLEO_TerminateScript(CRunningScript* thread);
 
 int WINAPI CLEO_GetOperandType(const CRunningScript* thread); // peek parameter data type. Returns int for legacy reason, should be eDataType.
 DWORD WINAPI CLEO_GetVarArgCount(CRunningScript* thread); // peek remaining var-args count

--- a/source/CCustomOpcodeSystem.cpp
+++ b/source/CCustomOpcodeSystem.cpp
@@ -1935,6 +1935,11 @@ extern "C"
 		reinterpret_cast<CCustomScript*>(thread)->SetDebugMode(enabled);
 	}
 
+	BOOL WINAPI CLEO_IsScriptRunning(const CLEO::CRunningScript* thread)
+	{
+		return GetInstance().ScriptEngine.IsActiveScriptPtr(thread);
+	}
+
 	void WINAPI CLEO_GetScriptInfoStr(CLEO::CRunningScript* thread, bool currLineInfo, char* buf, DWORD bufSize)
 	{
 		if (thread == nullptr || buf == nullptr || bufSize < 2)

--- a/source/CCustomOpcodeSystem.cpp
+++ b/source/CCustomOpcodeSystem.cpp
@@ -42,7 +42,7 @@ namespace CLEO
 	OpcodeResult __stdcall opcode_0AB6(CRunningScript* thread); // get_target_blip_coords
 	OpcodeResult __stdcall opcode_0AB7(CRunningScript* thread); // get_car_number_of_gears
 	OpcodeResult __stdcall opcode_0AB8(CRunningScript* thread); // get_car_current_gear
-	OpcodeResult __stdcall opcode_0ABA(CRunningScript* thread); // terminate_all_custom_scripts_with_this_name
+
 	OpcodeResult __stdcall opcode_0ABD(CRunningScript* thread); // is_car_siren_on
 	OpcodeResult __stdcall opcode_0ABE(CRunningScript* thread); // is_car_engine_on
 	OpcodeResult __stdcall opcode_0ABF(CRunningScript* thread); // cleo_set_car_engine_on
@@ -281,7 +281,6 @@ namespace CLEO
 		CLEO_RegisterOpcode(0x0AB6, opcode_0AB6);
 		CLEO_RegisterOpcode(0x0AB7, opcode_0AB7);
 		CLEO_RegisterOpcode(0x0AB8, opcode_0AB8);
-		CLEO_RegisterOpcode(0x0ABA, opcode_0ABA);
 		CLEO_RegisterOpcode(0x0ABD, opcode_0ABD);
 		CLEO_RegisterOpcode(0x0ABE, opcode_0ABE);
 		CLEO_RegisterOpcode(0x0ABF, opcode_0ABF);
@@ -1283,19 +1282,6 @@ namespace CLEO
 		return OR_CONTINUE;
 	}
 
-	//0ABA=1,end_custom_thread_named %1d%
-	OpcodeResult __stdcall opcode_0ABA(CRunningScript *thread)
-	{
-		OPCODE_READ_PARAM_STRING(threadName);
-
-		auto deleted_thread = (CCustomScript*)GetInstance().ScriptEngine.FindScriptNamed(threadName, false, true, 0);
-		if (deleted_thread)
-		{
-			GetInstance().ScriptEngine.RemoveCustomScript(deleted_thread);
-		}
-		return deleted_thread == thread ? OR_INTERRUPT : OR_CONTINUE;
-	}
-
 	//0ABD=1,  vehicle %1d% siren_on
 	OpcodeResult __stdcall opcode_0ABD(CRunningScript *thread)
 	{
@@ -1832,6 +1818,11 @@ extern "C"
 	void WINAPI CLEO_ThreadJumpAtLabelPtr(CLEO::CRunningScript* thread, int labelPtr)
 	{
 		ThreadJump(thread, labelPtr);
+	}
+
+	void WINAPI CLEO_TerminateScript(CLEO::CRunningScript* thread)
+	{
+		GetInstance().ScriptEngine.RemoveScript(thread);
 	}
 
 	int WINAPI CLEO_GetOperandType(const CLEO::CRunningScript* thread)

--- a/source/CScriptEngine.cpp
+++ b/source/CScriptEngine.cpp
@@ -1287,6 +1287,23 @@ namespace CLEO
         return nullptr;
     }
 
+    bool CScriptEngine::IsActiveScriptPtr(const CRunningScript* ptr) const
+    {
+        for (auto script = *activeThreadQueue; script != nullptr; script = script->GetNext())
+        {
+            if (script == ptr)
+                return ptr->IsActive();
+        }
+
+        for (const auto script : CustomScripts)
+        {
+            if (script == ptr)
+                return ptr->IsActive();
+        }
+
+        return false;
+    }
+
     bool CScriptEngine::IsValidScriptPtr(const CRunningScript* ptr) const
     {
         for (auto script = *activeThreadQueue; script != nullptr; script = script->GetNext())
@@ -1295,7 +1312,19 @@ namespace CLEO
                 return true;
         }
 
+        for (auto script = *inactiveThreadQueue; script != nullptr; script = script->GetNext())
+        {
+            if (script == ptr)
+                return true;
+        }
+
         for (const auto script : CustomScripts)
+        {
+            if (script == ptr)
+                return true;
+        }
+
+        for (const auto script : ScriptsWaitingForDelete)
         {
             if (script == ptr)
                 return true;

--- a/source/CScriptEngine.h
+++ b/source/CScriptEngine.h
@@ -132,7 +132,8 @@ namespace CLEO
 
         CRunningScript* FindScriptNamed(const char* threadName, bool standardScripts, bool customScripts, size_t resultIndex = 0); // can be called multiple times to find more scripts named threadName. resultIndex should be incremented until the method returns nullptr
         CRunningScript* FindScriptByFilename(const char* path, size_t resultIndex = 0); // if path is not absolute it will be resolved with cleo directory as root
-        bool IsValidScriptPtr(const CRunningScript*) const; // leads to active script? (regular or custom)
+        bool IsActiveScriptPtr(const CRunningScript*) const; // leads to active script? (regular or custom)
+        bool IsValidScriptPtr(const CRunningScript*) const; // leads to any script? (regular or custom)
         void AddCustomScript(CCustomScript*);
         void RemoveCustomScript(CCustomScript*);
         void RemoveAllCustomScripts();

--- a/source/CScriptEngine.h
+++ b/source/CScriptEngine.h
@@ -135,6 +135,7 @@ namespace CLEO
         bool IsActiveScriptPtr(const CRunningScript*) const; // leads to active script? (regular or custom)
         bool IsValidScriptPtr(const CRunningScript*) const; // leads to any script? (regular or custom)
         void AddCustomScript(CCustomScript*);
+        void RemoveScript(CRunningScript*); // native or custom
         void RemoveCustomScript(CCustomScript*);
         void RemoveAllCustomScripts();
         void UnregisterAllScripts();

--- a/source/cleo.def
+++ b/source/cleo.def
@@ -53,3 +53,4 @@ EXPORTS
 	_CLEO_SetScriptWorkDir@8				@50
 	_CLEO_RegisterCommand@8					@51
 	_CLEO_IsScriptRunning@4					@52
+	_CLEO_TerminateScript@4					@53

--- a/source/cleo.def
+++ b/source/cleo.def
@@ -52,3 +52,4 @@ EXPORTS
 	_CLEO_GetScriptWorkDir@4				@49
 	_CLEO_SetScriptWorkDir@8				@50
 	_CLEO_RegisterCommand@8					@51
+	_CLEO_IsScriptRunning@4					@52


### PR DESCRIPTION
Enabled CLEO_GetScriptFilename to work with inactive scripts
0ABA moved to memory plugin
0ABA fixed to stop all threads with given name
Added `terminate_script ptr` opcode
Added SDK exports:
* CLEO_IsScriptRunning
* CLEO_TerminateScript