### PR TITLE
Relax size limitations of 0a8d: READ_MEMORY

### DIFF
--- a/cleo_plugins/MemoryOperations/MemoryOperations.cpp
+++ b/cleo_plugins/MemoryOperations/MemoryOperations.cpp
@@ -279,8 +279,8 @@ public:
         auto size = OPCODE_READ_PARAM_INT();
         auto virtualProtect = OPCODE_READ_PARAM_BOOL();
 
-        // validate params
-        if (size < 0 || size > sizeof(SCRIPT_VAR))
+        // allowed sizes: 0, 1, 2, 3, 4 and multiplies of 4 until 256
+        if (size < 0 || size > (64 * 4) || (size > 4 && (size % 4 != 0)))
         {
             SHOW_ERROR("Invalid '%d' size argument in script %s\nScript suspended.", size, ScriptInfoStr(thread).c_str());
             return thread->Suspend();

--- a/cleo_plugins/MemoryOperations/MemoryOperations.cpp
+++ b/cleo_plugins/MemoryOperations/MemoryOperations.cpp
@@ -286,8 +286,15 @@ public:
             return thread->Suspend();
         }
 
+        auto output = OPCODE_READ_PARAM_OUTPUT_VAR_ANY32();
+
+        // clear unaffected bytes
+        if (size < 4)
+        {
+            output->dwParam = 0;
+        }
+
         // perform
-        DWORD value = 0;
         if (size > 0)
         {
             if (virtualProtect)
@@ -296,10 +303,9 @@ public:
                 VirtualProtect(address, size, PAGE_EXECUTE_READWRITE, &oldProtect);
             }
 
-            memcpy(&value, address, size);
+            memcpy(output, address, size);
         }
 
-        OPCODE_WRITE_PARAM_ANY32(value);
         return OR_CONTINUE;
     }
 

--- a/cleo_plugins/MemoryOperations/MemoryOperations.cpp
+++ b/cleo_plugins/MemoryOperations/MemoryOperations.cpp
@@ -279,8 +279,8 @@ public:
         auto size = OPCODE_READ_PARAM_INT();
         auto virtualProtect = OPCODE_READ_PARAM_BOOL();
 
-        // allowed sizes: 0, 1, 2, 3, 4 and multiplies of 4 until 256
-        if (size < 0 || size > (64 * 4) || (size > 4 && (size % 4 != 0)))
+        // allowed sizes: 0, 1, 2, 3, 4 and multiplies of 4 until 128
+        if (size < 0 || size > (32 * 4) || (size > 4 && (size % 4 != 0)))
         {
             SHOW_ERROR("Invalid '%d' size argument in script %s\nScript suspended.", size, ScriptInfoStr(thread).c_str());
             return thread->Suspend();

--- a/tests/cleo_tests/MemoryOperations/0A8D.txt
+++ b/tests/cleo_tests/MemoryOperations/0A8D.txt
@@ -14,6 +14,9 @@ function tests
     it("should read 3 bytes", test4)
     it("should read 4 bytes", test5)
     it("should read float", test6)
+    it("should read 8 bytes", test7)
+    it("should read 12 bytes", test8)
+    it("should read 16 bytes", test9)
     
     return
     
@@ -22,6 +25,9 @@ function tests
         1@ = 0xcccccccc
         2@ = 0xdddddddd
         3@ = 0xeeeeeeee
+        4@ = 0xffffffff
+        5@ = 0xaaaaaaaa
+        6@ = 0xbbbbbbbb
     return
 
     function test1
@@ -30,6 +36,9 @@ function tests
         assert_eq(1@, 0xcccccccc)
         assert_eq(2@, 0x00000000)
         assert_eq(3@, 0xeeeeeeee)
+        assert_eq(4@, 0xffffffff)
+        assert_eq(5@, 0xaaaaaaaa)
+        assert_eq(6@, 0xbbbbbbbb)
     end
 
     function test2
@@ -38,6 +47,9 @@ function tests
         assert_eq(1@, 0xcccccccc)
         assert_eq(2@, 0x00000044)
         assert_eq(3@, 0xeeeeeeee)
+        assert_eq(4@, 0xffffffff)
+        assert_eq(5@, 0xaaaaaaaa)
+        assert_eq(6@, 0xbbbbbbbb)
     end
 
     function test3
@@ -46,6 +58,9 @@ function tests
         assert_eq(1@, 0xcccccccc)
         assert_eq(2@, 0x00003344)
         assert_eq(3@, 0xeeeeeeee)
+        assert_eq(4@, 0xffffffff)
+        assert_eq(5@, 0xaaaaaaaa)
+        assert_eq(6@, 0xbbbbbbbb)
     end
 
     function test4
@@ -54,6 +69,9 @@ function tests
         assert_eq(1@, 0xcccccccc)
         assert_eq(2@, 0x00223344)
         assert_eq(3@, 0xeeeeeeee)
+        assert_eq(4@, 0xffffffff)
+        assert_eq(5@, 0xaaaaaaaa)
+        assert_eq(6@, 0xbbbbbbbb)
     end
 
     function test5
@@ -62,6 +80,9 @@ function tests
         assert_eq(1@, 0xcccccccc)
         assert_eq(2@, 0x11223344)
         assert_eq(3@, 0xeeeeeeee)
+        assert_eq(4@, 0xffffffff)
+        assert_eq(5@, 0xaaaaaaaa)
+        assert_eq(6@, 0xbbbbbbbb)
     end
 
     function test6
@@ -70,12 +91,52 @@ function tests
         get_var_pointer 0@ {store_to} 1@
         2@ = read_memory {address} 1@ {size} 4 {vp} false
 
-        assert_eq(2@, 125.0)
+        assert_eqf(2@, 125.0)
+        assert_eq(3@, 0xeeeeeeee)
+        assert_eq(4@, 0xffffffff)
+        assert_eq(5@, 0xaaaaaaaa)
+        assert_eq(6@, 0xbbbbbbbb)
+    end
+    
+    function test7
+        2@ = read_memory {address} 0@ {size} 8 {vp} false
+
+        assert_eq(1@, 0xcccccccc)
+        assert_eq(2@, 0x11223344)
+        assert_eq(3@, 0x55667788)
+        assert_eq(4@, 0xffffffff)
+        assert_eq(5@, 0xaaaaaaaa)
+        assert_eq(6@, 0xbbbbbbbb)
+    end
+    
+    function test8
+        2@ = read_memory {address} 0@ {size} 12 {vp} false
+
+        assert_eq(1@, 0xcccccccc)
+        assert_eq(2@, 0x11223344)
+        assert_eq(3@, 0x55667788)
+        assert_eq(4@, 0x99AABBCC)
+        assert_eq(5@, 0xaaaaaaaa)
+        assert_eq(6@, 0xbbbbbbbb)
+    end
+    
+    function test9
+        2@ = read_memory {address} 0@ {size} 16 {vp} false
+
+        assert_eq(1@, 0xcccccccc)
+        assert_eq(2@, 0x11223344)
+        assert_eq(3@, 0x55667788)
+        assert_eq(4@, 0x99AABBCC)
+        assert_eq(5@, 0xDDEEFF00)
+        assert_eq(6@, 0xbbbbbbbb)
     end
 
     :DATA
     hex
         44 33 22 11
+        88 77 66 55
+        CC BB AA 99
+        00 FF EE DD
         "some longer testing text" 00
     end
 end


### PR DESCRIPTION
Allow reading memory into several consecutive variables, like `float pos[3]`