### PR TITLE
Filepaths double separators handling

### DIFF
--- a/cleo_sdk/CLEO_Utils.h
+++ b/cleo_sdk/CLEO_Utils.h
@@ -130,6 +130,14 @@ namespace CLEO
         if (path.empty()) return;
 
         std::replace(path.begin(), path.end(), '/', '\\');
+
+        // remove doubled separators
+        size_t pos;
+        while ((pos = path.find("\\\\")) != std::string::npos)
+        {
+            path.erase(pos, 1);
+        }
+
         if (normalizeCase) std::transform(path.begin(), path.end(), path.begin(), [](unsigned char c) { return tolower(c); }); // to lower case
 
         // collapse references to parent directory

--- a/tests/cleo_tests/FilesystemOperations/0A9A.txt
+++ b/tests/cleo_tests/FilesystemOperations/0A9A.txt
@@ -13,13 +13,13 @@ function tests
     return
     
     function test1
-        0@ = open_file "cleo\\not_a_file.txt" {mode} "r" // tested opcode
+        0@ = open_file "cleo\not_a_file.txt" {mode} "r" // tested opcode
         assert_result_false()
     end
     
      function test2
         if
-            0@ = open_file "cleo\\.cleo_config.ini" {mode} "r" // tested opcode
+            0@ = open_file "cleo\.cleo_config.ini" {mode} "r" // tested opcode
         then
             assert(true)
             close_file 0@

--- a/tests/cleo_tests/FilesystemOperations/0AAB.txt
+++ b/tests/cleo_tests/FilesystemOperations/0AAB.txt
@@ -13,12 +13,12 @@ function tests
     return
     
     function test1
-        does_file_exist {path} "cleo\\not_a_file.txt" // tested opcode
+        does_file_exist {path} "cleo\not_a_file.txt" // tested opcode
         assert_result_false()
     end
     
      function test2
-        does_file_exist {path} "cleo\\.cleo_config.ini" // tested opcode
+        does_file_exist {path} "cleo\.cleo_config.ini" // tested opcode
         assert_result_true()
     end
 

--- a/tests/cleo_tests/FilesystemOperations/0AE4.txt
+++ b/tests/cleo_tests/FilesystemOperations/0AE4.txt
@@ -13,12 +13,12 @@ function tests
     return
     
     function test1
-        does_directory_exist {path} "cleo\\not_a_directory" // tested opcode
+        does_directory_exist {path} "cleo\not_a_directory" // tested opcode
         assert_result_false()
     end
     
      function test2
-        does_directory_exist {path} "cleo\\cleo_tests" // tested opcode
+        does_directory_exist {path} "cleo\cleo_tests" // tested opcode
         assert_result_true()
     end
 

--- a/tests/cleo_tests/FilesystemOperations/0AE5.txt
+++ b/tests/cleo_tests/FilesystemOperations/0AE5.txt
@@ -6,7 +6,7 @@ test("0AE5 (create_directory)", tests)
 terminate_this_custom_script
 
 
-const Test_Path = "cleo\\cleo_test_directory"
+const Test_Path = "cleo\cleo_test_directory"
 
 function tests
     before_each(@cleanup)

--- a/tests/cleo_tests/FilesystemOperations/0B00.txt
+++ b/tests/cleo_tests/FilesystemOperations/0B00.txt
@@ -6,7 +6,7 @@ test("0B00 (delete_file)", tests)
 terminate_this_custom_script
 
 
-const Test_Path = "cleo\\cleo_test_file.ini"
+const Test_Path = "cleo\cleo_test_file.ini"
 
 function tests
     before_each(@cleanup)
@@ -21,7 +21,7 @@ function tests
     return
     
     function test1
-        delete_file {path} "cleo\\not_a_file.ini" // tested opcode
+        delete_file {path} "cleo\not_a_file.ini" // tested opcode
         assert_result_false()
     end
     

--- a/tests/cleo_tests/FilesystemOperations/0B01.txt
+++ b/tests/cleo_tests/FilesystemOperations/0B01.txt
@@ -6,7 +6,7 @@ test("0B01 (delete_directory)", tests)
 terminate_this_custom_script
 
 
-const Test_Path = "cleo\\cleo_test_directory"
+const Test_Path = "cleo\cleo_test_directory"
 
 function tests
     before_each(@cleanup)

--- a/tests/cleo_tests/FilesystemOperations/0B02.txt
+++ b/tests/cleo_tests/FilesystemOperations/0B02.txt
@@ -6,7 +6,7 @@ test("0B02 (move_file)", tests)
 terminate_this_custom_script
 
 
-const Test_Path_Src = "cleo\\cleo_test_file.ini"
+const Test_Path_Src = "cleo\cleo_test_file.ini"
 const Test_Path_Dst = "_test_file_B.ini"
 
 function tests

--- a/tests/cleo_tests/FilesystemOperations/0B03.txt
+++ b/tests/cleo_tests/FilesystemOperations/0B03.txt
@@ -6,7 +6,7 @@ test("0B03 (move_directory)", tests)
 terminate_this_custom_script
 
 
-const Test_Path_Src = "cleo\\cleo_test_dir"
+const Test_Path_Src = "cleo\cleo_test_dir"
 const Test_Path_Dst = "test_directory"
 
 function tests

--- a/tests/cleo_tests/FilesystemOperations/0B04.txt
+++ b/tests/cleo_tests/FilesystemOperations/0B04.txt
@@ -6,7 +6,7 @@ test("0B04 (copy_file)", tests)
 terminate_this_custom_script
 
 
-const Test_Path_Src = "cleo\\cleo_test_file.ini"
+const Test_Path_Src = "cleo\cleo_test_file.ini"
 const Test_Path_Dst = "_test_file_B.ini"
 
 function tests

--- a/tests/cleo_tests/FilesystemOperations/0B05.txt
+++ b/tests/cleo_tests/FilesystemOperations/0B05.txt
@@ -6,7 +6,7 @@ test("0B05 (copy_directory)", tests)
 terminate_this_custom_script
 
 
-const Test_Path_Src = "cleo\\cleo_test_dir"
+const Test_Path_Src = "cleo\cleo_test_dir"
 const Test_Path_Dst = "test_directory"
 
 function tests

--- a/tests/cleo_tests/IniFiles/0AF0.txt
+++ b/tests/cleo_tests/IniFiles/0AF0.txt
@@ -6,7 +6,7 @@ test("0AF0 (read_int_from_ini_file)", tests)
 terminate_this_custom_script
 
 
-const Test_Path = "cleo\\cleo_test_file.ini"
+const Test_Path = "cleo\cleo_test_file.ini"
 
 function tests
     before_each(@setup)

--- a/tests/cleo_tests/IniFiles/0AF1.txt
+++ b/tests/cleo_tests/IniFiles/0AF1.txt
@@ -6,7 +6,7 @@ test("0AF1 (write_int_to_ini_file)", tests)
 terminate_this_custom_script
 
 
-const Test_Path = "cleo\\cleo_test_file.ini"
+const Test_Path = "cleo\cleo_test_file.ini"
 
 function tests
     before_each(@cleanup)

--- a/tests/cleo_tests/IniFiles/0AF2.txt
+++ b/tests/cleo_tests/IniFiles/0AF2.txt
@@ -6,7 +6,7 @@ test("0AF2 (read_float_from_ini_file)", tests)
 terminate_this_custom_script
 
 
-const Test_Path = "cleo\\cleo_test_file.ini"
+const Test_Path = "cleo\cleo_test_file.ini"
 
 function tests
     before_each(@setup)

--- a/tests/cleo_tests/IniFiles/0AF3.txt
+++ b/tests/cleo_tests/IniFiles/0AF3.txt
@@ -6,7 +6,7 @@ test("0AF3 (write_float_to_ini_file)", tests)
 terminate_this_custom_script
 
 
-const Test_Path = "cleo\\cleo_test_file.ini"
+const Test_Path = "cleo\cleo_test_file.ini"
 
 function tests
     before_each(@cleanup)

--- a/tests/cleo_tests/IniFiles/0AF4.txt
+++ b/tests/cleo_tests/IniFiles/0AF4.txt
@@ -6,7 +6,7 @@ test("0AF4 (read_string_from_ini_file)", tests)
 terminate_this_custom_script
 
 
-const Test_Path = "cleo\\cleo_test_file.ini"
+const Test_Path = "cleo\cleo_test_file.ini"
 
 function tests
     before_each(@setup)

--- a/tests/cleo_tests/IniFiles/0AF5.txt
+++ b/tests/cleo_tests/IniFiles/0AF5.txt
@@ -6,7 +6,7 @@ test("0AF5 (write_string_to_ini_file)", tests)
 terminate_this_custom_script
 
 
-const Test_Path = "cleo\\cleo_test_file.ini"
+const Test_Path = "cleo\cleo_test_file.ini"
 
 function tests
     before_each(@cleanup)


### PR DESCRIPTION
In case of filepath with duplicated separators some of Windows APIs tend to set last error variable to "invalid path", but access intended file anyway.
Remove doubled separators during path normalization, so CLEO internal paths comparisons can not be fooled by cases like this.