### PR TITLE
Keep default volume for audio streams in legacy scripts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,6 +81,7 @@ jobs:
           mkdir .output\Release\cleo\cleo_saves
           mkdir .output\Release\cleo\cleo_text
           mkdir .output\Release\cleo_readme
+          mkdir .output\Release\cleo_readme\examples
 
           @REM copy files
           copy source\cleo_config.ini .output\Release\cleo\.cleo_config.ini
@@ -88,6 +89,7 @@ jobs:
           copy cleo_plugins\.output\*.ini .output\Release\cleo\cleo_plugins
           copy cleo_plugins\Audio\bass\bass.dll .output\Release\bass.dll
           xcopy /E /I tests .output\Release\cleo
+          xcopy /E /I examples .output\Release\cleo_readme\examples
 
           @REM copy SDK
           copy .output\Release\CLEO.lib cleo_sdk\CLEO.lib

--- a/cleo_plugins/Audio/Audio.cpp
+++ b/cleo_plugins/Audio/Audio.cpp
@@ -112,7 +112,7 @@ public:
 
         auto ptr = soundSystem.CreateStream(path);
 
-        if (IsLegacyScript(thread))
+        if (ptr != nullptr && IsLegacyScript(thread))
         {
             ptr->SetType(CLEO::CSoundSystem::LegacyModeDefaultStreamType);
         }
@@ -222,7 +222,7 @@ public:
 
         auto ptr = soundSystem.CreateStream(path, true);
 
-        if (IsLegacyScript(thread))
+        if (ptr != nullptr && IsLegacyScript(thread))
         {
             ptr->SetType(CLEO::CSoundSystem::LegacyModeDefaultStreamType);
         }

--- a/cleo_plugins/Audio/Audio.cpp
+++ b/cleo_plugins/Audio/Audio.cpp
@@ -112,6 +112,11 @@ public:
 
         auto ptr = soundSystem.CreateStream(path);
 
+        if (IsLegacyScript(thread))
+        {
+            ptr->SetType(CLEO::CSoundSystem::LegacyModeDefaultStreamType);
+        }
+
         OPCODE_WRITE_PARAM_PTR(ptr);
         OPCODE_CONDITION_RESULT(ptr != nullptr);
         return OR_CONTINUE;
@@ -216,6 +221,11 @@ public:
             CLEO_ResolvePath(thread, _buff_path, sizeof(_buff_path));
 
         auto ptr = soundSystem.CreateStream(path, true);
+
+        if (IsLegacyScript(thread))
+        {
+            ptr->SetType(CLEO::CSoundSystem::LegacyModeDefaultStreamType);
+        }
 
         OPCODE_WRITE_PARAM_PTR(ptr);
         OPCODE_CONDITION_RESULT(ptr != nullptr);

--- a/cleo_plugins/Audio/CAudioStream.cpp
+++ b/cleo_plugins/Audio/CAudioStream.cpp
@@ -22,7 +22,6 @@ CAudioStream::CAudioStream(const char* filepath)
         return;
     }
 
-    SetType(CSoundSystem::defaultStreamType);
     BASS_ChannelGetAttribute(streamInternal, BASS_ATTRIB_FREQ, &rate);
     ok = true;
 }

--- a/cleo_plugins/Audio/CAudioStream.h
+++ b/cleo_plugins/Audio/CAudioStream.h
@@ -55,7 +55,7 @@ namespace CLEO
     protected:
         HSTREAM streamInternal = 0;
         eStreamState state = Paused;
-        eStreamType type = None;
+        eStreamType type = eStreamType::SoundEffect;
         bool ok = false;
         float rate = 44100.0f; // file's sampling rate
         double speed = 1.0f;

--- a/cleo_plugins/Audio/CSoundSystem.cpp
+++ b/cleo_plugins/Audio/CSoundSystem.cpp
@@ -13,7 +13,7 @@ namespace CLEO
     BASS_3DVECTOR CSoundSystem::vel(0.0, 0.0, 0.0);
     BASS_3DVECTOR CSoundSystem::front(0.0, -1.0, 0.0);
     BASS_3DVECTOR CSoundSystem::top(0.0, 0.0, 1.0);
-    eStreamType CSoundSystem::defaultStreamType = eStreamType::SoundEffect;
+    eStreamType CSoundSystem::LegacyModeDefaultStreamType = eStreamType::None;
     float CSoundSystem::masterSpeed = 1.0f;
     float CSoundSystem::masterVolumeSfx = 1.0f;
     float CSoundSystem::masterVolumeMusic = 1.0f;
@@ -55,7 +55,7 @@ namespace CLEO
         if (initialized) return true; // already done
 
         auto config = GetConfigFilename();
-        defaultStreamType = (eStreamType)GetPrivateProfileInt("General", "DefaultStreamType", 0, config.c_str());
+        LegacyModeDefaultStreamType = (eStreamType)GetPrivateProfileInt("General", "LegacyModeDefaultStreamType", 0, config.c_str());
         allowNetworkSources = GetPrivateProfileInt("General", "AllowNetworkSources", 1, config.c_str()) != 0;
 
         int default_device, total_devices, enabled_devices;

--- a/cleo_plugins/Audio/CSoundSystem.h
+++ b/cleo_plugins/Audio/CSoundSystem.h
@@ -31,12 +31,13 @@ namespace CLEO
         static BASS_3DVECTOR vel;
         static BASS_3DVECTOR front;
         static BASS_3DVECTOR top;
-        static eStreamType defaultStreamType;
         static float masterSpeed; // game simulation speed
         static float masterVolumeSfx;
         static float masterVolumeMusic;
 
     public:
+        static eStreamType LegacyModeDefaultStreamType;
+
         CSoundSystem() = default; // TODO: give to user an ability to force a sound device to use (ini-file or cmd-line?)
         ~CSoundSystem();
 

--- a/cleo_plugins/Audio/SA.Audio.ini
+++ b/cleo_plugins/Audio/SA.Audio.ini
@@ -1,10 +1,10 @@
 [General]
-; Manually select audio device. Visit `.cleo.log` file to check list of available options. -1 for automatic
+; Manually select audio device. See `.cleo.log` file to check list of available options. -1 for automatic
 AudioDevice=-1
 
 ; Allow playing streams from http(s) locations
 AllowNetworkSources=1
 
-; Which game's volume settings CLEO sounds should use by default: 0 - None, 1 - SFX, 2 - Music
-DefaultStreamType=1
-
+; Sounds created from scripts in legacy mode (*.cs3 or *.cs4) should use by default game's volume settings: 0 - None, 1 - SFX, 2 - Music
+; Select 1 if you have older mods that play sounds too loud
+LegacyModeDefaultStreamType=0

--- a/examples/Audio_Demo.txt
+++ b/examples/Audio_Demo.txt
@@ -1,0 +1,310 @@
+// CLEO5 example script
+// Sanny Builder 4
+// mode: GTA SA(v1.0 - SBL)
+{$CLEO .cs}
+
+const Model_Speaker = 2229
+const Audio_Path = ".\cleo_tests\Audio\Ding.mp3" // this script's file relative location
+
+wait 1000
+
+int sound_stream, speaker_object
+float value, valueCurr
+
+
+while true
+    wait 0
+    print_formatted_now "CLEO5 Audio Plugin DEMO~n~Press key 1 - 7" {time} 0
+    
+    if
+        test_cheat "1"
+    then
+        print_formatted_now "DEMO 1: Get progress" {time} 10000
+        START_TEST()
+
+        if
+            not load_3d_audio_stream Audio_Path {store_to} sound_stream
+        then
+            print_formatted_now "~r~Failed to load audio file!" {time} 10000
+            END_TEST()
+            continue
+        end
+        set_play_3d_audio_stream_at_object sound_stream {object} speaker_object
+        set_audio_stream_state sound_stream AudioStreamAction.Play
+
+        while is_audio_stream_playing sound_stream
+            valueCurr = get_audio_stream_progress sound_stream
+            print_formatted_now "DEMO 1: Get progress: %.2f" {time} 0 {args} valueCurr
+            wait 0
+        end
+
+        END_TEST()
+    end
+    
+    if
+        test_cheat "2"
+    then
+        print_formatted_now "DEMO 2: Set volume" {time} 10000
+        START_TEST()
+
+        if
+            not load_3d_audio_stream Audio_Path {store_to} sound_stream
+        then
+            print_formatted_now "~r~Failed to load audio file!" {time} 10000
+            END_TEST()
+            continue
+        end
+        set_play_3d_audio_stream_at_object sound_stream {object} speaker_object
+        set_audio_stream_looped sound_stream true
+        set_audio_stream_state sound_stream AudioStreamAction.Play
+
+        TIMERA = 1000
+        repeat
+            if
+                TIMERA >= 1000
+            then
+                value = generate_random_float_in_range 0.0 2.0
+                set_audio_stream_volume sound_stream value
+                TIMERA = 0
+            end
+
+            print_formatted_now "DEMO 2: Set volume: %.2f~n~Press 2 to stop" {time} 0 {args} value
+            wait 0
+        until test_cheat "2"
+
+        END_TEST()
+    end
+    
+    if
+        test_cheat "3"
+    then
+        print_formatted_now "Set volume with transition" {time} 10000
+        START_TEST()
+
+        if
+            not load_3d_audio_stream Audio_Path {store_to} sound_stream
+        then
+            print_formatted_now "~r~Failed to load audio file!" {time} 10000
+            END_TEST()
+            continue
+        end
+        set_play_3d_audio_stream_at_object sound_stream {object} speaker_object
+        set_audio_stream_looped sound_stream true
+        set_audio_stream_state sound_stream AudioStreamAction.Play
+
+        TIMERA = 2000
+        repeat
+            if
+                TIMERA >= 2000
+            then
+                value = generate_random_float_in_range 0.0 2.0
+                set_audio_stream_volume_with_transition sound_stream {volume} value {timeMs} 1000
+                TIMERA = 0
+            end
+
+            valueCurr = get_audio_stream_volume sound_stream
+            print_formatted_now "DEMO 3: Set volume: %.2f, Transition: 1.0s~n~Current volume: %.2f~n~Press 3 to stop" {time} 0 {args} value valueCurr
+            wait 0
+        until test_cheat "3"
+        
+        END_TEST()
+    end
+    
+    if
+        test_cheat "4"
+    then
+        print_formatted_now "DEMO 4: Set speed" {time} 10000
+        START_TEST()
+
+        if
+            not load_3d_audio_stream Audio_Path {store_to} sound_stream
+        then
+            print_formatted_now "~r~Failed to load audio file!" {time} 10000
+            END_TEST()
+            continue
+        end
+        set_play_3d_audio_stream_at_object sound_stream {object} speaker_object
+        set_audio_stream_looped sound_stream true
+        set_audio_stream_state sound_stream AudioStreamAction.Play
+
+        TIMERA = 1000
+        repeat
+            if
+                TIMERA >= 1000
+            then
+                value = generate_random_float_in_range 0.0 2.0
+                set_audio_stream_speed sound_stream value
+                TIMERA = 0
+            end
+
+            print_formatted_now "DEMO 4: Set speed %.2f~n~Press 4 to stop" {time} 0 {args} value
+            wait 0
+        until test_cheat "4"
+
+        END_TEST()
+    end
+    
+    if
+        test_cheat "5"
+    then
+        print_formatted_now "DEMO 5: Set speed with transition" {time} 10000
+        START_TEST()
+
+        if
+            not load_3d_audio_stream Audio_Path {store_to} sound_stream
+        then
+            print_formatted_now "~r~Failed to load audio file!" {time} 10000
+            END_TEST()
+            continue
+        end
+        set_play_3d_audio_stream_at_object sound_stream {object} speaker_object
+        set_audio_stream_looped sound_stream true
+        set_audio_stream_state sound_stream AudioStreamAction.Play
+
+        TIMERA = 2000
+        repeat
+            if
+                TIMERA >= 2000
+            then
+                value = generate_random_float_in_range 0.0 2.0
+                set_audio_stream_speed_with_transition sound_stream {volume} value {timeMs} 1000
+                TIMERA = 0
+            end
+
+            valueCurr = get_audio_stream_speed sound_stream
+            print_formatted_now "DEMO 5: Set speed: %.2f, Transition: 1.0s~n~Current speed: %.2f~n~Press 5 to stop" {time} 0 {args} value valueCurr
+            wait 0
+        until test_cheat "5"
+
+        END_TEST()
+    end
+    
+    if
+        test_cheat "6"
+    then
+        print_formatted_now "DEMO 6: Doppler effect" {time} 10000
+        START_TEST()
+
+        if
+            not load_3d_audio_stream Audio_Path {store_to} sound_stream
+        then
+            print_formatted_now "~r~Failed to load audio file!" {time} 10000
+            END_TEST()
+            continue
+        end
+        set_play_3d_audio_stream_at_object sound_stream {object} speaker_object
+        set_audio_stream_looped sound_stream true
+        set_audio_stream_volume sound_stream {volume} 4.0
+        set_audio_stream_state sound_stream AudioStreamAction.Play
+        wait 1000
+
+        int direction = 0
+        repeat
+            if
+                not camera_is_vector_move_running
+            then
+                camera_set_vector_track {from} 230.0 2525.0 16.5 {to} 230.0 2525.0 16.5 {time} 1000 {ease} true
+
+                if
+                    direction == 0
+                then
+                    camera_set_vector_move {from} 260.0 2522.0 18.0 {to} 200.0 2522.0 18.0 {time} 1000 {ease} true
+                else
+                    camera_set_vector_move {from} 200.0 2522.0 18.0 {to} 260.0 2522.0 18.0 {time} 1000 {ease} true
+                end
+                direction = 1 - direction
+            end
+
+            wait 0
+            print_formatted_now "DEMO 6: Doppler effect~n~Press 6 to stop" {time} 0
+        until test_cheat "6"
+
+        END_TEST()
+    end
+    
+    if
+        test_cheat "7"
+    then
+        print_formatted_now "DEMO 7: Game speed changes" {time} 10000
+        START_TEST()
+
+        if
+            not load_3d_audio_stream Audio_Path {store_to} sound_stream
+        then
+            print_formatted_now "~r~Failed to load audio file!" {time} 10000
+            END_TEST()
+            continue
+        end
+        set_play_3d_audio_stream_at_object sound_stream {object} speaker_object
+        set_audio_stream_looped sound_stream true
+        set_audio_stream_state sound_stream AudioStreamAction.Play
+
+        // walk
+        set_player_control 0 {control} false
+        flush_route
+        extend_route {xyz} 229.0 2525.0 15.5
+        extend_route {xyz} 230.0 2524.0 15.5
+        extend_route {xyz} 231.0 2525.0 15.5
+        extend_route {xyz} 230.0 2526.0 15.5
+        task_follow_point_route $scplayer {walk_speed} 6 {flag} 3
+        task_look_at_object $scplayer {object} speaker_object {time} -1
+
+        TIMERA = 2000
+        repeat
+            if
+                TIMERA >= 2000
+            then
+                value = generate_random_float_in_range 0.2 3.0
+                set_time_scale value
+                TIMERA = 0
+            end
+
+            print_formatted_now "DEMO 7: Game speed: %.2f~n~Press 7 to stop" {time} 0 {args} value
+            wait 0
+        until test_cheat "7"
+
+        set_time_scale 1.0
+        clear_char_tasks_immediately $scplayer
+        set_player_control 0 {control} true
+        END_TEST()
+    end
+end
+
+terminate_this_custom_script
+
+
+:START_TEST
+    remove_all_char_weapons $scplayer
+    set_max_wanted_level 0
+
+    display_radar false
+    display_hud false
+
+    set_char_coordinates $scplayer {xyz} 230.0 2527.0 15.5
+    set_char_heading $scplayer {heading} 180.0
+    set_area_visible 0
+    set_char_area_visible $scplayer {interiorId} 0
+    task_scratch_head $scplayer
+
+    set_fixed_camera_position {xyz} 230.0 2522.0 18.0 {ypr} 0.0 0.0 0.0
+    point_camera_at_char $scplayer {mode} CameraMode.Fixed {switchStyle} SwitchType.JumpCut
+    wait 1000
+    
+    // create speaker object (visual only)
+    request_model {modelId} Model_Speaker
+    load_all_models_now
+    speaker_object = create_object {modelId} Model_Speaker {xyz} 230.25 2525.0 16.0
+    mark_model_as_no_longer_needed {modelId} Model_Speaker
+    set_object_collision speaker_object {state} false
+    point_camera_at_point {xyz} 230.0 2525.0 16.5 {switchStyle} SwitchType.Interpolation
+return
+
+
+:END_TEST
+    remove_audio_stream sound_stream
+    delete_object speaker_object
+    camera_reset_new_scriptables
+    restore_camera
+    display_hud true
+    display_radar true
+return


### PR DESCRIPTION
Introduced separated default global volume settings for audio streams created from scripts in legacy mode.
Default type can be set in SA.Audio.ini

Added example scripts directory to cleo_readme. Added audio example script