### PR TITLE
Allowed more args in cleo_return than caller expected in legacy modes.

### DIFF
--- a/source/CCustomOpcodeSystem.cpp
+++ b/source/CCustomOpcodeSystem.cpp
@@ -1121,7 +1121,7 @@ namespace CLEO
 			returnParamCount = declaredParamCount;
 		}
 
-		return GetInstance().OpcodeSystem.CleoReturnGeneric(0x0AB2, thread, true, returnParamCount);
+		return GetInstance().OpcodeSystem.CleoReturnGeneric(0x0AB2, thread, !IsLegacyScript(thread), returnParamCount);
 	}
 
 	//0AB3=2,set_cleo_shared_var %1d% = %2d%


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b62d170a-13ba-467e-bb8a-28d57aed8378)
Fixes error occurring in Junior's Tuning Mod
In old Cleo target variables of not provided return values were just unmodified after call.