### PR TITLE
Standardized warning messages of terminate_this_script and terminate_…

### DIFF
--- a/source/CCustomOpcodeSystem.cpp
+++ b/source/CCustomOpcodeSystem.cpp
@@ -864,6 +864,7 @@ namespace CLEO
 		if (thread->IsMission() || !cs->IsCustom())
 		{
 			LOG_WARNING(0, "Incorrect usage of opcode [0A93] in script %s. Use [004E] instead.", ((CCustomScript*)thread)->GetInfoStr().c_str());
+			return OR_CONTINUE; // legacy behavior
 		}
 
 		GetInstance().ScriptEngine.RemoveScript(thread);

--- a/source/CCustomOpcodeSystem.cpp
+++ b/source/CCustomOpcodeSystem.cpp
@@ -863,11 +863,10 @@ namespace CLEO
 		CCustomScript *cs = reinterpret_cast<CCustomScript *>(thread);
 		if (thread->IsMission() || !cs->IsCustom())
 		{
-			LOG_WARNING(0, "Incorrect usage of opcode [0A93] in script %s", ((CCustomScript*)thread)->GetInfoStr().c_str());
-
-			return OR_CONTINUE;
+			LOG_WARNING(0, "Incorrect usage of opcode [0A93] in script %s. Use [004E] instead.", ((CCustomScript*)thread)->GetInfoStr().c_str());
 		}
-		GetInstance().ScriptEngine.RemoveCustomScript(cs);
+
+		GetInstance().ScriptEngine.RemoveScript(thread);
 		return OR_INTERRUPT;
 	}
 

--- a/source/CScriptEngine.cpp
+++ b/source/CScriptEngine.cpp
@@ -313,16 +313,6 @@ namespace CLEO
 
     extern "C" void __stdcall opcode_004E(CCustomScript *pScript) // terminate_this_script
     {
-        if (pScript->IsCustom())
-        {
-            if (pScript->IsMission())
-                *MissionLoaded = false;
-            else
-            {
-                LOG_WARNING(0, "Incorrect usage of opcode [004E] in script %s. Use [0A93] instead.", pScript->GetInfoStr().c_str());
-            }
-        }
-
         GetInstance().ScriptEngine.RemoveScript(pScript);
     }
 
@@ -1369,16 +1359,17 @@ namespace CLEO
 
     void CScriptEngine::RemoveScript(CRunningScript* thread)
     {
-        if (!thread->IsCustom())
+        if (thread->IsMission()) *MissionLoaded = false;
+
+        if (thread->IsCustom())
         {
-            if (thread->IsMission()) *MissionLoaded = false;
+            RemoveCustomScript((CCustomScript*)thread);
+        }
+        else // native script
+        {
             RemoveScriptFromQueue(thread, activeThreadQueue);
             AddScriptToQueue(thread, inactiveThreadQueue);
             StopScript(thread);
-        }
-        else
-        {
-            RemoveCustomScript((CCustomScript*)thread);
         }
     }
 
@@ -1397,7 +1388,7 @@ namespace CLEO
 		}
 		for (auto childThread : cs->childThreads)
 		{
-			CScriptEngine::RemoveCustomScript(childThread);
+			CScriptEngine::RemoveScript(childThread);
 		}
         if (cs == CustomMission)
         {

--- a/source/CScriptEngine.cpp
+++ b/source/CScriptEngine.cpp
@@ -319,7 +319,7 @@ namespace CLEO
                 *MissionLoaded = false;
             else
             {
-                TRACE("Incorrect usage of opcode [004E] in script %s.", pScript->GetName().c_str());
+                LOG_WARNING(0, "Incorrect usage of opcode [004E] in script %s. Use [0A93] instead.", pScript->GetInfoStr().c_str());
             }
         }
 

--- a/source/CScriptEngine.h
+++ b/source/CScriptEngine.h
@@ -142,7 +142,6 @@ namespace CLEO
         bool IsValidScriptPtr(const CRunningScript*) const; // leads to any script? (regular or custom)
         void AddCustomScript(CCustomScript*);
         void RemoveScript(CRunningScript*); // native or custom
-        void RemoveCustomScript(CCustomScript*);
         void RemoveAllCustomScripts();
         void UnregisterAllScripts();
         void ReregisterAllScripts();
@@ -151,6 +150,9 @@ namespace CLEO
 
         inline CCustomScript* GetCustomMission() { return CustomMission; }
         inline size_t WorkingScriptsCount() { return CustomScripts.size(); }
+
+    private:
+        void RemoveCustomScript(CCustomScript*);
     };
 
     extern void(__thiscall * AddScriptToQueue)(CRunningScript *, CRunningScript **queue);


### PR DESCRIPTION
Updated error messages:
![image](https://github.com/user-attachments/assets/7c65083b-1837-41c0-9612-01fcc377a88b)

**terminate_this_custom_script** now terminates native scripts too instead of throwing warning and allowing execution.