### PR TITLE
Legacy modes support for native scripts

### DIFF
--- a/cleo_plugins/Text/CTextManager.cpp
+++ b/cleo_plugins/Text/CTextManager.cpp
@@ -115,6 +115,8 @@ namespace CLEO
             }
         }
         CLEO::CLEO_StringListFree(list);
+
+        TRACE(""); // separator
     }
 
     void CTextManager::Clear()

--- a/source/CCustomOpcodeSystem.cpp
+++ b/source/CCustomOpcodeSystem.cpp
@@ -1088,9 +1088,8 @@ namespace CLEO
 		// pass arguments as new scope local variables
 		memcpy(locals, arguments, nParams * sizeof(SCRIPT_VAR));
 
-		// initialize rest of new scope local variables
-		auto scriptVer = CLEO_GetScriptVersion(thread);
-		if (scriptVer >= CLEO_VER_4_MIN) // CLEO 3 did not initialised local variables
+		// initialize (clear) rest of new scope local variables
+		if (CLEO_GetScriptVersion(thread) >= CLEO_VER_4_MIN) // CLEO 3 did not cleared local variables
 		{
 			for (DWORD i = nParams; i < 32; i++)
 			{

--- a/source/CCustomOpcodeSystem.cpp
+++ b/source/CCustomOpcodeSystem.cpp
@@ -892,9 +892,6 @@ namespace CLEO
 		SetScriptCondResult(thread, cs && cs->IsOK());
 		if (cs && cs->IsOK())
 		{
-			auto csscript = reinterpret_cast<CCustomScript*>(thread);
-			if (csscript->IsCustom())
-				cs->SetCompatibility(csscript->GetCompatibility());
 			CleoInstance.ScriptEngine.AddCustomScript(cs);
 			memset(missionLocals, 0, 1024 * sizeof(SCRIPT_VAR)); // same as CTheScripts::WipeLocalVariableMemoryForMissionScript
 			TransmitScriptParams(thread, (CRunningScript*)((BYTE*)missionLocals - 0x3C));
@@ -939,9 +936,13 @@ namespace CLEO
 	//0AA9=0,  is_game_version_original
 	OpcodeResult __stdcall opcode_0AA9(CRunningScript *thread)
 	{
-		auto gv = CleoInstance.VersionManager.GetGameVersion();
-		auto cs = (CCustomScript*)thread;
-		SetScriptCondResult(thread, gv == GV_US10 || (cs->IsCustom() && cs->GetCompatibility() <= CLEO_VER_4_MIN && gv == GV_EU10));
+		auto gameVer = CleoInstance.VersionManager.GetGameVersion();
+		auto scriptVer = CLEO_GetScriptVersion(thread);
+
+		bool result = (gameVer == GV_US10) ||
+			(scriptVer <= CLEO_VER_4_MIN && gameVer == GV_EU10);
+
+		OPCODE_CONDITION_RESULT(result);
 		return OR_CONTINUE;
 	}
 
@@ -1088,12 +1089,12 @@ namespace CLEO
 		memcpy(locals, arguments, nParams * sizeof(SCRIPT_VAR));
 
 		// initialize rest of new scope local variables
-		auto cs = reinterpret_cast<CCustomScript*>(thread);
-		if (cs->IsCustom() && cs->GetCompatibility() >= CLEO_VER_4_MIN) // CLEO 3 did not initialised local variables
+		auto scriptVer = CLEO_GetScriptVersion(thread);
+		if (scriptVer >= CLEO_VER_4_MIN) // CLEO 3 did not initialised local variables
 		{
 			for (DWORD i = nParams; i < 32; i++)
 			{
-				cs->SetIntVar(i, 0); // fill with zeros
+				thread->SetIntVar(i, 0); // fill with zeros
 			}
 		}
 
@@ -1859,10 +1860,6 @@ extern "C"
 		{
 			CleoInstance.ScriptEngine.AddCustomScript(cs);
 			if (fromThread) TransmitScriptParams(fromThread, cs);
-
-			cs->SetDebugMode(fromThread ? 
-				reinterpret_cast<CCustomScript*>(fromThread)->GetDebugMode() : // from parent
-				CleoInstance.ScriptEngine.NativeScriptsDebugMode); // global
 		}
 		else
 		{

--- a/source/CScriptEngine.cpp
+++ b/source/CScriptEngine.cpp
@@ -706,7 +706,7 @@ namespace CLEO
             case VPref::Script: resolved = GetScriptFileDir(); break;
             case VPref::Game: resolved = Filepath_Game; break;
             case VPref::Cleo: resolved = Filepath_Cleo; break;
-            case VPref::Modules: resolved = Filepath_Cleo + "\\cleo_modules"; break;
+            case VPref::Modules: resolved = Filepath_Cleo + "\\modules"; break;
             default : resolved = "<error>"; break; // should never happen
         }
 

--- a/source/CScriptEngine.cpp
+++ b/source/CScriptEngine.cpp
@@ -706,7 +706,7 @@ namespace CLEO
             case VPref::Script: resolved = GetScriptFileDir(); break;
             case VPref::Game: resolved = Filepath_Game; break;
             case VPref::Cleo: resolved = Filepath_Cleo; break;
-            case VPref::Modules: resolved = Filepath_Cleo + "\\modules"; break;
+            case VPref::Modules: resolved = Filepath_Cleo + "\\cleo_modules"; break;
             default : resolved = "<error>"; break; // should never happen
         }
 

--- a/source/CScriptEngine.cpp
+++ b/source/CScriptEngine.cpp
@@ -938,14 +938,18 @@ namespace CLEO
 
         NativeScriptsDebugMode = GetPrivateProfileInt("General", "DebugMode", 0, Filepath_Config.c_str()) != 0;
 
+        // global native scripts legacy mode
         int ver = GetPrivateProfileInt("General", "MainScmLegacyMode", 0, Filepath_Config.c_str());
         switch(ver)
         {
             case 3: NativeScriptsVersion = eCLEO_Version::CLEO_VER_3; break;
             case 4: NativeScriptsVersion = eCLEO_Version::CLEO_VER_4; break;
-            case 5: NativeScriptsVersion = eCLEO_Version::CLEO_VER_5; break;
-            default: NativeScriptsVersion = eCLEO_Version::CLEO_VER_CUR; break;
+            default: 
+                NativeScriptsVersion = eCLEO_Version::CLEO_VER_CUR;
+                ver = 0;
+            break;
         }
+        if (ver != 0) TRACE("Legacy mode for native scripts active: CLEO%d", ver);
 
         MainScriptCurWorkDir = Filepath_Game;
 

--- a/source/CScriptEngine.cpp
+++ b/source/CScriptEngine.cpp
@@ -265,7 +265,7 @@ namespace CLEO
             if (thread->IsCustom())
                 return reinterpret_cast<const CCustomScript*>(thread)->GetCompatibility();
             else
-                return CLEO::eCLEO_Version::CLEO_VER_CUR;
+                return CleoInstance.ScriptEngine.NativeScriptsVersion;
         }
 
         LPCSTR WINAPI CLEO_GetScriptFilename(const CRunningScript* thread)
@@ -937,6 +937,16 @@ namespace CLEO
         }
 
         NativeScriptsDebugMode = GetPrivateProfileInt("General", "DebugMode", 0, Filepath_Config.c_str()) != 0;
+
+        int ver = GetPrivateProfileInt("General", "MainScmLegacyMode", 0, Filepath_Config.c_str());
+        switch(ver)
+        {
+            case 3: NativeScriptsVersion = eCLEO_Version::CLEO_VER_3; break;
+            case 4: NativeScriptsVersion = eCLEO_Version::CLEO_VER_4; break;
+            case 5: NativeScriptsVersion = eCLEO_Version::CLEO_VER_5; break;
+            default: NativeScriptsVersion = eCLEO_Version::CLEO_VER_CUR; break;
+        }
+
         MainScriptCurWorkDir = Filepath_Game;
 
         CleoInstance.ModuleSystem.LoadCleoModules();
@@ -1537,13 +1547,13 @@ namespace CLEO
                 if (path.extension() == cs4_ext)
                     CompatVer = CLEO_VER_4;
                 else
-                    if (path.extension() == cs3_ext)
-                        CompatVer = CLEO_VER_3;
+                if (path.extension() == cs3_ext)
+                    CompatVer = CLEO_VER_3;
 
-                if (CompatVer == CLEO_VER_CUR && parent != nullptr && parent - IsCustom())
+                if (CompatVer == CLEO_VER_CUR && parent != nullptr)
                 {
                     // inherit compatibility mode from parent
-                    CompatVer = ((CCustomScript*)parent)->GetCompatibility();
+                    CompatVer = CLEO_GetScriptVersion(parent);
 
                     // try loading file with same compatibility mode filetype extension
                     auto compatPath = path;
@@ -1554,12 +1564,12 @@ namespace CLEO
                             path = compatPath;
                     }
                     else
-                        if (CompatVer == CLEO_VER_3)
-                        {
-                            compatPath.replace_extension(cs3_ext);
-                            if (FS::is_regular_file(compatPath))
-                                path = compatPath;
-                        }
+                    if (CompatVer == CLEO_VER_3)
+                    {
+                        compatPath.replace_extension(cs3_ext);
+                        if (FS::is_regular_file(compatPath))
+                            path = compatPath;
+                    }
                 }
 
                 scriptFileDir = path.parent_path().string();

--- a/source/CScriptEngine.h
+++ b/source/CScriptEngine.h
@@ -115,6 +115,7 @@ namespace CLEO
         CCustomScript *LoadScript(const char *szFilePath);
 
         bool NativeScriptsDebugMode; // debug mode enabled?
+        CLEO::eCLEO_Version NativeScriptsVersion; // allows using legacy modes
         std::string MainScriptFileDir;
         std::string MainScriptFileName;
         std::string MainScriptCurWorkDir;

--- a/source/cleo_config.ini
+++ b/source/cleo_config.ini
@@ -1,3 +1,6 @@
 [General]
-; debug opcodes, on screen prints etc.: 0 - off, 1 - enabled
+; default debug mode state for all scripts (see opcode debug_on/debug_off): 0 - off, 1 - enabled
 DebugMode=0
+
+; legacy mode for main script(s): 0 - off, 3 - CLEO3, 4 - CLEO4
+MainScmLegacyMode=0


### PR DESCRIPTION
cleo_config.ini now has option to enable legacy scripts modes for native scripts (main.scm).
Unified way of queering script version (with CLEO_GetScriptVersion).
Removed duplicated assignments of script version and debug mode properties, as these are already handled by CCustomScript constructor.

To test legacy modes in main script use:
`$a = pow {number} 1 {power} 2.0`
Number argument is supposed to be float, error message is not displayed in legacy modes.