### PR TITLE
Fix CLEO not loading with UAL

### DIFF
--- a/cleo_sdk/CLEO_Utils.h
+++ b/cleo_sdk/CLEO_Utils.h
@@ -162,6 +162,19 @@ namespace CLEO
         path.replace(0, base.length() + 1, ""); // remove path separator too if present
     }
 
+    // get path without last file/directory element
+    static const std::string_view FilepathGetParent(const std::string_view str)
+    {
+        auto separatorPos = str.find_last_of('\\');
+
+        if (separatorPos == std::string::npos)
+        {
+            return {};
+        }
+
+        return std::string_view(str.data(), separatorPos);
+    }
+
     // this plugin's config file
     static std::string GetConfigFilename()
     {

--- a/source/stdafx.h
+++ b/source/stdafx.h
@@ -36,16 +36,11 @@ namespace FS = std::filesystem;
 
 static std::string GetGameDirectory() // already stored in Filepath_Game
 {
-    static const auto GTA_GetCWD = (char* (__cdecl*)(char*, int))0x00836E91; // SA 1.0 US ingame function
-
     std::string path;
-
     path.resize(MAX_PATH);
-    GTA_GetCWD(path.data(), path.size()); // assume work dir is game location when initialized
-    path.resize(strlen(path.data()));
-
+    GetModuleFileNameA(NULL, path.data(), path.size()); // game exe absolute path
+    path.resize(CLEO::FilepathGetParent(path).length());
     CLEO::FilepathNormalize(path);
-
     return std::move(path);
 }
 


### PR DESCRIPTION
When CLEO is loaded earlier with UAL game's get current work dir function is not available yet.