### PR TITLE
allow updating existing release when publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -165,3 +165,4 @@ jobs:
           tag: ${{ github.ref_name }}
           prerelease: ${{ contains(github.ref_name, 'beta') || contains(github.ref_name, 'alpha') }}
           artifacts: "SA.CLEO_*.zip"
+          allowUpdates: true


### PR DESCRIPTION
with this change a new release can be run and created using GitHub UI. No need to create the tag in the local repository and push from the terminal. Just go to https://github.com/cleolibrary/CLEO5/releases/new, fill in the tag name, select set as a pre-release and click Publish.