### PR TITLE
Cleo log improvements

### DIFF
--- a/CLEO5.vcxproj
+++ b/CLEO5.vcxproj
@@ -72,6 +72,9 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="$(PLUGIN_SDK_DIR)\plugin_sa\game_sa\CTimer.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="third-party\simdjson\simdjson.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>

--- a/cleo_plugins/Text/CTextManager.cpp
+++ b/cleo_plugins/Text/CTextManager.cpp
@@ -106,11 +106,11 @@ namespace CLEO
             {
                 std::ifstream stream(list.strings[i]);
                 auto result = ParseFxtFile(stream);
-                TRACE("Added %d new FXT entries from file '%s'", result, list.strings[i]);
+                TRACE(" Added %d new FXT entries from file '%s'", result, list.strings[i]);
             }
             catch (std::exception& ex)
             {
-                LOG_WARNING(0, "Loading of FXT file '%s' failed: \n%s", list.strings[i], ex.what());
+                LOG_WARNING(0, " Loading of FXT file '%s' failed: \n%s", list.strings[i], ex.what());
             }
         }
         CLEO::CLEO_StringListFree(list);

--- a/cleo_plugins/Text/CTextManager.cpp
+++ b/cleo_plugins/Text/CTextManager.cpp
@@ -80,6 +80,7 @@ namespace CLEO
 
     CTextManager::~CTextManager()
     {
+        TRACE(""); // separator
         TRACE("Deleting FXTs...");
         size_t count = 0;
         for (auto it = fxts.begin(); it != fxts.end();)

--- a/cleo_sdk/CLEO_Utils.h
+++ b/cleo_sdk/CLEO_Utils.h
@@ -117,6 +117,39 @@ namespace CLEO
         }
     }
 
+    // erase GTA's text formatting sequences like ~r~
+    static void StringRemoveFormatting(std::string& str)
+    {
+        size_t pos = 0;
+        while (true)
+        {
+            pos = str.find('~', pos);
+            if (pos == std::string::npos || 
+                (pos + 2) >= str.length()) // not enought characters left for formatting sequence
+            {
+                break;
+            }
+
+            if (str[pos + 2] != '~')
+            {
+                pos++;
+                continue;
+            }
+
+            switch (str[pos + 1])
+            {
+                case 'n':
+                case 'N':
+                    str.replace(pos, 3, "\n");
+                    break;
+                
+                default:
+                    str.erase(pos, 3);
+                    break;
+            }
+        }
+    }
+
     static std::string ScriptInfoStr(CLEO::CRunningScript* thread)
     {
         std::string info(1024, '\0');

--- a/source/CCodeInjector.cpp
+++ b/source/CCodeInjector.cpp
@@ -9,6 +9,9 @@ namespace CLEO
     {
         if (bAccessOpen) return;
 
+        TRACE(""); // separator
+        TRACE("Opening memory access...");
+
         auto dwLoadOffset = static_cast<memory_pointer>(GetModuleHandle(nullptr));
 
         // Unprotect image - make .text and .rdata section writeable
@@ -22,7 +25,7 @@ namespace CLEO
             if (!strcmp((char*)pSection->Name, ".text") || !strcmp((char*)pSection->Name, ".rdata"))
             {
                 DWORD dwPhysSize = (pSection->Misc.VirtualSize + 4095) & ~4095;
-                TRACE("Unprotecting memory region '%s': 0x%08X (size: 0x%08X)",
+                TRACE(" Unprotecting memory region '%s': 0x%08X (size: 0x%08X)",
                     pSection->Name,
                     (DWORD)pSection->VirtualAddress,
                     (DWORD)dwPhysSize
@@ -32,6 +35,7 @@ namespace CLEO
                     SHOW_ERROR("Virtual protect error");
             }
         }
+        TRACE(""); // separator
 
         bAccessOpen = true;
     }

--- a/source/CCustomOpcodeSystem.cpp
+++ b/source/CCustomOpcodeSystem.cpp
@@ -88,11 +88,11 @@ namespace CLEO
 	void(__cdecl * SpawnCar)(DWORD);
 
 	CRunningScript* CCustomOpcodeSystem::lastScript = nullptr;
-	WORD CCustomOpcodeSystem::lastOpcode = 0;
+	WORD CCustomOpcodeSystem::lastOpcode = 0xFFFF;
 	WORD* CCustomOpcodeSystem::lastOpcodePtr = nullptr;
 	WORD CCustomOpcodeSystem::lastCustomOpcode = 0;
 	std::string CCustomOpcodeSystem::lastErrorMsg = {};
-	WORD CCustomOpcodeSystem::prevOpcode = 0;
+	WORD CCustomOpcodeSystem::prevOpcode = 0xFFFF;
 	BYTE CCustomOpcodeSystem::handledParamCount = 0;
 
 	// opcode handler for custom opcodes

--- a/source/CDebug.cpp
+++ b/source/CDebug.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 #include "CDebug.h"
 #include "CleoBase.h"
+#include "CTimer.h"
 #include <shellapi.h>
 
 CDebug Debug;
@@ -21,6 +22,15 @@ void CDebug::Trace(CLEO::eLogLevel level, const char* msg)
 
     sprintf(szBuf, "%02d/%02d/%04d %02d:%02d:%02d.%03d ", t.wDay, t.wMonth, t.wYear, t.wHour, t.wMinute, t.wSecond, t.wMilliseconds);
     char* stampEnd = szBuf + strlen(szBuf);
+
+    // add separator line if frame rendered since last log entry
+    if (lastFrame != CTimer::m_FrameCounter)
+    {
+        if (m_hFile.good())
+            m_hFile << szBuf << std::endl;
+
+        lastFrame = CTimer::m_FrameCounter;
+    }
 
     strcpy(stampEnd, msg);
 

--- a/source/CDebug.cpp
+++ b/source/CDebug.cpp
@@ -44,7 +44,7 @@ void CDebug::Trace(CLEO::eLogLevel level, const char* msg)
         // add separator line if frame rendered since last log entry
         if (lastFrame != CTimer::m_FrameCounter)
         {
-            m_hFile << timestampStr << std::endl;
+            m_hFile << std::endl << timestampStr;
             lastFrame = CTimer::m_FrameCounter;
         }
 

--- a/source/CDebug.h
+++ b/source/CDebug.h
@@ -18,6 +18,8 @@ public:
 #else
         CLEO::Trace(CLEO::eLogLevel::Default, "CLEO v%s", CLEO_VERSION_STR);
 #endif
+
+        std::remove("cleo.log"); // delete CLEO 4 log file if present
     }
 
     ~CDebug()

--- a/source/CDebug.h
+++ b/source/CDebug.h
@@ -29,6 +29,7 @@ public:
     void Trace(CLEO::eLogLevel level, const char* msg);
     
 private:
+    unsigned int lastFrame = -1;
     std::mutex mutex;
     std::ofstream m_hFile;
  };

--- a/source/CDebug.h
+++ b/source/CDebug.h
@@ -18,8 +18,6 @@ public:
 #else
         CLEO::Trace(CLEO::eLogLevel::Default, "CLEO v%s", CLEO_VERSION_STR);
 #endif
-
-        std::remove("cleo.log"); // delete CLEO 4 log file if present
     }
 
     ~CDebug()

--- a/source/CScriptEngine.cpp
+++ b/source/CScriptEngine.cpp
@@ -1404,14 +1404,14 @@ namespace CLEO
 
         std::for_each(ScriptsWaitingForDelete.begin(), ScriptsWaitingForDelete.end(), [this](CCustomScript *cs) 
         {
-            TRACE("Deleting inactive script named '%s'", cs->GetName().c_str());
+            TRACE(" Deleting inactive script named '%s'", cs->GetName().c_str());
             delete cs;
         });
         ScriptsWaitingForDelete.clear();
 
         if (CustomMission)
         {
-            TRACE("Unregistering custom mission named '%s'", CustomMission->GetName().c_str());
+            TRACE(" Unregistering custom mission named '%s'", CustomMission->GetName().c_str());
             RemoveScriptFromQueue(CustomMission, activeThreadQueue);
             CustomMission->SetActive(false);
             delete CustomMission;

--- a/source/CScriptEngine.cpp
+++ b/source/CScriptEngine.cpp
@@ -1075,6 +1075,7 @@ namespace CLEO
         // load cleo saving file
         try
         {
+            TRACE(""); // separator
             TRACE("Loading cleo safe '%s'", saveFile.c_str());
             std::ifstream ss(saveFile.c_str(), std::ios::binary);
             if (ss.is_open())

--- a/source/CleoBase.cpp
+++ b/source/CleoBase.cpp
@@ -188,7 +188,6 @@ namespace CLEO
 
         saveSlot = MenuManager->m_bWantToLoad ? MenuManager->m_nSelectedSaveGame : -1;
 
-        TRACE(""); // separator
         TRACE("Starting new game, save slot: %d", saveSlot);
 
         // execute registered callbacks
@@ -200,7 +199,6 @@ namespace CLEO
         if (!m_bGameInProgress) return;
         m_bGameInProgress = false;
 
-        TRACE(""); // separator
         TRACE("Ending current game");
         GetInstance().CallCallbacks(eCallbackId::GameEnd); // execute registered callbacks
         ScriptEngine.GameEnd();


### PR DESCRIPTION
Automatic adding separator line to .cleo.log if frame render occur since last log entry.
Removed outputting text formatting sequences like `~r~` to log file. Logging `~n~` as actual new line.
Logging last and previous opcodes as FFFF if no script was executed.