### PR TITLE
Fix INI write opcodes inverted condition result.

### DIFF
--- a/cleo_plugins/IniFiles/IniFiles.cpp
+++ b/cleo_plugins/IniFiles/IniFiles.cpp
@@ -59,7 +59,7 @@ public:
 
 		char strValue[32];
 		_itoa(value, strValue, 10);
-		auto result = WritePrivateProfileString(section, key, strValue, path);
+		auto result = WritePrivateProfileString(section, key, strValue, path) != 0;
 
 		OPCODE_CONDITION_RESULT(result);
 		return OR_CONTINUE;
@@ -104,7 +104,7 @@ public:
 
 		char strValue[32];
 		sprintf(strValue, "%g", value);
-		auto result = WritePrivateProfileString(section, key, strValue, path);
+		auto result = WritePrivateProfileString(section, key, strValue, path) != 0;
 
 		OPCODE_CONDITION_RESULT(result);
 		return OR_CONTINUE;
@@ -145,7 +145,7 @@ public:
 		OPCODE_READ_PARAM_STRING(section);
 		OPCODE_READ_PARAM_STRING(key);
 
-		auto result = WritePrivateProfileString(section, key, strValue, path);
+		auto result = WritePrivateProfileString(section, key, strValue, path) != 0;
 
 		OPCODE_CONDITION_RESULT(result);
 		return OR_CONTINUE;


### PR DESCRIPTION
```BOOL WritePrivateProfileStringA```
"If the function successfully copies the string to the initialization file, the return value is nonzero."