### PR TITLE
Added get_text_length opcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
   - new opcode **2605 ([display_text_formatted](https://library.sannybuilder.com/#/sa/text/2605))**
   - new opcode **2606 ([load_fxt](https://library.sannybuilder.com/#/sa/text/2606))**
   - new opcode **2607 ([unload_fxt](https://library.sannybuilder.com/#/sa/text/2607))**
+  - new opcode **2608 ([get_text_length](https://library.sannybuilder.com/#/sa/text/2608))**
 - new and updated opcodes
   - implemented support for **memory pointer string** arguments for all game's native opcodes
   - **0B1E ([sign_extend](https://library.sannybuilder.com/#/sa/bitwise/0B1E))**

--- a/cleo_plugins/Text/Text.cpp
+++ b/cleo_plugins/Text/Text.cpp
@@ -61,6 +61,7 @@ public:
 		CLEO_RegisterOpcode(0x2605, opcode_2605); // display_text_formatted
 		CLEO_RegisterOpcode(0x2606, opcode_2606); // load_fxt
 		CLEO_RegisterOpcode(0x2607, opcode_2607); // unload_fxt
+		CLEO_RegisterOpcode(0x2608, opcode_2608); // get_text_length
 
 		// register event callbacks
 		CLEO_RegisterCallback(eCallbackId::GameBegin, OnGameBegin);
@@ -482,6 +483,17 @@ public:
 		}
 
 		OPCODE_CONDITION_RESULT(removed != 0);
+		return OR_CONTINUE;
+	}
+
+	//2608=3,get_text_length %1d% store_to %2d%
+	static OpcodeResult __stdcall opcode_2608(CLEO::CRunningScript* thread)
+	{
+		OPCODE_READ_PARAM_STRING(str);
+
+		auto result = strlen(str);
+
+		OPCODE_WRITE_PARAM_INT(result);
 		return OR_CONTINUE;
 	}
 } textInstance;

--- a/tests/cleo_tests/Text/2608.txt
+++ b/tests/cleo_tests/Text/2608.txt
@@ -1,0 +1,33 @@
+{$CLEO .s}
+{$INCLUDE_ONCE ../cleo_tester.inc}
+
+script_name '2608'
+test("2608 (get_text_length)", tests)
+terminate_this_custom_script
+
+function tests
+    it("should return text length", test1)
+    return
+
+    function test1
+        int length
+        
+        shortstring short = 'One'
+        2608: get_text_length {text} short {length} length
+        assert_eq(length, 3)
+        
+        string_format short = ''
+        2608: get_text_length {text} short {length} length
+        assert_eq(length, 0)
+        
+        longstring long = "Longer string"
+        2608: get_text_length {text} long {length} length
+        assert_eq(length, 13)
+        
+        int buff = allocate_memory {size} 255
+        string_format buff = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc et tellus vehicula, tempus felis malesuada, commodo nunc. Interdum et malesuada fames ac ante ipsum primis in faucibus. Etiam condimentum porttitor lorem est."
+        2608: get_text_length {text} buff {length} length
+        free_memory {address} buff
+        assert_eq(length, 220)
+    end
+end


### PR DESCRIPTION
Such basic operation should be possible in base CLEO without need for installing third party addons.

GET_STRING_LENGTH from NewOpcodes crashes with texts longer that 100 characters.
Same opcode from CLEO+ is hard caped to 128 characters.

Meanwhile CLEO5 supports up to 255 and pointer to cstring can store even longer texts.

https://discord.com/channels/911487285990674473/1226215589740286012/1267509561405734994