### PR TITLE
Fixed display_text_formatted texts overwriting themself

### DIFF
--- a/cleo_plugins/Text/Text.cpp
+++ b/cleo_plugins/Text/Text.cpp
@@ -23,6 +23,8 @@ public:
 	static const size_t MsgBigStyleCount = 7;
 	static char msgBuffBig[MsgBigStyleCount][MAX_STR_LEN + 1];
 
+	static WORD genericLabelCounter;
+
 	MemPatch patchCTextGet;
 
     Text()
@@ -67,6 +69,7 @@ public:
 
 		// register event callbacks
 		CLEO_RegisterCallback(eCallbackId::GameBegin, OnGameBegin);
+		CLEO_RegisterCallback(eCallbackId::GameProcess, OnGameProcess);
 		CLEO_RegisterCallback(eCallbackId::GameEnd, OnGameEnd);
 
 		// install hooks
@@ -76,6 +79,7 @@ public:
 	~Text()
 	{
 		CLEO_UnregisterCallback(eCallbackId::GameBegin, OnGameBegin);
+		CLEO_UnregisterCallback(eCallbackId::GameProcess, OnGameProcess);
 		CLEO_UnregisterCallback(eCallbackId::GameEnd, OnGameEnd);
 
 		patchCTextGet.Apply(); // undo hook
@@ -84,6 +88,11 @@ public:
 	static void __stdcall OnGameBegin(DWORD saveSlot)
 	{
 		textManager.LoadFxts();
+	}
+
+	static void __stdcall OnGameProcess()
+	{
+		genericLabelCounter = 0;
 	}
 
 	static void __stdcall OnGameEnd()
@@ -439,10 +448,11 @@ public:
 		auto posY = OPCODE_READ_PARAM_FLOAT();
 		OPCODE_READ_PARAM_STRING_FORMATTED(text);
 
-		// new GXT label
+		// new generic GXT label
 		// includes unprintable character, to ensure there will be no collision with user GXT labels
-		char gxt[8] = { 0x01, 'C', 'L', 'E', 'O', '_', 0x01, 0x00 };
-		gxt[6] += CTheScripts::NumberOfIntroTextLinesThisFrame; // unique label for each possible entry
+		char gxt[9] = { 0x01, 'C', 'L', 'E', 0x00, 0x00, 0x00, 0x00, 0x00 }; // enough space for even worst case scenario
+		_itoa(genericLabelCounter, gxt + 4, 36); // 0xFFFF -> "1ekf"
+		genericLabelCounter++;
 
 		textManager.AddFxt(gxt, text);
 
@@ -512,3 +522,4 @@ CTextManager Text::textManager;
 char Text::msgBuffLow[MAX_STR_LEN + 1];
 char Text::msgBuffHigh[MAX_STR_LEN + 1];
 char Text::msgBuffBig[MsgBigStyleCount][MAX_STR_LEN + 1];
+WORD Text::genericLabelCounter;

--- a/cleo_plugins/Text/Text.cpp
+++ b/cleo_plugins/Text/Text.cpp
@@ -448,6 +448,12 @@ public:
 		auto posY = OPCODE_READ_PARAM_FLOAT();
 		OPCODE_READ_PARAM_STRING_FORMATTED(text);
 
+		if (CTheScripts::NumberOfIntroTextLinesThisFrame >= 0x60) // GTA SA CTheScripts::IntroTextLines capacity
+		{
+			LOG_WARNING(thread, "Display text limit (%d) exceeded in script %s", 0x60, ScriptInfoStr(thread).c_str());
+			return OR_CONTINUE;
+		}
+
 		// new generic GXT label
 		// includes unprintable character, to ensure there will be no collision with user GXT labels
 		char gxt[9] = { 0x01, 'C', 'L', 'E', 0x00, 0x00, 0x00, 0x00, 0x00 }; // enough space for even worst case scenario

--- a/examples/Screen_Drawing.txt
+++ b/examples/Screen_Drawing.txt
@@ -1,0 +1,97 @@
+// CLEO5 example script
+// Sanny Builder 4
+// mode: GTA SA (v1.0 - SBL)
+{$CLEO .cs}
+
+script_name {name} 'scrdraw'
+
+float screenPos[2]
+screenPos[0] = 320.0 // screen width is 640.0
+screenPos[1] = 224.0 // screen height is 448.0
+
+while true
+    wait {time} 0
+    
+    int state
+    float stickPos
+    
+    // horizontal movement
+    state = get_pad_state {pad} PadId.Pad1 {buttonId} Button.LeftStickX
+    if
+        state <> 0
+    then
+        stickPos =# state
+        stickPos /= 128.0 // convert to -1.0 +1.0 range
+        
+        stickPos *= 14.0 // movement speed
+        screenPos[0] +=@ stickPos // FPS consistent
+        
+        if
+            screenPos[0] < 10.0
+        then
+            screenPos[0] = 10.0
+            TimerA = 0
+        end
+        
+        if
+            screenPos[0] > 630.0
+        then
+            screenPos[0] = 630.0
+            TimerA = 0
+        end
+    end
+    
+    // vertical movement
+    state = get_pad_state {pad} PadId.Pad1 {buttonId} Button.LeftStickY
+    if
+        state <> 0
+    then
+        stickPos =# state
+        stickPos /= 128.0 // convert to -1.0 +1.0 range
+        
+        stickPos *= 10.0 // movement speed
+        screenPos[1] +=@ stickPos // FPS consistent
+        
+        if
+            screenPos[1] < 10.0
+        then
+            screenPos[1] = 10.0
+            TimerA = 0
+        end
+        
+        if
+            screenPos[1] > 438.0 // 448 is bottom screen pos
+        then
+            screenPos[1] = 438.0
+            TimerA = 0
+        end
+    end
+    
+    int score = TimerA / 300
+    
+    // draw on screen
+    use_text_commands {state} true
+    
+    // rectangle background
+    draw_rect {pos} screenPos[0] screenPos[1] {size} 20.0 20.0 {rgb} 0x00 0x00 0x00 {alpha} 200
+    
+    // rectangle center
+    if
+        score > 0
+    then
+        draw_rect {pos} screenPos[0] screenPos[1] {size} 16.0 16.0 {rgb} 0xFF 0xFF 0x00 {alpha} 255 // yellow
+    else
+        draw_rect {pos} screenPos[0] screenPos[1] {size} 16.0 16.0 {rgb} 0xFF 0x00 0x00 {alpha} 255 // red
+    end
+    
+    // points
+    set_text_font {font} Font.Menu
+    set_text_scale {width} 0.6 {height} 2.4
+    set_text_colour {rgb} 0xFF 0xFF 0x00 {alpha} 255
+    set_text_edge {size} 2 {rgb} 0 0 0 {alpha} 200
+    set_text_centre {state} true
+    set_text_centre_size {width} 640.0
+    display_text_formatted {pos} 320.0 20.0 {format} "Points: %d" {args} score    
+end
+
+terminate_this_custom_script


### PR DESCRIPTION
Apparently **CTheScripts::NumberOfIntroTextLinesThisFrame** is cleared on every script processing, not once peer render frame.
This caused GXT labels generated by multiple scripts to not be unique.