### PR TITLE
Stack pointer validation for call function/method opcodes

### DIFF
--- a/cleo_plugins/MemoryOperations/MemoryOperations.cpp
+++ b/cleo_plugins/MemoryOperations/MemoryOperations.cpp
@@ -161,8 +161,11 @@ public:
         SCRIPT_VAR* arguments_end = arguments + numArg;
         numPop *= 4; // bytes peer argument
         DWORD result;
+        int oriSp, postSp; // stack validation
         _asm
         {
+            mov oriSp, esp
+
             // transfer args to stack
             lea ecx, arguments
             call_func_loop :
@@ -179,6 +182,21 @@ public:
                 call func
                 mov result, eax // get result
                 add esp, numPop // cleanup stack
+
+            mov postSp, esp
+        }
+
+        // validate stack pointer
+        if (postSp != oriSp)
+        {
+            _asm
+            {
+                mov esp, oriSp // fix stack pointer
+            }
+
+            int diff = oriSp - postSp;
+            SHOW_ERROR("Function call left stack position changed (%s%d) in script %s \nScript suspended.", diff > 0 ? "+" : "", diff, CLEO::ScriptInfoStr(thread).c_str());
+            return thread->Suspend();
         }
 
         if (returnArg)

--- a/cleo_plugins/MemoryOperations/MemoryOperations.cpp
+++ b/cleo_plugins/MemoryOperations/MemoryOperations.cpp
@@ -195,7 +195,8 @@ public:
             }
 
             int diff = oriSp - postSp;
-            SHOW_ERROR("Function call left stack position changed (%s%d) in script %s \nScript suspended.", diff > 0 ? "+" : "", diff, CLEO::ScriptInfoStr(thread).c_str());
+            int requiredPop = (numPop + diff) / 4;
+            SHOW_ERROR("Function call left stack position changed (%s%d). This usually happens when incorrect calling convention is used. \nArgument 'pop' value should have been %d in script %s \nScript suspended.", diff > 0 ? "+" : "", diff, requiredPop, CLEO::ScriptInfoStr(thread).c_str());
             return thread->Suspend();
         }
 


### PR DESCRIPTION
Can it backfire in any way? Plugin compiled in debug configuration throws similar exceptions\error messages when stack pointer is left modified.
Does it make sense to allow scripts in legacy mode to not pop after call?
![image](https://github.com/user-attachments/assets/303aaaf0-3f89-4757-b0d3-ca50c62a2ed4)
