### PR TITLE
3d audio streams decay distance

### DIFF
--- a/CLEO5.vcxproj
+++ b/CLEO5.vcxproj
@@ -72,6 +72,9 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="$(PLUGIN_SDK_DIR)\plugin_sa\game_sa\CTimer.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="third-party\simdjson\simdjson.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>

--- a/cleo_plugins/Audio/Audio.cpp
+++ b/cleo_plugins/Audio/Audio.cpp
@@ -66,7 +66,7 @@ public:
 
         // register event callbacks
         CLEO_RegisterCallback(eCallbackId::GameBegin, OnGameBegin);
-        CLEO_RegisterCallback(eCallbackId::GameProcess, OnGameProcess);
+        CLEO_RegisterCallback(eCallbackId::GameProcessed, OnGameProcessed);
         CLEO_RegisterCallback(eCallbackId::GameEnd, OnGameEnd);
         CLEO_RegisterCallback(eCallbackId::DrawingFinished, OnDrawingFinished);
         CLEO_RegisterCallback(eCallbackId::MainWindowFocus, OnMainWindowFocus);
@@ -75,7 +75,7 @@ public:
     ~Audio()
     {
         CLEO_UnregisterCallback(eCallbackId::GameBegin, OnGameBegin);
-        CLEO_UnregisterCallback(eCallbackId::GameProcess, OnGameProcess);
+        CLEO_UnregisterCallback(eCallbackId::GameProcessed, OnGameProcessed);
         CLEO_UnregisterCallback(eCallbackId::GameEnd, OnGameEnd);
         CLEO_UnregisterCallback(eCallbackId::DrawingFinished, OnDrawingFinished);
         CLEO_UnregisterCallback(eCallbackId::MainWindowFocus, OnMainWindowFocus);
@@ -86,7 +86,7 @@ public:
         soundSystem.Init();
     }
 
-    static void __stdcall OnGameProcess()
+    static void __stdcall OnGameProcessed()
     {
         soundSystem.Process();
     }
@@ -180,7 +180,7 @@ public:
     {
         auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
 
-        auto state = CAudioStream::eStreamState::Stopped;
+        auto state = CAudioStream::StreamState::Stopped;
         if (stream) state = stream->GetState();
 
         OPCODE_WRITE_PARAM_INT(state);
@@ -305,10 +305,10 @@ public:
     {
         auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
 
-        auto state = CAudioStream::eStreamState::Stopped;
+        auto state = CAudioStream::StreamState::Stopped;
         if (stream) state = stream->GetState();
 
-        OPCODE_CONDITION_RESULT(state == CAudioStream::eStreamState::Playing);
+        OPCODE_CONDITION_RESULT(state == CAudioStream::StreamState::Playing);
         return OR_CONTINUE;
     }
 

--- a/cleo_plugins/Audio/Audio.vcxproj
+++ b/cleo_plugins/Audio/Audio.vcxproj
@@ -148,6 +148,7 @@ xcopy /Y "$(OutDir)$(TargetName).*" "$(GTA_SA_DIR)\cleo\cleo_plugins\" </Command
     <ClCompile Include="$(PLUGIN_SDK_DIR)\plugin_sa\game_sa\CVector.cpp" />
     <ClCompile Include="$(PLUGIN_SDK_DIR)\plugin_sa\game_sa\RenderWare.cpp" />
     <ClCompile Include="$(PLUGIN_SDK_DIR)\plugin_sa\game_sa\CAEAudioHardware.cpp" />
+    <ClCompile Include="$(PLUGIN_SDK_DIR)\plugin_sa\game_sa\CPad.cpp" />
     <ClCompile Include="Audio.cpp" />
     <ClCompile Include="C3DAudioStream.cpp" />
     <ClCompile Include="CAudioStream.cpp" />

--- a/cleo_plugins/Audio/Audio.vcxproj.filters
+++ b/cleo_plugins/Audio/Audio.vcxproj.filters
@@ -41,6 +41,9 @@
     </ClCompile>
     <ClCompile Include="CAudioStream.cpp" />
     <ClCompile Include="C3DAudioStream.cpp" />
+    <ClCompile Include="$(PLUGIN_SDK_DIR)\plugin_sa\game_sa\CPad.cpp">
+      <Filter>plugin_sdk</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\cleo_sdk\CLEO_Utils.h">

--- a/cleo_plugins/Audio/C3DAudioStream.cpp
+++ b/cleo_plugins/Audio/C3DAudioStream.cpp
@@ -25,6 +25,7 @@ C3DAudioStream::C3DAudioStream(const char* filepath) : CAudioStream()
 
     BASS_ChannelGetAttribute(streamInternal, BASS_ATTRIB_FREQ, &rate);
     BASS_ChannelSet3DAttributes(streamInternal, BASS_3DMODE_NORMAL, -1.0f, -1.0f, -1, -1, -1.0f);
+    BASS_ChannelSetAttribute(streamInternal, BASS_ATTRIB_VOL, 0.0f); // muted until processed
     ok = true;
 }
 
@@ -96,11 +97,6 @@ void C3DAudioStream::UpdatePosition()
         {
             velocity = position - velocity; // curr - prev
             velocity /= CSoundSystem::timeStep; // meters peer second
-
-            // make Doppler effect less dramatic
-            velocity.x = sqrtf(abs(velocity.x)) * (velocity.x > 0.0f ? 1.0f : -1.0f);
-            velocity.y = sqrtf(abs(velocity.y)) * (velocity.y > 0.0f ? 1.0f : -1.0f);
-            velocity.z = sqrtf(abs(velocity.z)) * (velocity.z > 0.0f ? 1.0f : -1.0f);
         }
     }
     else

--- a/cleo_plugins/Audio/C3DAudioStream.cpp
+++ b/cleo_plugins/Audio/C3DAudioStream.cpp
@@ -116,14 +116,14 @@ void C3DAudioStream::UpdatePosition()
         }
         else // listener inside sound soruce, no lef-right panning or Doppler effects then
         {
-            // blending curve
-            outsideness = max(2.0f * outsideness - 1.0f, 0.0f); // blending curve
+            auto fakeVel = velocity * outsideness + CSoundSystem::velocity * (1.0f - outsideness); // blend
+
+            // modify blending curve for stereo panning
+            outsideness = max(2.0f * outsideness - 1.0f, 0.0f); 
             outsideness *= outsideness;
 
             auto fakePos = CSoundSystem::position + CSoundSystem::forward; // 1 meter in front of the listener, dead center
             fakePos = position * outsideness + fakePos * (1.0f - outsideness); // blend
-
-            auto fakeVel = velocity * outsideness + CSoundSystem::velocity * (1.0f - outsideness); // blend
 
             BASS_ChannelSet3DPosition(streamInternal,
                 &toBass(fakePos),

--- a/cleo_plugins/Audio/C3DAudioStream.cpp
+++ b/cleo_plugins/Audio/C3DAudioStream.cpp
@@ -56,19 +56,25 @@ float C3DAudioStream::CalculateVolume()
 {
     if (!placed) return 0.0f; // muted until position calculated
 
+    float volumeDb = 0.0; // default volume for game's mission audio
+
     // calculate distance based volume
     float distance = CSoundSystem::GetDistance(&position);
     distance = max(distance - sourceRadius, 0.0f);
-    distance /= max(powf(sourceRadius, 0.333f), 0.001f); // bigger sources reach further
-    float decay = 1.0f / (1.0f + 0.32f * distance); // hand fitted to match game's decay curve
+    //distance /= max(powf(sourceRadius, 0.333f), 0.001f); // bigger sources reach further
 
-    float volume = GetParam(Volume) * Volume_3D_Adjust * decay;
-    volume = max(volume - 0.025f, 0.0f); // BASS tends to make even very low volumes still well audible. Fight it with small offset
+    //float decay = 1.0f / (1.0f + 0.32f * distance); // hand fitted to match game's decay curve
+    auto decay = (float)CAEAudioEnvironment__GetDistanceAttenuation(distance);
+    //decay = dbToLinear(decay);
 
-    // non 3d world, 2d "post effect"
-    volume *= CSoundSystem::GetMasterVolume(type);
+    //float volume = GetParam(Volume) * Volume_3D_Adjust * decay;
+    //volume = max(volume - 0.025f, 0.0f); // BASS tends to make even very low volumes still well audible. Fight it with small offset
 
-    return volume;
+    volumeDb += decay;
+
+    float volume = dbToLinear(volumeDb);
+
+    return volume * Volume_3D_Adjust * CSoundSystem::GetMasterVolume(type);
 }
 
 void C3DAudioStream::UpdatePosition()

--- a/cleo_plugins/Audio/C3DAudioStream.h
+++ b/cleo_plugins/Audio/C3DAudioStream.h
@@ -6,7 +6,7 @@ namespace CLEO
     class C3DAudioStream : public CAudioStream
     {
     public:
-        const float Volume_3D_Adjust = 0.333f; // to match other ingame sound sources
+        const float Volume_3D_Adjust = 0.333f; // to match other ingame 3d sounds
 
         C3DAudioStream(const char* filepath);
 
@@ -21,7 +21,7 @@ namespace CLEO
         CEntity* host = nullptr;
         CVector position = { 0.0f, 0.0f, 0.0f };
         bool placed = false; // position calcualted?
-        float sourceRadius = 10.0f; // same as in play_mission_audio opcode
+        float sourceRadius = 5.0f;
 
         C3DAudioStream(const C3DAudioStream&) = delete; // no copying!
         void UpdatePosition();

--- a/cleo_plugins/Audio/C3DAudioStream.h
+++ b/cleo_plugins/Audio/C3DAudioStream.h
@@ -6,7 +6,7 @@ namespace CLEO
     class C3DAudioStream : public CAudioStream
     {
     public:
-        const float Volume_3D_Adjust = 0.333f; // to match other ingame 3d sounds
+        const float Volume_3D_Adjust = 0.25f; // to match other ingame 3d sounds
 
         C3DAudioStream(const char* filepath);
 

--- a/cleo_plugins/Audio/C3DAudioStream.h
+++ b/cleo_plugins/Audio/C3DAudioStream.h
@@ -6,17 +6,22 @@ namespace CLEO
     class C3DAudioStream : public CAudioStream
     {
     public:
+        const float Volume_3D_Adjust = 0.333f; // to match other ingame sound sources
+
         C3DAudioStream(const char* filepath);
 
         // overloaded actions
         virtual void Set3dPosition(const CVector& pos);
         virtual void Set3dSourceSize(float radius);
-        virtual void Link(CPlaceable* placable = nullptr);
+        virtual void Link(CEntity* entity = nullptr);
         virtual void Process();
+        virtual float CalculateVolume();
 
     protected:
-        CPlaceable* link = nullptr;
-        BASS_3DVECTOR position = { 0.0f, 0.0f, 0.0f };
+        CEntity* host = nullptr;
+        CVector position = { 0.0f, 0.0f, 0.0f };
+        bool placed = false; // position calcualted?
+        float sourceRadius = 10.0f; // same as in play_mission_audio opcode
 
         C3DAudioStream(const C3DAudioStream&) = delete; // no copying!
         void UpdatePosition();

--- a/cleo_plugins/Audio/CAudioStream.cpp
+++ b/cleo_plugins/Audio/CAudioStream.cpp
@@ -176,17 +176,7 @@ void CAudioStream::ResetParams()
 
 float CAudioStream::CalculateVolume()
 {
-    float masterVolume;
-    switch(type)
-    {
-        case SoundEffect: masterVolume = CSoundSystem::masterVolumeSfx; break;
-        case Music: masterVolume = CSoundSystem::masterVolumeMusic; break;
-        default: masterVolume = 1.0f; break;
-    }
-
-    float fadeVolume = 1.0f - TheCamera.m_fFadeAlpha / 255.0f; // TODO: handle TheCamera.m_bIgnoreFadingStuffForMusic if neccessary
-
-    return GetParam(Volume) * fadeVolume * masterVolume;
+    return GetParam(Volume) * CSoundSystem::GetMasterVolume(type);
 }
 
 void CAudioStream::ProcessTransitions(bool instant)

--- a/cleo_plugins/Audio/CAudioStream.cpp
+++ b/cleo_plugins/Audio/CAudioStream.cpp
@@ -210,6 +210,8 @@ void CAudioStream::ProcessTransitions(bool instant)
 
 void CAudioStream::ApplyParams()
 {
+    if (CSoundSystem::skipFrame) return;
+
     // volume
     float volume = CalculateVolume();
     BASS_ChannelSetAttribute(streamInternal, BASS_ATTRIB_VOL, volume);

--- a/cleo_plugins/Audio/CSoundSystem.cpp
+++ b/cleo_plugins/Audio/CSoundSystem.cpp
@@ -206,24 +206,28 @@ namespace CLEO
         {
             // update globals
             skipFrame = TheCamera.m_bJust_Switched || TheCamera.m_bCameraJustRestored || CPad::GetPad(0)->JustOutOfFrontEnd; // avoid camera change/jump cut velocity glitches
-            timeStep = (float)(CTimer::m_snTimeInMillisecondsNonClipped - CTimer::m_snPreviousTimeInMillisecondsNonClipped) / 1000.0f; // time delta in seconds
+            timeStep = CTimer::ms_fTimeStep * 0.02f; // time delta in seconds
             masterSpeed = CTimer::ms_fTimeScale;
 
             CVector prevPos = position;
             position = TheCamera.GetPosition(); // get new
 
+            // new camera velocity
+            if (!skipFrame)
+            {
+                CVector vel = position - prevPos;
+                vel /= timeStep; // meters peer second
+
+                // averaging to smooth artifact caused by GTA's janky mouse camera control
+                velocity += velocity + vel;
+                velocity /= 3;
+            }
+            else
+                velocity = {};
+
             if (!skipFrame)
             {
                 if (paused) Resume();
-
-                // camera velocity
-                velocity = position - prevPos;
-                velocity /= timeStep; // meters peer second
-
-                // make Doppler effect less dramatic
-                velocity.x = sqrtf(abs(velocity.x)) * (velocity.x > 0.0f ? 1.0f : -1.0f);
-                velocity.y = sqrtf(abs(velocity.y)) * (velocity.y > 0.0f ? 1.0f : -1.0f);
-                velocity.z = sqrtf(abs(velocity.z)) * (velocity.z > 0.0f ? 1.0f : -1.0f);
 
                 forward = TheCamera.GetForward();
                 up = TheCamera.GetUp();

--- a/cleo_plugins/Audio/CSoundSystem.cpp
+++ b/cleo_plugins/Audio/CSoundSystem.cpp
@@ -257,16 +257,16 @@ namespace CLEO
         float volume;
         switch (type)
         {
-            case SoundEffect: 
+            case SoundEffect:
                 volume = AEAudioHardware.m_fEffectMasterScalingFactor* AEAudioHardware.m_fEffectsFaderScalingFactor * 0.5f; // fitted to game's sfx volume
                 break;
 
-            case Music: 
+            case Music:
                 volume = AEAudioHardware.m_fMusicMasterScalingFactor * AEAudioHardware.m_fMusicFaderScalingFactor * 0.5f;
                 break;
 
-            default: 
-                volume = 1.0f; 
+            default:
+                volume = 1.0f;
                 break;
         }
 
@@ -276,7 +276,11 @@ namespace CLEO
             volume *= 1.0f - TheCamera.m_fFadeAlpha / 255.0f;
         }
 
-        // TODO: music volume lowering when in cutscenes, when mission or ped speach is active etc.
+        // music volume lowering in cutscenes, when characters talk, mission sounds are played etc.
+        if (type == Music)
+        {
+            if (TheCamera.m_bWideScreenOn) volume /= 3.0f;
+        }
 
         return volume;
     }

--- a/cleo_plugins/Audio/CSoundSystem.cpp
+++ b/cleo_plugins/Audio/CSoundSystem.cpp
@@ -271,9 +271,12 @@ namespace CLEO
         }
 
         // screen fading
-        volume = 1.0f - TheCamera.m_fFadeAlpha / 255.0f; // TODO: handle TheCamera.m_bIgnoreFadingStuffForMusic if neccessary
+        if (!TheCamera.m_bIgnoreFadingStuffForMusic) // it actually applies to all sounds
+        {
+            volume *= 1.0f - TheCamera.m_fFadeAlpha / 255.0f;
+        }
 
-        // TODO: muscic volume lowering when in cutscenes, when mission or ped speach is acttive etc.
+        // TODO: music volume lowering when in cutscenes, when mission or ped speach is active etc.
 
         return volume;
     }

--- a/cleo_plugins/Audio/CSoundSystem.h
+++ b/cleo_plugins/Audio/CSoundSystem.h
@@ -29,11 +29,12 @@ namespace CLEO
         static bool CSoundSystem::allowNetworkSources;
 
         static CVector position;
+        static CVector forward;
+        static CVector up;
+        static CVector velocity;
         static bool skipFrame; // do not apply changes during this frame
         static float timeStep; // delta time for current frame
         static float masterSpeed; // game simulation speed
-        static float masterVolumeSfx;
-        static float masterVolumeMusic;
 
     public:
         static eStreamType LegacyModeDefaultStreamType;
@@ -55,6 +56,7 @@ namespace CLEO
         void Process();
 
         static float GetDistance(const CVector* position); // distance from coords to the camera
+        static float GetMasterVolume(eStreamType type);
     };
 
     // convert GTA to BASS coordinate system

--- a/cleo_plugins/Audio/CSoundSystem.h
+++ b/cleo_plugins/Audio/CSoundSystem.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "bass.h"
+#include "CVector.h"
 #include <set>
 
 namespace CLEO
@@ -27,10 +28,9 @@ namespace CLEO
         static bool useFloatAudio;
         static bool CSoundSystem::allowNetworkSources;
 
-        static BASS_3DVECTOR pos;
-        static BASS_3DVECTOR vel;
-        static BASS_3DVECTOR front;
-        static BASS_3DVECTOR top;
+        static CVector position;
+        static bool skipFrame; // do not apply changes during this frame
+        static float timeStep; // delta time for current frame
         static float masterSpeed; // game simulation speed
         static float masterVolumeSfx;
         static float masterVolumeMusic;
@@ -53,7 +53,13 @@ namespace CLEO
         void Pause();
         void Resume();
         void Process();
+
+        static float GetDistance(const CVector* position); // distance from coords to the camera
     };
 
+    // convert GTA to BASS coordinate system
+    inline BASS_3DVECTOR toBass(const CVector& v) { return BASS_3DVECTOR(v.x, v.z, v.y); }
+    inline BASS_3DVECTOR toBass(const CVector* v) { return toBass(*v); }
+    
     bool isNetworkSource(const char* path);
 }

--- a/cleo_plugins/Audio/CSoundSystem.h
+++ b/cleo_plugins/Audio/CSoundSystem.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "CLEO_Utils.h"
 #include "bass.h"
 #include "CVector.h"
 #include <set>
@@ -14,6 +15,10 @@ namespace CLEO
         SoundEffect,
         Music,
     };
+
+    // functions inside game executable
+    static long double(__cdecl* CAEAudioUtility__AudioLog10)(float value) = memory_pointer(0x004D9E50);
+    static double(__cdecl* CAEAudioEnvironment__GetDistanceAttenuation)(float distance) = memory_pointer(0x004D7F20);
 
     class CSoundSystem
     {
@@ -62,6 +67,9 @@ namespace CLEO
     // convert GTA to BASS coordinate system
     inline BASS_3DVECTOR toBass(const CVector& v) { return BASS_3DVECTOR(v.x, v.z, v.y); }
     inline BASS_3DVECTOR toBass(const CVector* v) { return toBass(*v); }
+
+    // convert Decibel gain (-100.0 - 0.0) to linear factor (0.0 - 1.0)
+    inline float dbToLinear(float value) { return powf(10.0f, value / 20.0f); }
     
     bool isNetworkSource(const char* path);
 }

--- a/cleo_sdk/CLEO.h
+++ b/cleo_sdk/CLEO.h
@@ -288,7 +288,8 @@ const char DIR_MODULES[] = "modules:"; // game\cleo\modules directory
 enum class eCallbackId : DWORD
 {
 	GameBegin, // void WINAPI OnGameBegin(DWORD saveSlot); // -1 if not started from save
-	GameProcess, // void WINAPI OnGameProcess(); // called once every frame during gameplay
+	GameProcess, // void WINAPI OnGameProcess(); // called once every frame before game logic processing
+	GameProcessed, // void WINAPI OnGameProcess(); // called once every frame after game logic processing
 	GameEnd, // void WINAPI OnGameEnd();
 	ScriptsLoaded, // void WINAPI OnScriptsLoaded();
 	ScriptsFinalize, // void WINAPI OnScriptsFinalize();

--- a/cleo_sdk/CLEO_Utils.h
+++ b/cleo_sdk/CLEO_Utils.h
@@ -327,6 +327,29 @@ namespace CLEO
         BOOL needTerminator = false;
     };
 
+    // a pointer automatically convertible to integral types
+    union memory_pointer
+    {
+        size_t address;
+        void* pointer;
+
+        inline memory_pointer(void* p) : pointer(p) { }
+        inline memory_pointer(size_t a) : address(a) { }
+        inline operator void* () { return pointer; }
+        inline operator size_t() { return address; }
+        inline memory_pointer& operator=(void* p) { return *this = p; }
+        inline memory_pointer& operator=(size_t p) { return *this = p; }
+
+        // conversion to/from any-type pointer
+        template<typename T>
+        inline memory_pointer(T* p) : pointer(reinterpret_cast<void*>(p)) {}
+        template<typename T>
+        inline operator T* () { return reinterpret_cast<T*>(pointer); }
+        template<typename T>
+        inline memory_pointer& operator=(T* p) { return *this = reinterpret_cast<void*>(p); }
+    };
+    VALIDATE_SIZE(memory_pointer, 4);
+
     class MemPatch
     {
         void* address = nullptr;

--- a/source/CCodeInjector.h
+++ b/source/CCodeInjector.h
@@ -3,30 +3,6 @@
 
 namespace CLEO
 {
-    // a pointer automatically convertible to integral types
-    union memory_pointer
-    {
-        size_t address;
-        void *pointer;
-
-        inline memory_pointer(void *p) : pointer(p) { }
-        inline memory_pointer(size_t a) : address(a) { }
-        inline operator void *() { return pointer; }
-        inline operator size_t() { return address; }
-        inline memory_pointer& operator=(void *p) { return *this = p; }
-        inline memory_pointer& operator=(size_t p) { return *this = p; }
-
-        // conversion to/from any-type pointer
-        template<typename T>
-        inline memory_pointer(T *p) : pointer(reinterpret_cast<void *>(p)) {}
-        template<typename T>
-        inline operator T *() { return reinterpret_cast<T *>(pointer); }
-        template<typename T>
-        inline memory_pointer& operator=(T *p) { return *this = reinterpret_cast<void *>(p); }
-    };
-
-    VALIDATE_SIZE(memory_pointer, 4);
-
     const memory_pointer memory_und = nullptr;
 
     // Implements dirty tricks for low-level memory managemant

--- a/source/CleoBase.cpp
+++ b/source/CleoBase.cpp
@@ -12,13 +12,13 @@ namespace CLEO
         Stop();
     }
 
-    void __declspec(naked) CCleoInstance::OnUpdateGameLogics()
+    void __cdecl CCleoInstance::OnUpdateGameLogics()
     {
         CleoInstance.CallCallbacks(eCallbackId::GameProcess); // execute registered callbacks
 
-        static DWORD dwFunc;
-        dwFunc = (DWORD)(CleoInstance.UpdateGameLogics);
-        _asm jmp dwFunc
+        CleoInstance.UpdateGameLogics(); // call original function
+
+        CleoInstance.CallCallbacks(eCallbackId::GameProcessed); // execute registered callbacks
     }
 
     HWND CCleoInstance::OnCreateMainWnd(HINSTANCE hinst)


### PR DESCRIPTION
Updated for new BASS version with fixed Doppler calculations.
Implemented distance volume decay for 3d sounds to match other ingame sounds.
Proper handling of 3d source sizes, including channel panning and Doppler effect.