### PR TITLE
INI opcode updates. More unit tests.

### DIFF
--- a/tests/cleo_tests/IniFiles/0AF0.txt
+++ b/tests/cleo_tests/IniFiles/0AF0.txt
@@ -15,16 +15,25 @@ function tests
     it("should fail on not-existing file", test1)
     it("should fail on invalid file", test2)
     it("should fail on not existing value", test3)
-    it("should fail on invalid type", test4)
-    it("should read value", test5)
+    it("should fail on invalid data", test4)
+    it("should read int from int data", test5)
+    it("should read int from negative int data", test6)
+    it("should read int from hex int data", test7)
+    it("should read int from float data", test8)
+    it("should read int from negative float data", test9)
+    it("should read int from mixed data", test10)
 
     return
     
     :setup
         delete_file {path} Test_Path
-        write_int_to_ini_file {value} 42 {path} Test_Path {section} "test" {key} "test_int"
-        write_float_to_ini_file {value} 50.0 {path} Test_Path {section} "test" {key} "test_float"
-        write_string_to_ini_file {value} "value_one" {path} Test_Path {section} "test" {key} "test_string"
+        write_int_to_ini_file       {value} 42 {path} Test_Path {section} "test" {key} "test_int"
+        write_int_to_ini_file       {value} -42 {path} Test_Path {section} "test" {key} "test_int_neg"
+        write_string_to_ini_file    {value} "0x42" {path} Test_Path {section} "test" {key} "test_int_hex"
+        write_float_to_ini_file     {value} 50.0 {path} Test_Path {section} "test" {key} "test_float"
+        write_float_to_ini_file     {value} -50.0 {path} Test_Path {section} "test" {key} "test_float_neg"
+        write_string_to_ini_file    {value} "value_one" {path} Test_Path {section} "test" {key} "test_string"
+        write_string_to_ini_file    {value} "  12.3four " {path} Test_Path {section} "test" {key} "test_mixed"
     return
     
     :cleanup
@@ -32,28 +41,72 @@ function tests
     return
     
     function test1
-        int value = read_int_from_ini_file {path} "not_a_file.ini" {section} "test" {key} "test_int"
+        int value = 555
+        value = read_int_from_ini_file {path} "not_a_file.ini" {section} "test" {key} "test_float"
         assert_result_false()
+        assert_eq(value, 555)
     end
     
     function test2
-        int value = read_int_from_ini_file {path} "cleo.asi" {section} "test" {key} "test_int"
+        int value = 555
+        value = read_int_from_ini_file {path} "cleo.asi" {section} "test" {key} "test_int"
         assert_result_false()
+        assert_eq(value, 555)
     end
     
     function test3
-        int value = read_int_from_ini_file {path} Test_Path {section} "test" {key} "invalid_key"
+        int value = 555
+        value = read_int_from_ini_file {path} Test_Path {section} "test" {key} "invalid_key"
         assert_result_false()
+        assert_eq(value, 555)
     end
     
     function test4
-        int value = read_int_from_ini_file {path} Test_Path {section} "test" {key} "test_string"
+        int value = 555
+        value = read_int_from_ini_file {path} Test_Path {section} "test" {key} "test_string"
         assert_result_false()
+        assert_eq(value, 555)
     end
     
     function test5
-        int value = read_int_from_ini_file {path} Test_Path {section} "test" {key} "test_int"
+        int value = 555
+        value = read_int_from_ini_file {path} Test_Path {section} "test" {key} "test_int"
         assert_result_true()
         assert_eq(value, 42)
+    end
+    
+    function test6
+        int value = 555
+        value = read_int_from_ini_file {path} Test_Path {section} "test" {key} "test_int_neg"
+        assert_result_true()
+        assert_eq(value, -42)
+    end
+    
+    function test7
+        int value = 555
+        value = read_int_from_ini_file {path} Test_Path {section} "test" {key} "test_int_hex"
+        assert_result_true()
+        assert_eq(value, 0x42)
+    end
+    
+    function test8
+        int value = 555
+        value = read_int_from_ini_file {path} Test_Path {section} "test" {key} "test_float"
+        assert_result_true()
+        assert_eq(value, 50)
+    end
+    
+    function test9
+        int value = 555
+        value = read_int_from_ini_file {path} Test_Path {section} "test" {key} "test_float_neg"
+        assert_result_true()
+        assert_eq(value, -50)
+    end
+    
+    function test10
+        int value = 555
+        value = read_int_from_ini_file {path} Test_Path {section} "test" {key} "test_mixed"
+        assert_result_true()
+        assert_eq(value, 12)
     end
 end

--- a/tests/cleo_tests/IniFiles/0AF1.txt
+++ b/tests/cleo_tests/IniFiles/0AF1.txt
@@ -15,7 +15,7 @@ function tests
     it("should fail to overwrite file", test1)
     it("should fail to overwrite directory", test2)
     it("should create new file", test3)
-    it("should append to existing file", test4)
+    it("should add to existing file", test4)
     it("should overwrite value", test5)
     return
     

--- a/tests/cleo_tests/IniFiles/0AF2.txt
+++ b/tests/cleo_tests/IniFiles/0AF2.txt
@@ -15,16 +15,25 @@ function tests
     it("should fail on not-existing file", test1)
     it("should fail on invalid file", test2)
     it("should fail on not existing value", test3)
-    it("should fail on invalid type", test4)
-    it("should read value", test5)
+    it("should fail on invalid data", test4)
+    it("should read float from int data", test5)
+    it("should read float from negative int data", test6)
+    it("should read float from hex int data", test7)
+    it("should read float from float data", test8)
+    it("should read float from negative float data", test9)
+    it("should read float from mixed data", test10)
 
     return
     
     :setup
         delete_file {path} Test_Path
-        write_int_to_ini_file {value} 42 {path} Test_Path {section} "test" {key} "test_int"
-        write_float_to_ini_file {value} 50.0 {path} Test_Path {section} "test" {key} "test_float"
-        write_string_to_ini_file {value} "value_one" {path} Test_Path {section} "test" {key} "test_string"
+        write_int_to_ini_file       {value} 42 {path} Test_Path {section} "test" {key} "test_int"
+        write_int_to_ini_file       {value} -42 {path} Test_Path {section} "test" {key} "test_int_neg"
+        write_string_to_ini_file    {value} "0x42" {path} Test_Path {section} "test" {key} "test_int_hex"
+        write_float_to_ini_file     {value} 50.0 {path} Test_Path {section} "test" {key} "test_float"
+        write_float_to_ini_file     {value} -50.0 {path} Test_Path {section} "test" {key} "test_float_neg"
+        write_string_to_ini_file    {value} "value_one" {path} Test_Path {section} "test" {key} "test_string"
+        write_string_to_ini_file    {value} "  12.3four " {path} Test_Path {section} "test" {key} "test_mixed"
     return
     
     :cleanup
@@ -32,28 +41,72 @@ function tests
     return
     
     function test1
-        float value = read_float_from_ini_file {path} "not_a_file.ini" {section} "test" {key} "test_float"
+        float value = 555.0
+        value = read_float_from_ini_file {path} "not_a_file.ini" {section} "test" {key} "test_float"
         assert_result_false()
+        assert_eq(value, 555.0)
     end
     
     function test2
-        float value = read_float_from_ini_file {path} "cleo.asi" {section} "test" {key} "test_float"
+        float value = 555.0
+        value = read_float_from_ini_file {path} "cleo.asi" {section} "test" {key} "test_int"
         assert_result_false()
+        assert_eq(value, 555.0)
     end
     
     function test3
-        float value = read_float_from_ini_file {path} Test_Path {section} "test" {key} "invalid_key"
+        float value = 555.0
+        value = read_float_from_ini_file {path} Test_Path {section} "test" {key} "invalid_key"
         assert_result_false()
+        assert_eq(value, 555.0)
     end
     
     function test4
-        float value = read_float_from_ini_file {path} Test_Path {section} "test" {key} "test_string"
+        float value = 555.0
+        value = read_float_from_ini_file {path} Test_Path {section} "test" {key} "test_string"
         assert_result_false()
+        assert_eq(value, 555.0)
     end
     
     function test5
-        float value = read_float_from_ini_file {path} Test_Path {section} "test" {key} "test_float"
+        float value = 555.0
+        value = read_float_from_ini_file {path} Test_Path {section} "test" {key} "test_int"
         assert_result_true()
-        assert_eqf(value, 50.0)
+        assert_eq(value, 42.0)
+    end
+    
+    function test6
+        float value = 555.0
+        value = read_float_from_ini_file {path} Test_Path {section} "test" {key} "test_int_neg"
+        assert_result_true()
+        assert_eq(value, -42.0)
+    end
+    
+    function test7
+        float value = 555.0
+        value = read_float_from_ini_file {path} Test_Path {section} "test" {key} "test_int_hex"
+        assert_result_true()
+        assert_eq(value, 66.0) // 0x42
+    end
+    
+    function test8
+        float value = 555.0
+        value = read_float_from_ini_file {path} Test_Path {section} "test" {key} "test_float"
+        assert_result_true()
+        assert_eq(value, 50.0)
+    end
+    
+    function test9
+        float value = 555.0
+        value = read_float_from_ini_file {path} Test_Path {section} "test" {key} "test_float_neg"
+        assert_result_true()
+        assert_eq(value, -50.0)
+    end
+    
+    function test10
+        float value = 555.0
+        value = read_float_from_ini_file {path} Test_Path {section} "test" {key} "test_mixed"
+        assert_result_true()
+        assert_eq(value, 12.3)
     end
 end

--- a/tests/cleo_tests/IniFiles/0AF3.txt
+++ b/tests/cleo_tests/IniFiles/0AF3.txt
@@ -15,7 +15,7 @@ function tests
     it("should fail to overwrite file", test1)
     it("should fail to overwrite directory", test2)
     it("should create new file", test3)
-    it("should append to existing file", test4)
+    it("should add to existing file", test4)
     it("should overwrite value", test5)
     return
     

--- a/tests/cleo_tests/IniFiles/0AF4.txt
+++ b/tests/cleo_tests/IniFiles/0AF4.txt
@@ -15,15 +15,20 @@ function tests
     it("should fail on not-existing file", test1)
     it("should fail on invalid file", test2)
     it("should fail on not existing value", test3)
-    it("should read value", test4)
+    it("should read string value", test4)
+    it("should trim whitespaces", test5)
 
     return
     
     :setup
         delete_file {path} Test_Path
-        write_int_to_ini_file {value} 42 {path} Test_Path {section} "test" {key} "test_int"
-        write_float_to_ini_file {value} 50.0 {path} Test_Path {section} "test" {key} "test_float"
-        write_string_to_ini_file {value} "value_one" {path} Test_Path {section} "test" {key} "test_string"
+        write_int_to_ini_file       {value} 42 {path} Test_Path {section} "test" {key} "test_int"
+        write_int_to_ini_file       {value} -42 {path} Test_Path {section} "test" {key} "test_int_neg"
+        write_string_to_ini_file    {value} "0x42" {path} Test_Path {section} "test" {key} "test_int_hex"
+        write_float_to_ini_file     {value} 50.0 {path} Test_Path {section} "test" {key} "test_float"
+        write_float_to_ini_file     {value} -50.0 {path} Test_Path {section} "test" {key} "test_float_neg"
+        write_string_to_ini_file    {value} "value_one" {path} Test_Path {section} "test" {key} "test_string"
+        write_string_to_ini_file    {value} "  12.3four " {path} Test_Path {section} "test" {key} "test_mixed"
     return
     
     :cleanup
@@ -31,23 +36,37 @@ function tests
     return
     
     function test1
-        longstring value = read_string_from_ini_file {path} "not_a_file.ini" {section} "test" {key} "test_string"
+        longstring value = "initial"
+        value = read_string_from_ini_file {path} "not_a_file.ini" {section} "test" {key} "test_string"
         assert_result_false()
+        assert_eqs(value, "initial")
     end
     
     function test2
-        longstring value = read_string_from_ini_file {path} "cleo.asi" {section} "test" {key} "test_string"
+        longstring value = "initial"
+        value = read_string_from_ini_file {path} "cleo.asi" {section} "test" {key} "test_string"
         assert_result_false()
+        assert_eqs(value, "initial")
     end
     
     function test3
-        longstring value = read_string_from_ini_file {path} Test_Path {section} "test" {key} "invalid_key"
+        longstring value = "initial"
+        value = read_string_from_ini_file {path} Test_Path {section} "test" {key} "invalid_key"
         assert_result_false()
+        assert_eqs(value, "initial")
     end
     
     function test4
-        longstring value = read_string_from_ini_file {path} Test_Path {section} "test" {key} "test_string"
+        longstring value = "initial"
+        value = read_string_from_ini_file {path} Test_Path {section} "test" {key} "test_string"
         assert_result_true()
         assert_eqs(value, "value_one")
-    end    
+    end
+    
+    function test5
+        longstring value = "initial"
+        value = read_string_from_ini_file {path} Test_Path {section} "test" {key} "test_mixed"
+        assert_result_true()
+        assert_eqs(value, "12.3four")
+    end  
 end

--- a/tests/cleo_tests/IniFiles/0AF5.txt
+++ b/tests/cleo_tests/IniFiles/0AF5.txt
@@ -15,7 +15,7 @@ function tests
     it("should fail to overwrite file", test1)
     it("should fail to overwrite directory", test2)
     it("should create new file", test3)
-    it("should append to existing file", test4)
+    it("should add to existing file", test4)
     it("should overwrite value", test5)
     return
     


### PR DESCRIPTION
Tests updated to reflect way read number from ini API works (read number characters until error).
Fixed reporting success when reading numbers from fields not containing number at all.
Fixed success result when path points directory.
Fixed read int opcode returning value `0x80000000` on error. (kept in legacy mode)
Fixed read int opcode reporting fail if value in file was `0x80000000`

All INI unit tests passing.