### PR TITLE
Flashing of debug break message.

### DIFF
--- a/cleo_plugins/DebugUtils/DebugUtils.cpp
+++ b/cleo_plugins/DebugUtils/DebugUtils.cpp
@@ -97,7 +97,8 @@ public:
         screenLog.Draw();
 
         // draw active breakpoints list
-        if(!pausedScripts.empty())
+        if (!pausedScripts.empty() &&
+            (CTimer::m_FrameCounter & 0xE) != 0) // flashing
         {
             for (size_t i = 0; i < pausedScripts.size(); i++)
             {


### PR DESCRIPTION
Make script break point message flashing, so it does not look like game froze.