### PR TITLE
Cleo scripts listing with modloader

### DIFF
--- a/source/CScriptEngine.cpp
+++ b/source/CScriptEngine.cpp
@@ -1013,8 +1013,18 @@ namespace CLEO
             }
         };
 
-        auto searchPattern = Filepath_Cleo + "\\*.*";
+        auto searchPattern = Filepath_Cleo + "\\*" + cs_ext;
         auto list = CLEO_ListDirectory(nullptr, searchPattern.c_str(), false, true);
+        processFileList(list);
+        CLEO_StringListFree(list);
+
+        searchPattern = Filepath_Cleo + "\\*" + cs3_ext;
+        list = CLEO_ListDirectory(nullptr, searchPattern.c_str(), false, true);
+        processFileList(list);
+        CLEO_StringListFree(list);
+
+        searchPattern = Filepath_Cleo + "\\*" + cs4_ext;
+        list = CLEO_ListDirectory(nullptr, searchPattern.c_str(), false, true);
         processFileList(list);
         CLEO_StringListFree(list);
 


### PR DESCRIPTION
Temporary fix to keep ModLoader feeding CLEO scripts.
![image](https://github.com/cleolibrary/CLEO5/assets/11084446/9ae3b879-1022-4222-814f-15763a496dc2)
