### PR TITLE
Translate key names in debug prints

### DIFF
--- a/cleo_plugins/DebugUtils/DebugUtils.cpp
+++ b/cleo_plugins/DebugUtils/DebugUtils.cpp
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <sstream>
 
+#include "CMessages.h"
 #include "CTimer.h"
 
 #include "CLEO.h"
@@ -12,6 +13,7 @@
 #include "ScriptLog.h"
 
 using namespace CLEO;
+using namespace plugin;
 
 class DebugUtils
 {
@@ -256,6 +258,7 @@ public:
         else // breakpoint formatted name string
         {
             OPCODE_READ_PARAM_STRING_FORMATTED(nameStr);
+            CMessages::InsertPlayerControlKeysInString(nameStr);
             name = nameStr;
         }
 
@@ -286,6 +289,7 @@ public:
         }
 
         OPCODE_READ_PARAM_STRING_FORMATTED(message);
+        CMessages::InsertPlayerControlKeysInString(message);
 
         CLEO_Log(eLogLevel::Debug, message);
         return OR_CONTINUE;
@@ -336,8 +340,8 @@ public:
             file << szBuf;
         }
 
-        auto format = CLEO_ReadStringOpcodeParam(thread);
-        auto message = CLEO_ReadParamsFormatted(thread, format);
+        OPCODE_READ_PARAM_STRING_FORMATTED(message);
+        CMessages::InsertPlayerControlKeysInString(message);
 
         file << message << std::endl;
 

--- a/cleo_plugins/DebugUtils/DebugUtils.vcxproj
+++ b/cleo_plugins/DebugUtils/DebugUtils.vcxproj
@@ -129,6 +129,7 @@ xcopy /Y "$(OutDir)$(TargetName).*" "$(GTA_SA_DIR)\cleo\cleo_plugins\"
     <ClCompile Include="$(PLUGIN_SDK_DIR)\plugin_sa\game_sa\RenderWare.cpp" />
     <ClCompile Include="$(PLUGIN_SDK_DIR)\shared\game\CRGBA.cpp" />
     <ClCompile Include="$(PLUGIN_SDK_DIR)\plugin_sa\game_sa\CTimer.cpp" />
+    <ClCompile Include="$(PLUGIN_SDK_DIR)\plugin_sa\game_sa\CMessages.cpp" />
     <ClCompile Include="DebugUtils.cpp" />
     <ClCompile Include="ScreenLog.cpp" />
   </ItemGroup>

--- a/cleo_plugins/DebugUtils/DebugUtils.vcxproj.filters
+++ b/cleo_plugins/DebugUtils/DebugUtils.vcxproj.filters
@@ -15,6 +15,9 @@
     <ClCompile Include="$(PLUGIN_SDK_DIR)\plugin_sa\game_sa\CTimer.cpp">
       <Filter>sdk</Filter>
     </ClCompile>
+    <ClCompile Include="$(PLUGIN_SDK_DIR)\plugin-sdk\plugin_sa\game_sa\CMessages.cpp">
+      <Filter>sdk</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ScreenLog.h" />


### PR DESCRIPTION
Handle key formatting sequences in same way as other opcodes do. Currently `~k~` of `~k~~PED_FIRE~` is ignored and game draws button icons instead of textual names.