### PR TITLE
Block use of CFileMgr::SetDir by call_function opcodes.

### DIFF
--- a/cleo_plugins/MemoryOperations/AntiHacks.h
+++ b/cleo_plugins/MemoryOperations/AntiHacks.h
@@ -1,0 +1,32 @@
+#pragma once
+#include "CLEO.h"
+#include <string>
+
+namespace AntiHacks
+{
+	// checks if specific function call is allowed. Performs replacement action if needed
+	static bool CheckCall(CLEO::CRunningScript* thread, void* function, void* object, CLEO::SCRIPT_VAR* args, size_t argCount, DWORD& result)
+	{
+		switch ((size_t)function)
+		{
+			case 0x005387D0: // CFileMgr::SetDir(const char* relPath)
+			//case 0x00836F1E: // int _chdir(LPCSTR lpPathName) TODO?
+			//case 0x0085824C: // imp_SetCurrentDirectoryA TODO?
+			{
+				// some older mods used CFileMgr::SetDir directly instead of 0A99 opcode
+				auto resolved = std::string(args[0].pcParam);
+				resolved.resize(MAX_PATH);
+				CLEO_ResolvePath(thread, resolved.data(), resolved.size());
+
+				CLEO::CLEO_SetScriptWorkDir(thread, resolved.c_str());
+				return false;
+			}
+			break;
+
+			default:
+			break;
+		}
+
+		return true; // allow
+	}
+};

--- a/cleo_plugins/MemoryOperations/MemoryOperations.vcxproj
+++ b/cleo_plugins/MemoryOperations/MemoryOperations.vcxproj
@@ -148,6 +148,7 @@ if defined GTA_SA_DIR (
   <ItemGroup>
     <ClInclude Include="..\..\cleo_sdk\CLEO.h" />
     <ClInclude Include="..\..\cleo_sdk\CLEO_Utils.h" />
+    <ClInclude Include="AntiHacks.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\Resource.rc" />

--- a/cleo_plugins/MemoryOperations/MemoryOperations.vcxproj.filters
+++ b/cleo_plugins/MemoryOperations/MemoryOperations.vcxproj.filters
@@ -39,6 +39,7 @@
     <ClInclude Include="..\..\cleo_sdk\CLEO_Utils.h">
       <Filter>cleo_sdk</Filter>
     </ClInclude>
+    <ClInclude Include="AntiHacks.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\Resource.rc" />


### PR DESCRIPTION
Cherry picked from ModLoader support branch.
Still not solves all problems with SkinSelector, but prevents it from sabotaging the game and other scripts.