### PR TITLE
Enabled support of network sources in audio stream opcodes.

### DIFF
--- a/cleo_plugins/Audio/Audio.cpp
+++ b/cleo_plugins/Audio/Audio.cpp
@@ -105,7 +105,12 @@ public:
     //0AAC=2,  %2d% = load_audiostream %1d%  // IF and SET
     static OpcodeResult __stdcall opcode_0AAC(CScriptThread* thread)
     {
-        OPCODE_READ_PARAM_FILEPATH(path);
+        OPCODE_READ_PARAM_STRING_LEN(path, 511);
+
+        if (_strnicmp("http:", path, 5) != 0 && _strnicmp("https:", path, 6) != 0)
+        {
+            CLEO_ResolvePath(thread, _buff_path, sizeof(_buff_path)); // regular file
+        }
 
         auto ptr = soundSystem.CreateStream(path);
 
@@ -207,7 +212,12 @@ public:
     //0AC1=2,%2d% = load_audiostream_with_3d_support %1d% //IF and SET
     static OpcodeResult __stdcall opcode_0AC1(CScriptThread* thread)
     {
-        OPCODE_READ_PARAM_FILEPATH(path);
+        OPCODE_READ_PARAM_STRING_LEN(path, 511);
+
+        if (_strnicmp("http:", path, 5) != 0 && _strnicmp("https:", path, 6) != 0)
+        {
+            CLEO_ResolvePath(thread, _buff_path, sizeof(_buff_path)); // regular file
+        }
 
         auto ptr = soundSystem.CreateStream(path, true);
 

--- a/cleo_plugins/Audio/Audio.cpp
+++ b/cleo_plugins/Audio/Audio.cpp
@@ -107,10 +107,8 @@ public:
     {
         OPCODE_READ_PARAM_STRING_LEN(path, 511);
 
-        if (_strnicmp("http:", path, 5) != 0 && _strnicmp("https:", path, 6) != 0)
-        {
-            CLEO_ResolvePath(thread, _buff_path, sizeof(_buff_path)); // regular file
-        }
+        if (!isNetworkSource(path))
+            CLEO_ResolvePath(thread, _buff_path, sizeof(_buff_path));
 
         auto ptr = soundSystem.CreateStream(path);
 
@@ -214,10 +212,8 @@ public:
     {
         OPCODE_READ_PARAM_STRING_LEN(path, 511);
 
-        if (_strnicmp("http:", path, 5) != 0 && _strnicmp("https:", path, 6) != 0)
-        {
-            CLEO_ResolvePath(thread, _buff_path, sizeof(_buff_path)); // regular file
-        }
+        if (!isNetworkSource(path))
+            CLEO_ResolvePath(thread, _buff_path, sizeof(_buff_path));
 
         auto ptr = soundSystem.CreateStream(path, true);
 
@@ -424,4 +420,3 @@ public:
 } audioInstance;
 
 CSoundSystem Audio::soundSystem;
-

--- a/cleo_plugins/Audio/C3DAudioStream.cpp
+++ b/cleo_plugins/Audio/C3DAudioStream.cpp
@@ -6,13 +6,19 @@ using namespace CLEO;
 
 C3DAudioStream::C3DAudioStream(const char* filepath) : CAudioStream()
 {
+    if (isNetworkSource(filepath) && !CSoundSystem::allowNetworkSources)
+    {
+        TRACE("Loading of 3d-audiostream '%s' failed. Support of network sources was disabled in SA.Audio.ini", filepath);
+        return;
+    }
+
     unsigned flags = BASS_SAMPLE_3D | BASS_SAMPLE_MONO | BASS_SAMPLE_SOFTWARE;
     if (CSoundSystem::useFloatAudio) flags |= BASS_SAMPLE_FLOAT;
 
     if (!(streamInternal = BASS_StreamCreateFile(FALSE, filepath, 0, 0, flags)) &&
         !(streamInternal = BASS_StreamCreateURL(filepath, 0, flags, nullptr, nullptr)))
     {
-        LOG_WARNING(0, "Loading 3d-audiostream %s failed. Error code: %d", filepath, BASS_ErrorGetCode());
+        LOG_WARNING(0, "Loading of 3d-audiostream '%s' failed. Error code: %d", filepath, BASS_ErrorGetCode());
         return;
     }
 

--- a/cleo_plugins/Audio/CAudioStream.cpp
+++ b/cleo_plugins/Audio/CAudioStream.cpp
@@ -6,13 +6,19 @@ using namespace CLEO;
 
 CAudioStream::CAudioStream(const char* filepath)
 {
+    if (isNetworkSource(filepath) && !CSoundSystem::allowNetworkSources)
+    {
+        TRACE("Loading of audiostream '%s' failed. Support of network sources was disabled in SA.Audio.ini", filepath);
+        return;
+    }
+
     unsigned flags = BASS_SAMPLE_SOFTWARE;
     if (CSoundSystem::useFloatAudio) flags |= BASS_SAMPLE_FLOAT;
 
     if (!(streamInternal = BASS_StreamCreateFile(FALSE, filepath, 0, 0, flags)) &&
         !(streamInternal = BASS_StreamCreateURL(filepath, 0, flags, 0, nullptr)))
     {
-        LOG_WARNING(0, "Loading audiostream %s failed. Error code: %d", filepath, BASS_ErrorGetCode());
+        LOG_WARNING(0, "Loading of audiostream '%s' failed. Error code: %d", filepath, BASS_ErrorGetCode());
         return;
     }
 

--- a/cleo_plugins/Audio/CSoundSystem.cpp
+++ b/cleo_plugins/Audio/CSoundSystem.cpp
@@ -8,6 +8,7 @@
 namespace CLEO
 {
     bool CSoundSystem::useFloatAudio = false;
+    bool CSoundSystem::allowNetworkSources = true;
     BASS_3DVECTOR CSoundSystem::pos(0.0, 0.0, 0.0);
     BASS_3DVECTOR CSoundSystem::vel(0.0, 0.0, 0.0);
     BASS_3DVECTOR CSoundSystem::front(0.0, -1.0, 0.0);
@@ -27,6 +28,12 @@ namespace CLEO
             TRACE("Found sound device %d%s: %s", total, default_device == total ?
                 " (default)" : "", info.name);
         }
+    }
+
+    bool isNetworkSource(const char* path)
+    {
+        return _strnicmp("http:", path, 5) == 0 ||
+            _strnicmp("https:", path, 6) == 0;
     }
 
     CSoundSystem::~CSoundSystem()
@@ -49,6 +56,7 @@ namespace CLEO
 
         auto config = GetConfigFilename();
         defaultStreamType = (eStreamType)GetPrivateProfileInt("General", "DefaultStreamType", 0, config.c_str());
+        allowNetworkSources = GetPrivateProfileInt("General", "AllowNetworkSources", 1, config.c_str()) != 0;
 
         int default_device, total_devices, enabled_devices;
         EnumerateBassDevices(total_devices, enabled_devices, default_device);

--- a/cleo_plugins/Audio/CSoundSystem.h
+++ b/cleo_plugins/Audio/CSoundSystem.h
@@ -25,6 +25,7 @@ namespace CLEO
         bool paused = false;
 
         static bool useFloatAudio;
+        static bool CSoundSystem::allowNetworkSources;
 
         static BASS_3DVECTOR pos;
         static BASS_3DVECTOR vel;
@@ -52,4 +53,6 @@ namespace CLEO
         void Resume();
         void Process();
     };
+
+    bool isNetworkSource(const char* path);
 }

--- a/cleo_plugins/Audio/SA.Audio.ini
+++ b/cleo_plugins/Audio/SA.Audio.ini
@@ -2,6 +2,9 @@
 ; Manually select audio device. Visit `.cleo.log` file to check list of available options. -1 for automatic
 AudioDevice=-1
 
+; Allow playing streams from http(s) locations
+AllowNetworkSources=1
+
 ; Which game's volume settings CLEO sounds should use by default: 0 - None, 1 - SFX, 2 - Music
 DefaultStreamType=1
 


### PR DESCRIPTION
Test script
```cpp
{$CLEO .cs}

wait 1000
AudioStream aStream = load_audio_stream {audioFileName} "http://uifserver.net/play/intro.mp3"
AudioStream.SetState(aStream, AudioStreamAction.Play)

terminate_this_custom_script
```