### PR TITLE
Fix Alpha.71 crashes

### DIFF
--- a/source/CCodeInjector.h
+++ b/source/CCodeInjector.h
@@ -35,17 +35,13 @@ namespace CLEO
         bool bAccessOpen;
 
     public:
-        CCodeInjector() {
-            bAccessOpen = false;
-
-            // moved here so that access is open for plugins
-            OpenReadWriteAccess();			// we might as well leave it open, too
-                                            //GetInstance().Start();
-        }
-        ~CCodeInjector()
+        CCodeInjector() 
         {
-            //GetInstance().Stop();
-        };
+            bAccessOpen = false;
+            OpenReadWriteAccess(); // moved here so that access is open for plugins
+        }
+
+        ~CCodeInjector() = default;
 
         void OpenReadWriteAccess();
         void CloseReadWriteAccess();
@@ -59,12 +55,12 @@ namespace CLEO
             else { TRACE("Replaced call at: 0x%08X, original function was: 0x%08X", (DWORD)position, (DWORD)*origFuncPtr); }
         }
 
-        void ReplaceJump(memory_pointer newJumpDst, memory_pointer position, memory_pointer* origJumpDest = nullptr)
+        void ReplaceJump(memory_pointer newJumpDst, memory_pointer position, void** origJumpDest = nullptr)
         {
             MemJump((size_t)position, (size_t)newJumpDst, (size_t*)origJumpDest);
 
             if (origJumpDest == nullptr) { TRACE("Replaced jump at: 0x%08X", (DWORD)position); }
-            else { TRACE("Replaced jump at: 0x%08X, original destination was: 0x%08X", (DWORD)position, (DWORD)origJumpDest->address); }
+            else { TRACE("Replaced jump at: 0x%08X, original destination was: 0x%08X", (DWORD)position, (DWORD)*origJumpDest); }
         }
 
         template<typename T>

--- a/source/CCustomOpcodeSystem.cpp
+++ b/source/CCustomOpcodeSystem.cpp
@@ -107,7 +107,7 @@ namespace CLEO
 
 		// execute registered callbacks
 		OpcodeResult result = OR_NONE;
-		for (void* func : GetInstance().GetCallbacks(eCallbackId::ScriptOpcodeProcess))
+		for (void* func : CleoInstance.GetCallbacks(eCallbackId::ScriptOpcodeProcess))
 		{
 			typedef OpcodeResult WINAPI callback(CRunningScript*, DWORD);
 			result = ((callback*)func)(thread, opcode);
@@ -135,7 +135,7 @@ namespace CLEO
 
 			if (opcode > LastOriginalOpcode)
 			{
-				auto extensionMsg = GetInstance().OpcodeInfoDb.GetExtensionMissingMessage(opcode);
+				auto extensionMsg = CleoInstance.OpcodeInfoDb.GetExtensionMissingMessage(opcode);
 				if (!extensionMsg.empty()) extensionMsg = " " + extensionMsg;
 
 				SHOW_ERROR("Custom opcode [%04X] not registered!%s\nCalled in script %s\nPreviously called opcode: [%04X]\nScript suspended.",
@@ -152,7 +152,7 @@ namespace CLEO
 
 			if(result == OR_ERROR)
 			{
-				auto extensionMsg = GetInstance().OpcodeInfoDb.GetExtensionMissingMessage(opcode);
+				auto extensionMsg = CleoInstance.OpcodeInfoDb.GetExtensionMissingMessage(opcode);
 				if (!extensionMsg.empty()) extensionMsg = " " + extensionMsg;
 
 				SHOW_ERROR("Opcode [%04X] not found!%s\nCalled in script %s\nPreviously called opcode: [%04X]\nScript suspended.",
@@ -167,7 +167,7 @@ namespace CLEO
 
 		// execute registered callbacks
 		OpcodeResult callbackResult = OR_NONE;
-		for (void* func : GetInstance().GetCallbacks(eCallbackId::ScriptOpcodeProcessFinished))
+		for (void* func : CleoInstance.GetCallbacks(eCallbackId::ScriptOpcodeProcessFinished))
 		{
 			typedef OpcodeResult WINAPI callback(CRunningScript*, DWORD, OpcodeResult);
 			auto res = ((callback*)func)(thread, opcode, result);
@@ -182,7 +182,7 @@ namespace CLEO
 	{
 		TRACE("Cleaning up script data...");
 
-		GetInstance().CallCallbacks(eCallbackId::ScriptsFinalize);
+		CleoInstance.CallCallbacks(eCallbackId::ScriptsFinalize);
 
 		// clean up after opcode_0AB1
 		ScmFunction::Clear();
@@ -191,7 +191,7 @@ namespace CLEO
 	void CCustomOpcodeSystem::Inject(CCodeInjector& inj)
 	{
 		TRACE("Injecting CustomOpcodeSystem...");
-		CGameVersionManager& gvm = GetInstance().VersionManager;
+		CGameVersionManager& gvm = CleoInstance.VersionManager;
 
 		// replace all handlers in original table
 		// store original opcode handlers for later use
@@ -801,7 +801,7 @@ namespace CLEO
 
 	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_004E(CRunningScript* thread)
 	{
-		GetInstance().ScriptEngine.RemoveScript(thread);
+		CleoInstance.ScriptEngine.RemoveScript(thread);
 		return OR_INTERRUPT;
 	}
 
@@ -810,7 +810,7 @@ namespace CLEO
 		if (thread->SP == 0 && !IsLegacyScript(thread)) // CLEO5 - allow use of GOSUB `return` to exit cleo calls too
 		{
 			SetScriptCondResult(thread, false);
-			return GetInstance().OpcodeSystem.CleoReturnGeneric(0x0051, thread, false); // try CLEO's function return
+			return CleoInstance.OpcodeSystem.CleoReturnGeneric(0x0051, thread, false); // try CLEO's function return
 		}
 
 		if (thread->SP == 0)
@@ -842,7 +842,7 @@ namespace CLEO
 		SetScriptCondResult(thread, cs && cs->IsOK());
 		if (cs && cs->IsOK())
 		{
-			GetInstance().ScriptEngine.AddCustomScript(cs);
+			CleoInstance.ScriptEngine.AddCustomScript(cs);
 			TransmitScriptParams(thread, cs);
 			cs->SetDebugMode(reinterpret_cast<CCustomScript*>(thread)->GetDebugMode());
 		}
@@ -866,7 +866,7 @@ namespace CLEO
 			return OR_CONTINUE; // legacy behavior
 		}
 
-		GetInstance().ScriptEngine.RemoveScript(thread);
+		CleoInstance.ScriptEngine.RemoveScript(thread);
 		return OR_INTERRUPT;
 	}
 
@@ -886,7 +886,7 @@ namespace CLEO
 			auto csscript = reinterpret_cast<CCustomScript*>(thread);
 			if (csscript->IsCustom())
 				cs->SetCompatibility(csscript->GetCompatibility());
-			GetInstance().ScriptEngine.AddCustomScript(cs);
+			CleoInstance.ScriptEngine.AddCustomScript(cs);
 			memset(missionLocals, 0, 1024 * sizeof(SCRIPT_VAR)); // same as CTheScripts::WipeLocalVariableMemoryForMissionScript
 			TransmitScriptParams(thread, (CRunningScript*)((BYTE*)missionLocals - 0x3C));
 			cs->SetDebugMode(reinterpret_cast<CCustomScript*>(thread)->GetDebugMode());
@@ -930,7 +930,7 @@ namespace CLEO
 	//0AA9=0,  is_game_version_original
 	OpcodeResult __stdcall opcode_0AA9(CRunningScript *thread)
 	{
-		auto gv = GetInstance().VersionManager.GetGameVersion();
+		auto gv = CleoInstance.VersionManager.GetGameVersion();
 		auto cs = (CCustomScript*)thread;
 		SetScriptCondResult(thread, gv == GV_US10 || (cs->IsCustom() && cs->GetCompatibility() <= CLEO_VER_4_MIN && gv == GV_EU10));
 		return OR_CONTINUE;
@@ -991,7 +991,7 @@ namespace CLEO
 			modulePath = reinterpret_cast<CCustomScript*>(thread)->ResolvePath(modulePath.c_str(), DIR_SCRIPT); // by default search relative to current script location
 
 			// get export reference
-			auto scriptRef = GetInstance().ModuleSystem.GetExport(modulePath, strExport);
+			auto scriptRef = CleoInstance.ModuleSystem.GetExport(modulePath, strExport);
 			if (!scriptRef.Valid())
 			{
 				SHOW_ERROR("Not found module '%s' export '%s', requested by opcode [0AB1] in script %s", modulePath.c_str(), moduleTxt.c_str(), ((CCustomScript*)thread)->GetInfoStr().c_str());
@@ -1120,7 +1120,7 @@ namespace CLEO
 			returnParamCount = declaredParamCount;
 		}
 
-		return GetInstance().OpcodeSystem.CleoReturnGeneric(0x0AB2, thread, !IsLegacyScript(thread), returnParamCount);
+		return CleoInstance.OpcodeSystem.CleoReturnGeneric(0x0AB2, thread, !IsLegacyScript(thread), returnParamCount);
 	}
 
 	//0AB3=2,set_cleo_shared_var %1d% = %2d%
@@ -1145,7 +1145,7 @@ namespace CLEO
 		}
 
 		GetScriptParams(thread, 1);
-		GetInstance().ScriptEngine.CleoVariables[varIdx].dwParam = opcodeParams[0].dwParam;
+		CleoInstance.ScriptEngine.CleoVariables[varIdx].dwParam = opcodeParams[0].dwParam;
 		return OR_CONTINUE;
 	}
 
@@ -1168,7 +1168,7 @@ namespace CLEO
 			return thread->Suspend();
 		}
 
-		opcodeParams[0].dwParam = GetInstance().ScriptEngine.CleoVariables[varIdx].dwParam;
+		opcodeParams[0].dwParam = CleoInstance.ScriptEngine.CleoVariables[varIdx].dwParam;
 		CLEO_RecordOpcodeParams(thread, 1);
 		return OR_CONTINUE;
 	}
@@ -1211,7 +1211,7 @@ namespace CLEO
 	OpcodeResult __stdcall opcode_0AB6(CRunningScript *thread)
 	{
 		// steam offset is different, so get it manually for now
-		CGameVersionManager& gvm = GetInstance().VersionManager;
+		CGameVersionManager& gvm = CleoInstance.VersionManager;
 		DWORD hMarker = gvm.GetGameVersion() !=  GV_STEAM ? MenuManager->m_nTargetBlipIndex : *((DWORD*)0xC3312C);
 		CMarker *pMarker;
 		if (hMarker && (pMarker = &RadarBlips[LOWORD(hMarker)]) && /*pMarker->m_nPoolIndex == HIWORD(hMarker) && */pMarker->m_nBlipDisplay)
@@ -1524,7 +1524,7 @@ namespace CLEO
 		argCount--;
 		SetScriptCondResult(thread, result != 0);
 
-		return GetInstance().OpcodeSystem.CleoReturnGeneric(0x2002, thread, true, argCount);
+		return CleoInstance.OpcodeSystem.CleoReturnGeneric(0x2002, thread, true, argCount);
 	}
 
 	//2003=-1, cleo_return_fail
@@ -1538,7 +1538,7 @@ namespace CLEO
 		}
 
 		SetScriptCondResult(thread, false);
-		return GetInstance().OpcodeSystem.CleoReturnGeneric(0x2003, thread);
+		return CleoInstance.OpcodeSystem.CleoReturnGeneric(0x2003, thread);
 	}
 }
 
@@ -1562,7 +1562,7 @@ extern "C"
 
 	BOOL WINAPI CLEO_RegisterCommand(const char* commandName, CustomOpcodeHandler callback)
 	{
-		WORD opcode = GetInstance().OpcodeInfoDb.GetOpcode(commandName);
+		WORD opcode = CleoInstance.OpcodeInfoDb.GetOpcode(commandName);
 		if (opcode == 0xFFFF)
 		{
 			LOG_WARNING(0, "Failed to register opcode [%s]! Command name not found in the database.", commandName);
@@ -1648,14 +1648,14 @@ extern "C"
 		// store state
 		auto param = opcodeParams[0];
 		auto ip = thread->CurrentIP;
-		auto count = GetInstance().OpcodeSystem.handledParamCount;
+		auto count = CleoInstance.OpcodeSystem.handledParamCount;
 
 		GetScriptParams(thread, 1);
 		DWORD result = opcodeParams[0].dwParam;
 
 		// restore state
 		thread->CurrentIP = ip;
-		GetInstance().OpcodeSystem.handledParamCount = count;
+		CleoInstance.OpcodeSystem.handledParamCount = count;
 		opcodeParams[0] = param;
 
 		return result;
@@ -1666,14 +1666,14 @@ extern "C"
 		// store state
 		auto param = opcodeParams[0];
 		auto ip = thread->CurrentIP;
-		auto count = GetInstance().OpcodeSystem.handledParamCount;
+		auto count = CleoInstance.OpcodeSystem.handledParamCount;
 
 		GetScriptParams(thread, 1);
 		float result = opcodeParams[0].fParam;
 
 		// restore state
 		thread->CurrentIP = ip;
-		GetInstance().OpcodeSystem.handledParamCount = count;
+		CleoInstance.OpcodeSystem.handledParamCount = count;
 		opcodeParams[0] = param;
 
 		return result;
@@ -1683,13 +1683,13 @@ extern "C"
 	{
 		// store state
 		auto ip = thread->CurrentIP;
-		auto count = GetInstance().OpcodeSystem.handledParamCount;
+		auto count = CleoInstance.OpcodeSystem.handledParamCount;
 
 		auto result = GetScriptParamPointer(thread);
 
 		// restore state
 		thread->CurrentIP = ip;
-		GetInstance().OpcodeSystem.handledParamCount = count;
+		CleoInstance.OpcodeSystem.handledParamCount = count;
 
 		return result;
 	}
@@ -1701,7 +1701,7 @@ extern "C"
 
 	DWORD WINAPI CLEO_GetParamsHandledCount()
 	{
-		return GetInstance().OpcodeSystem.handledParamCount;
+		return CleoInstance.OpcodeSystem.handledParamCount;
 	}
 
 	void WINAPI CLEO_WriteStringOpcodeParam(CLEO::CRunningScript* thread, const char* str)
@@ -1780,7 +1780,7 @@ extern "C"
 			}
 		}
 
-		GetInstance().OpcodeSystem.handledParamCount += count;
+		CleoInstance.OpcodeSystem.handledParamCount += count;
 	}
 
 	void WINAPI CLEO_SkipUnusedVarArgs(CLEO::CRunningScript* thread)
@@ -1795,7 +1795,7 @@ extern "C"
 
 	void WINAPI CLEO_TerminateScript(CLEO::CRunningScript* thread)
 	{
-		GetInstance().ScriptEngine.RemoveScript(thread);
+		CleoInstance.ScriptEngine.RemoveScript(thread);
 	}
 
 	int WINAPI CLEO_GetOperandType(const CLEO::CRunningScript* thread)
@@ -1846,12 +1846,12 @@ extern "C"
 		if (fromThread) SetScriptCondResult(fromThread, cs && cs->IsOK());
 		if (cs && cs->IsOK())
 		{
-			GetInstance().ScriptEngine.AddCustomScript(cs);
+			CleoInstance.ScriptEngine.AddCustomScript(cs);
 			if (fromThread) TransmitScriptParams(fromThread, cs);
 
 			cs->SetDebugMode(fromThread ? 
 				reinterpret_cast<CCustomScript*>(fromThread)->GetDebugMode() : // from parent
-				GetInstance().ScriptEngine.NativeScriptsDebugMode); // global
+				CleoInstance.ScriptEngine.NativeScriptsDebugMode); // global
 		}
 		else
 		{
@@ -1866,17 +1866,17 @@ extern "C"
 
 	CLEO::CRunningScript* WINAPI CLEO_GetLastCreatedCustomScript()
 	{
-		return GetInstance().ScriptEngine.LastScriptCreated;
+		return CleoInstance.ScriptEngine.LastScriptCreated;
 	}
 
 	CLEO::CRunningScript* WINAPI CLEO_GetScriptByName(const char* threadName, BOOL standardScripts, BOOL customScripts, DWORD resultIndex)
 	{
-		return GetInstance().ScriptEngine.FindScriptNamed(threadName, standardScripts, customScripts, resultIndex);
+		return CleoInstance.ScriptEngine.FindScriptNamed(threadName, standardScripts, customScripts, resultIndex);
 	}
 
 	CLEO::CRunningScript* WINAPI CLEO_GetScriptByFilename(const char* path, DWORD resultIndex)
 	{
-		return GetInstance().ScriptEngine.FindScriptByFilename(path, resultIndex);
+		return CleoInstance.ScriptEngine.FindScriptByFilename(path, resultIndex);
 	}
 
 	void WINAPI CLEO_AddScriptDeleteDelegate(FuncScriptDeleteDelegateT func)
@@ -1901,7 +1901,7 @@ extern "C"
 
 	BOOL WINAPI CLEO_IsScriptRunning(const CLEO::CRunningScript* thread)
 	{
-		return GetInstance().ScriptEngine.IsActiveScriptPtr(thread);
+		return CleoInstance.ScriptEngine.IsActiveScriptPtr(thread);
 	}
 
 	void WINAPI CLEO_GetScriptInfoStr(CLEO::CRunningScript* thread, bool currLineInfo, char* buf, DWORD bufSize)
@@ -1921,8 +1921,8 @@ extern "C"
 
 	void WINAPI CLEO_GetScriptParamInfoStr(int idexOffset, char* buf, DWORD bufSize)
 	{
-		auto curr = idexOffset - 1 + GetInstance().OpcodeSystem.handledParamCount;
-		auto name = GetInstance().OpcodeInfoDb.GetArgumentName(GetInstance().OpcodeSystem.lastOpcode, curr);
+		auto curr = idexOffset - 1 + CleoInstance.OpcodeSystem.handledParamCount;
+		auto name = CleoInstance.OpcodeInfoDb.GetArgumentName(CleoInstance.OpcodeSystem.lastOpcode, curr);
 
 		curr++; // 1-based argument index display
 

--- a/source/CDebug.cpp
+++ b/source/CDebug.cpp
@@ -52,10 +52,9 @@ void CDebug::Trace(CLEO::eLogLevel level, const char* msg)
 #endif
 
     // output to callbacks
-    auto& cleo = GetInstance();
-    if (cleo.IsStarted())
+    if (CleoInstance.IsStarted())
     {
-        for (void* func : cleo.GetCallbacks(eCallbackId::Log))
+        for (void* func : CleoInstance.GetCallbacks(eCallbackId::Log))
         {
             typedef void WINAPI callback(eLogLevel, const char*);
             ((callback*)func)(level, stampEnd);

--- a/source/CDmaFix.cpp
+++ b/source/CDmaFix.cpp
@@ -9,7 +9,7 @@ namespace CLEO
     void CDmaFix::Inject(CCodeInjector& inj)
     {
         TRACE("Injecting DmaFix...");
-        CGameVersionManager& gvm = GetInstance().VersionManager;
+        CGameVersionManager& gvm = CleoInstance.VersionManager;
         switch (gvm.GetGameVersion())
         {
         case GV_EU10:

--- a/source/CGameMenu.cpp
+++ b/source/CGameMenu.cpp
@@ -24,7 +24,7 @@ namespace CLEO
 
     void __fastcall OnDrawMenuBackground(void *texture, int dummy, RwRect2D *rect, RwRGBA *color)
     {
-        GetInstance().Start(CCleoInstance::InitStage::OnDraw); // late initialization
+        CleoInstance.Start(CCleoInstance::InitStage::OnDraw); // late initialization
 
         CTexture_DrawInRect(texture, rect, color); // call original
 
@@ -47,8 +47,8 @@ namespace CLEO
         float posX = 25.0f * sizeX; // left margin
         float posY = RsGlobal.maximumHeight - 15.0f * sizeY; // bottom margin
 
-        auto cs_count = GetInstance().ScriptEngine.WorkingScriptsCount();
-        auto plugin_count = GetInstance().PluginSystem.GetNumPlugins();
+        auto cs_count = CleoInstance.ScriptEngine.WorkingScriptsCount();
+        auto plugin_count = CleoInstance.PluginSystem.GetNumPlugins();
         if (cs_count || plugin_count)
         {
             posY -= 15.0f * sizeY; // add space for bottom text
@@ -82,7 +82,7 @@ namespace CLEO
     void CGameMenu::Inject(CCodeInjector& inj)
     {
         TRACE("Injecting MenuStatusNotifier...");
-        CGameVersionManager& gvm = GetInstance().VersionManager;
+        CGameVersionManager& gvm = CleoInstance.VersionManager;
         MenuManager = gvm.TranslateMemoryAddress(MA_MENU_MANAGER);
 
         inj.MemoryReadOffset(gvm.TranslateMemoryAddress(MA_CALL_CTEXTURE_DRAW_BG_RECT).address + 1, CTexture__DrawInRect, true);

--- a/source/CScriptEngine.cpp
+++ b/source/CScriptEngine.cpp
@@ -83,7 +83,7 @@ namespace CLEO
             call FUNC_GetScriptParams
         }
 
-        GetInstance().OpcodeSystem.handledParamCount += count;
+        CleoInstance.OpcodeSystem.handledParamCount += count;
     }
 
     void __fastcall _TransmitScriptParams(CRunningScript *pScript, int dummy, CRunningScript *pScriptB)
@@ -105,7 +105,7 @@ namespace CLEO
             call FUNC_SetScriptParams
         }
 
-        GetInstance().OpcodeSystem.handledParamCount += count;
+        CleoInstance.OpcodeSystem.handledParamCount += count;
     }
 
     void __fastcall _SetScriptCondResult(CRunningScript *pScript, int dummy, int val)
@@ -161,7 +161,7 @@ namespace CLEO
         }
         else if (paramType == DT_VARLEN_STRING)
         {
-            GetInstance().OpcodeSystem.handledParamCount++;
+            CleoInstance.OpcodeSystem.handledParamCount++;
             thread->IncPtr(1); // already processed paramType
 
             DWORD length = *thread->GetBytePointer(); // as unsigned byte!
@@ -183,7 +183,7 @@ namespace CLEO
             {
                 case DT_TEXTLABEL:
                 {
-                    GetInstance().OpcodeSystem.handledParamCount++;
+                    CleoInstance.OpcodeSystem.handledParamCount++;
                     memcpy(buff, str, min(buffLen, 8));
                     thread->IncPtr(8); // text data
                     return buff;
@@ -191,7 +191,7 @@ namespace CLEO
 
                 case DT_STRING:
                 {
-                    GetInstance().OpcodeSystem.handledParamCount++;
+                    CleoInstance.OpcodeSystem.handledParamCount++;
                     memcpy(buff, str, min(buffLen, 16));
                     thread->IncPtr(16); // ext data
                     return buff;
@@ -237,7 +237,7 @@ namespace CLEO
     SCRIPT_VAR* GetScriptParamPointer(CRunningScript* thread)
     {
         SCRIPT_VAR* ptr = GetScriptParamPointer2(thread, 0);
-        GetInstance().OpcodeSystem.handledParamCount++; // TODO: hook game's GetScriptParamPointer1 and GetScriptParamPointer2 procedures so this is always incremented
+        CleoInstance.OpcodeSystem.handledParamCount++; // TODO: hook game's GetScriptParamPointer1 and GetScriptParamPointer2 procedures so this is always incremented
         return ptr;
     }
 
@@ -270,7 +270,7 @@ namespace CLEO
 
         LPCSTR WINAPI CLEO_GetScriptFilename(const CRunningScript* thread)
         {
-            if (!GetInstance().ScriptEngine.IsValidScriptPtr(thread))
+            if (!CleoInstance.ScriptEngine.IsValidScriptPtr(thread))
             {
                 return nullptr;
             }
@@ -319,10 +319,10 @@ namespace CLEO
     void OnSaveScmData(void)
     {
         TRACE("Saving scripts save data...");
-        GetInstance().ScriptEngine.SaveState();
-        GetInstance().ScriptEngine.UnregisterAllScripts();
+        CleoInstance.ScriptEngine.SaveState();
+        CleoInstance.ScriptEngine.UnregisterAllScripts();
         SaveScmData();
-        GetInstance().ScriptEngine.ReregisterAllScripts();
+        CleoInstance.ScriptEngine.ReregisterAllScripts();
     }
 
     struct CleoSafeHeader
@@ -402,11 +402,11 @@ namespace CLEO
 
     void __fastcall HOOK_ProcessScript(CCustomScript * pScript, int)
     {
-        GetInstance().ScriptEngine.GameBegin(); // all initialized and ready to process scripts
+        CleoInstance.ScriptEngine.GameBegin(); // all initialized and ready to process scripts
 
         // run registered callbacks
         bool process = true;
-        for (void* func : GetInstance().GetCallbacks(eCallbackId::ScriptProcess))
+        for (void* func : CleoInstance.GetCallbacks(eCallbackId::ScriptProcess))
         {
             typedef bool WINAPI callback(CRunningScript*);
             process = process && ((callback*)func)(pScript);
@@ -422,7 +422,7 @@ namespace CLEO
 
     void HOOK_DrawScriptStuff(char bBeforeFade)
     {
-        GetInstance().ScriptEngine.DrawScriptStuff(bBeforeFade);
+        CleoInstance.ScriptEngine.DrawScriptStuff(bBeforeFade);
 
         if(bBeforeFade)
             DrawScriptStuff_H(bBeforeFade);
@@ -430,7 +430,7 @@ namespace CLEO
             DrawScriptStuff(bBeforeFade);
 
         // run registered callbacks
-        for (void* func : GetInstance().GetCallbacks(eCallbackId::ScriptDraw))
+        for (void* func : CleoInstance.GetCallbacks(eCallbackId::ScriptDraw))
         {
             typedef void WINAPI callback(bool);
             ((callback*)func)(bBeforeFade != 0);
@@ -581,7 +581,7 @@ namespace CLEO
     bool CCustomScript::GetDebugMode() const
     {
         if (!bIsCustom)
-            return GetInstance().ScriptEngine.NativeScriptsDebugMode;
+            return CleoInstance.ScriptEngine.NativeScriptsDebugMode;
 
         return bDebugMode;
     }
@@ -589,7 +589,7 @@ namespace CLEO
     void CCustomScript::SetDebugMode(bool enabled)
     {
         if (!bIsCustom)
-            GetInstance().ScriptEngine.NativeScriptsDebugMode = enabled;
+            CleoInstance.ScriptEngine.NativeScriptsDebugMode = enabled;
         else
             bDebugMode = enabled;
     }
@@ -597,7 +597,7 @@ namespace CLEO
     const char* CCustomScript::GetScriptFileDir() const
     {
         if(!bIsCustom)
-            return GetInstance().ScriptEngine.MainScriptFileDir.c_str();
+            return CleoInstance.ScriptEngine.MainScriptFileDir.c_str();
 
         return scriptFileDir.c_str();
     }
@@ -605,7 +605,7 @@ namespace CLEO
     void CCustomScript::SetScriptFileDir(const char* directory)
     {
         if (!bIsCustom)
-            GetInstance().ScriptEngine.MainScriptFileDir = directory;
+            CleoInstance.ScriptEngine.MainScriptFileDir = directory;
         else
             scriptFileDir = directory;
     }
@@ -613,7 +613,7 @@ namespace CLEO
     const char* CCustomScript::GetScriptFileName() const 
     {
         if (!bIsCustom)
-            return GetInstance().ScriptEngine.MainScriptFileName.c_str();
+            return CleoInstance.ScriptEngine.MainScriptFileName.c_str();
 
         return scriptFileName.c_str();
     }
@@ -621,7 +621,7 @@ namespace CLEO
     void CCustomScript::SetScriptFileName(const char* filename) 
     {
         if (!bIsCustom)
-            GetInstance().ScriptEngine.MainScriptFileName = filename;
+            CleoInstance.ScriptEngine.MainScriptFileName = filename;
         else
             scriptFileName = filename;
     }
@@ -637,7 +637,7 @@ namespace CLEO
     const char* CCustomScript::GetWorkDir() const
     {
         if (!bIsCustom)
-            return GetInstance().ScriptEngine.MainScriptCurWorkDir.c_str();
+            return CleoInstance.ScriptEngine.MainScriptCurWorkDir.c_str();
 
         return workDir.c_str(); 
     }
@@ -650,7 +650,7 @@ namespace CLEO
         auto resolved = ResolvePath(directory);
 
         if (!bIsCustom)
-            GetInstance().ScriptEngine.MainScriptCurWorkDir = resolved;
+            CleoInstance.ScriptEngine.MainScriptCurWorkDir = resolved;
         else
             workDir = resolved;
     }
@@ -770,7 +770,7 @@ namespace CLEO
                 ss << " - ";
                 ss << std::hex << std::uppercase << std::setw(4) << std::setfill('0') << CCustomOpcodeSystem::lastOpcode;
 
-                auto commandName = GetInstance().OpcodeInfoDb.GetCommandName(CCustomOpcodeSystem::lastOpcode);
+                auto commandName = CleoInstance.OpcodeInfoDb.GetCommandName(CCustomOpcodeSystem::lastOpcode);
                 if (commandName != nullptr)
                 {
                     ss << ": " << commandName;
@@ -836,7 +836,7 @@ namespace CLEO
     void CScriptEngine::Inject(CCodeInjector& inj)
     {
         TRACE("Injecting ScriptEngine...");
-        CGameVersionManager& gvm = GetInstance().VersionManager;
+        CGameVersionManager& gvm = CleoInstance.VersionManager;
 
         // Global Events crashfix
         //inj.MemoryWrite(0xA9AF6C, 0, 4);
@@ -939,8 +939,8 @@ namespace CLEO
         NativeScriptsDebugMode = GetPrivateProfileInt("General", "DebugMode", 0, Filepath_Config.c_str()) != 0;
         MainScriptCurWorkDir = Filepath_Game;
 
-        GetInstance().ModuleSystem.LoadCleoModules();
-        LoadState(GetInstance().saveSlot);
+        CleoInstance.ModuleSystem.LoadCleoModules();
+        LoadState(CleoInstance.saveSlot);
         LoadCustomScripts();
     }
 
@@ -950,7 +950,7 @@ namespace CLEO
         gameInProgress = false;
 
         RemoveAllCustomScripts();
-        GetInstance().ModuleSystem.Clear();
+        CleoInstance.ModuleSystem.Clear();
         memset(CleoVariables, 0, sizeof(CleoVariables));
     }
 
@@ -1121,7 +1121,7 @@ namespace CLEO
             CleoSafeHeader header = { CleoSafeHeader::sign, savedThreads.size(), InactiveScriptHashes.size() };
 
             // steam offset is different, so get it manually for now
-            CGameVersionManager& gvm = GetInstance().VersionManager;
+            CGameVersionManager& gvm = CleoInstance.VersionManager;
             int nSlot = gvm.GetGameVersion() != GV_STEAM ? *(BYTE*)&MenuManager->m_nSelectedSaveGame : *((BYTE*)MenuManager + 0x15B);
 
             char safe_name[MAX_PATH];
@@ -1318,7 +1318,7 @@ namespace CLEO
         cs->SetActive(true);
 
         // run registered callbacks
-        for (void* func : GetInstance().GetCallbacks(eCallbackId::ScriptRegister))
+        for (void* func : CleoInstance.GetCallbacks(eCallbackId::ScriptRegister))
         {
             typedef void WINAPI callback(CCustomScript*);
             ((callback*)func)(cs);
@@ -1344,7 +1344,7 @@ namespace CLEO
     void CScriptEngine::RemoveCustomScript(CCustomScript *cs)
     {
         // run registered callbacks
-        for (void* func : GetInstance().GetCallbacks(eCallbackId::ScriptUnregister))
+        for (void* func : CleoInstance.GetCallbacks(eCallbackId::ScriptUnregister))
         {
             typedef void WINAPI callback(CCustomScript*);
             ((callback*)func)(cs);
@@ -1554,7 +1554,7 @@ namespace CLEO
                 }
                 else
                 {
-                    bDebugMode = GetInstance().ScriptEngine.NativeScriptsDebugMode; // global setting
+                    bDebugMode = CleoInstance.ScriptEngine.NativeScriptsDebugMode; // global setting
                     workDir = Filepath_Game; // game root
                 }
 
@@ -1596,7 +1596,7 @@ namespace CLEO
                     memcpy(Name, fName.c_str(), len);
                 }
             }
-            GetInstance().ScriptEngine.LastScriptCreated = this;
+            CleoInstance.ScriptEngine.LastScriptCreated = this;
             bOK = true;
         }
         catch (std::exception& e)
@@ -1614,7 +1614,7 @@ namespace CLEO
         if (BaseIP && !bIsMission) delete[] BaseIP;
         RunScriptDeleteDelegate(reinterpret_cast<CRunningScript*>(this));
 
-        if (GetInstance().ScriptEngine.LastScriptCreated == this) GetInstance().ScriptEngine.LastScriptCreated = nullptr;
+        if (CleoInstance.ScriptEngine.LastScriptCreated == this) CleoInstance.ScriptEngine.LastScriptCreated = nullptr;
     }
 
     float VectorSqrMagnitude(CVector vector) { return vector.x * vector.x + vector.y * vector.y + vector.z * vector.z; }

--- a/source/CleoBase.h
+++ b/source/CleoBase.h
@@ -56,8 +56,6 @@ namespace CLEO
         void CallCallbacks(eCallbackId id);
         void CallCallbacks(eCallbackId id, DWORD arg);
 
-        static void __cdecl OnDrawingFinished();
-
         void(__cdecl * UpdateGameLogics)() = nullptr;
         static void __cdecl OnUpdateGameLogics();
 
@@ -90,7 +88,7 @@ namespace CLEO
         static void OnGameRestart3();
 
         // empty function called after everything else is drawn
-        memory_pointer DebugDisplayTextBuffer = nullptr;
+        void* DebugDisplayTextBuffer_Orig = nullptr;
         static void OnDebugDisplayTextBuffer();
 
     private:
@@ -99,6 +97,6 @@ namespace CLEO
         std::map<eCallbackId, std::set<void*>> m_callbacks;
     };
 
-    CCleoInstance& GetInstance();
+    extern CCleoInstance CleoInstance;
 }
 

--- a/source/dllmain.cpp
+++ b/source/dllmain.cpp
@@ -7,7 +7,7 @@ class Starter
     static Starter dummy;
     Starter()
     {
-        auto gv = CLEO::GetInstance().VersionManager.GetGameVersion();
+        auto gv = CLEO::CleoInstance.VersionManager.GetGameVersion();
         TRACE("Started on game of version: %s",
             (gv == CLEO::GV_US10) ? "SA 1.0 us" :
             (gv == CLEO::GV_EU11) ? "SA 1.01 eu" :
@@ -31,12 +31,12 @@ class Starter
                 " 10) gta_sa.exe, decrypted 3.0 steam executable, 5 697 536 bytes."
             );
 
-        CLEO::GetInstance().Start(CLEO::CCleoInstance::InitStage::Initial);
+        CLEO::CleoInstance.Start(CLEO::CCleoInstance::InitStage::Initial);
     }
 
     ~Starter()
     {
-        CLEO::GetInstance().Stop();
+        CLEO::CleoInstance.Stop();
     }
 };
 


### PR DESCRIPTION
Fixed use of GetInstance() and memory_pointer class use inside cdecl naked function causing exception
Removed GetInstance() in favor of just using CleoInstance.