### PR TITLE
Fix 0AB2 return params in legacy scripts.

### DIFF
--- a/source/CCustomOpcodeSystem.cpp
+++ b/source/CCustomOpcodeSystem.cpp
@@ -1120,7 +1120,7 @@ namespace CLEO
 			returnParamCount = declaredParamCount;
 		}
 
-		return GetInstance().OpcodeSystem.CleoReturnGeneric(0x0AB2, thread, !IsLegacyScript(thread), returnParamCount);
+		return GetInstance().OpcodeSystem.CleoReturnGeneric(0x0AB2, thread, true, returnParamCount, !IsLegacyScript(thread));
 	}
 
 	//0AB3=2,set_cleo_shared_var %1d% = %2d%


### PR DESCRIPTION
Function signature is
```CleoReturnGeneric(opcode, thread, returnArgs, returnArgCount, strictArgCount)```