### PR TITLE
Clear screen log on new game start

### DIFF
--- a/cleo_plugins/DebugUtils/DebugUtils.cpp
+++ b/cleo_plugins/DebugUtils/DebugUtils.cpp
@@ -60,6 +60,7 @@ public:
         }
 
         // register event callbacks
+        CLEO_RegisterCallback(eCallbackId::GameBegin, OnGameBegin);
         CLEO_RegisterCallback(eCallbackId::Log, OnLog);
         CLEO_RegisterCallback(eCallbackId::DrawingFinished, OnDrawingFinished);
         CLEO_RegisterCallback(eCallbackId::ScriptProcess, OnScriptProcess);
@@ -68,6 +69,7 @@ public:
 
     ~DebugUtils()
     {
+        CLEO_UnregisterCallback(eCallbackId::GameBegin, OnGameBegin);
         CLEO_UnregisterCallback(eCallbackId::Log, OnLog);
         CLEO_UnregisterCallback(eCallbackId::DrawingFinished, OnDrawingFinished);
         CLEO_UnregisterCallback(eCallbackId::ScriptProcess, OnScriptProcess);
@@ -75,6 +77,11 @@ public:
     }
 
     // ---------------------------------------------- event callbacks -------------------------------------------------
+
+    static void WINAPI OnGameBegin(DWORD saveSlot)
+    {
+        screenLog.Clear();
+    }
 
     static void WINAPI OnScriptsFinalize()
     {

--- a/cleo_plugins/DebugUtils/ScreenLog.cpp
+++ b/cleo_plugins/DebugUtils/ScreenLog.cpp
@@ -73,6 +73,11 @@ void ScreenLog::Add(eLogLevel level, const char* msg)
     }
 }
 
+void ScreenLog::Clear()
+{
+    entries.clear();
+}
+
 void ScreenLog::Draw()
 {
     // scroll animation

--- a/cleo_plugins/DebugUtils/ScreenLog.h
+++ b/cleo_plugins/DebugUtils/ScreenLog.h
@@ -16,6 +16,7 @@ public:
 
     void Init();
     void Add(eLogLevel level, const char* msg);
+    void Clear();
     void Draw();
     void DrawLine(const char* msg, size_t row = 0);
 


### PR DESCRIPTION
Do not show log messages from previous game session in new session.