### PR TITLE
Fix BASS_StreamFree called twice for 3d audio streams.

### DIFF
--- a/cleo_plugins/Audio/C3DAudioStream.cpp
+++ b/cleo_plugins/Audio/C3DAudioStream.cpp
@@ -27,11 +27,6 @@ C3DAudioStream::C3DAudioStream(const char* filepath) : CAudioStream()
     ok = true;
 }
 
-C3DAudioStream::~C3DAudioStream()
-{
-    if (streamInternal) BASS_StreamFree(streamInternal);
-}
-
 void C3DAudioStream::Set3dPosition(const CVector& pos)
 {
     link = nullptr;

--- a/cleo_plugins/Audio/C3DAudioStream.h
+++ b/cleo_plugins/Audio/C3DAudioStream.h
@@ -7,7 +7,6 @@ namespace CLEO
     {
     public:
         C3DAudioStream(const char* filepath);
-        virtual ~C3DAudioStream();
 
         // overloaded actions
         virtual void Set3dPosition(const CVector& pos);

--- a/cleo_plugins/Audio/CSoundSystem.cpp
+++ b/cleo_plugins/Audio/CSoundSystem.cpp
@@ -20,7 +20,6 @@ namespace CLEO
 
     void EnumerateBassDevices(int& total, int& enabled, int& default_device)
     {
-        TRACE(""); // separator
         TRACE("Listing audio devices:");
 
         BASS_DEVICEINFO info;
@@ -62,6 +61,16 @@ namespace CLEO
     bool CSoundSystem::Init()
     {
         if (initialized) return true; // already done
+
+        TRACE(""); // separator
+        TRACE("Initializing SoundSystem...");
+
+        auto ver = HIWORD(BASS_GetVersion());
+        TRACE("BASS library version is %d (required %d or newer)", ver, BASSVERSION);
+        if (ver < BASSVERSION)
+        {
+            SHOW_ERROR("Invalid BASS library version! Expected at least %d, found %d.", BASSVERSION, ver);
+        }
 
         auto config = GetConfigFilename();
         LegacyModeDefaultStreamType = (eStreamType)GetPrivateProfileInt("General", "LegacyModeDefaultStreamType", 0, config.c_str());


### PR DESCRIPTION
Parent class destructor was doing exactly same thing.
Added BASS version check and logging.