### PR TITLE
cleo.log improvements

### DIFF
--- a/cleo_plugins/Text/CTextManager.cpp
+++ b/cleo_plugins/Text/CTextManager.cpp
@@ -106,7 +106,7 @@ namespace CLEO
             {
                 std::ifstream stream(list.strings[i]);
                 auto result = ParseFxtFile(stream);
-                TRACE("Added %d new FXT entries from file %s", result, list.strings[i]);
+                TRACE("Added %d new FXT entries from file '%s'", result, list.strings[i]);
             }
             catch (std::exception& ex)
             {

--- a/cleo_plugins/Text/CTextManager.cpp
+++ b/cleo_plugins/Text/CTextManager.cpp
@@ -92,6 +92,9 @@ namespace CLEO
 
     void CTextManager::LoadFxts()
     {
+        TRACE(""); // separator
+        TRACE("Loading CLEO text files...");
+
         // create FXT directory if not present yet
         FS::create_directory(FS::path(Gta_Root_Dir_Path).append("cleo\\cleo_text"));
 

--- a/source/CCustomOpcodeSystem.cpp
+++ b/source/CCustomOpcodeSystem.cpp
@@ -239,6 +239,7 @@ namespace CLEO
 	{
 		if (initialized) return;
 
+		TRACE(""); // separator
 		TRACE("Initializing CLEO core opcodes...");
 
 		CLEO_RegisterOpcode(0x0051, opcode_0051);

--- a/source/CPluginSystem.cpp
+++ b/source/CPluginSystem.cpp
@@ -57,6 +57,7 @@ void CPluginSystem::LoadPlugins()
         CLEO_StringListFree(files);
     };
 
+    TRACE(""); // separator
     TRACE("Listing CLEO plugins:");
     ScanPluginsDir(FS::path(Filepath_Cleo).append("cleo_plugins").string(), "SA.", ".cleo");
     ScanPluginsDir(FS::path(Filepath_Cleo).append("cleo_plugins").string(), "", ".cleo"); // legacy plugins in new location
@@ -68,6 +69,7 @@ void CPluginSystem::LoadPlugins()
         for (auto it = paths.crbegin(); it != paths.crend(); it++)
         {
             const auto filename = it->c_str();
+            TRACE(""); // separator
             TRACE("Loading plugin '%s'", filename);
 
             HMODULE hlib = LoadLibrary(filename);
@@ -79,6 +81,7 @@ void CPluginSystem::LoadPlugins()
 
             plugins.push_back(hlib);
         }
+        TRACE(""); // separator
     }
     else
     {

--- a/source/CScriptEngine.cpp
+++ b/source/CScriptEngine.cpp
@@ -1023,7 +1023,7 @@ namespace CLEO
 
         if (!found.empty())
         {
-            TRACE("Starting CLEO scripts");
+            TRACE("Starting CLEO scripts...");
 
             for (const auto& path : found)
             {
@@ -1476,7 +1476,8 @@ namespace CLEO
         LastSearchPed(0), LastSearchCar(0), LastSearchObj(0),
         CompatVer(CLEO_VER_CUR)
     {
-        TRACE("Loading custom script %s...", szFileName);
+        TRACE(""); // separator
+        TRACE("Loading custom script '%s'...", szFileName);
 
         bIsCustom = true;
         bIsMission = bUseMissionCleanup = bIsMiss;

--- a/source/CleoBase.cpp
+++ b/source/CleoBase.cpp
@@ -164,6 +164,7 @@ namespace CLEO
 
         saveSlot = MenuManager->m_bWantToLoad ? MenuManager->m_nSelectedSaveGame : -1;
 
+        TRACE(""); // separator
         TRACE("Starting new game, save slot: %d", saveSlot);
 
         // execute registered callbacks
@@ -175,6 +176,7 @@ namespace CLEO
         if (!m_bGameInProgress) return;
         m_bGameInProgress = false;
 
+        TRACE(""); // separator
         TRACE("Ending current game");
         GetInstance().CallCallbacks(eCallbackId::GameEnd); // execute registered callbacks
         ScriptEngine.GameEnd();


### PR DESCRIPTION
Added some empty lines to separate logical blocks in the log.
Cleaned up audio devices listing, fixed listing two devices as `default`.

Preview
```
09/09/2024 05:48:27.745 Starting new game, save slot: -1
09/09/2024 05:48:27.747 
09/09/2024 05:48:27.748 Listing audio devices:
09/09/2024 05:48:27.752  0: No sound
09/09/2024 05:48:27.752  1: Default
09/09/2024 05:48:27.752  2: Cyfrowe urządzenie audio (S/PDIF) (Urządzenie zgodne ze standardem High Definition Audio)
09/09/2024 05:48:27.752  3: AMD HDMI Output (AMD High Definition Audio Device)
09/09/2024 05:48:27.752  4: Głośniki (Urządzenie zgodne ze standardem High Definition Audio)
09/09/2024 05:48:27.752  Default device index: 4
09/09/2024 05:48:27.752 Selecting default audio device #4: Głośniki (Urządzenie zgodne ze standardem High Definition Audio)
09/09/2024 05:48:27.761 SoundSystem initialized
09/09/2024 05:48:27.761 Floating-point audio supported!
09/09/2024 05:48:27.761 Audio hardware acceleration disabled (no EAX)
09/09/2024 05:48:27.762 
09/09/2024 05:48:27.763 Loading CLEO text files...
09/09/2024 05:48:27.782 Added 561 new FXT entries from file D:\GTA_SA\cleo\cleo_text\Tuning Mod.fxt
09/09/2024 05:48:27.784 Added 47 new FXT entries from file D:\GTA_SA\cleo\cleo_text\WeaponNames(EN).fxt
09/09/2024 05:48:27.790 Added 313 new FXT entries from file D:\GTA_SA\cleo\cleo_text\cheats.fxt
09/09/2024 05:48:27.796 
09/09/2024 05:48:27.796 Listing CLEO scripts:
```