### PR TITLE
Added CLEO version info to error message boxes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@
 - now all opcodes in range **0-7FFF** can be registered by plugins
 - plugins moved to _cleo\cleo_plugins_ directory
 - new SDK methods:
+  - CLEO_GetVersionStr
   - CLEO_RegisterCommand
   - CLEO_RegisterCallback
   - CLEO_GetVarArgCount

--- a/cleo_sdk/CLEO.h
+++ b/cleo_sdk/CLEO.h
@@ -459,6 +459,7 @@ extern "C" {
 #endif	//__cplusplus
 
 DWORD WINAPI CLEO_GetVersion();
+LPCSTR WINAPI CLEO_GetVersionStr(); // for example "5.0.0-alpha.1"
 eGameVersion WINAPI CLEO_GetGameVersion();
 
 BOOL WINAPI CLEO_RegisterOpcode(WORD opcode, _pOpcodeHandler callback);

--- a/cleo_sdk/CLEO_Utils.h
+++ b/cleo_sdk/CLEO_Utils.h
@@ -375,7 +375,8 @@ namespace CLEO
             ShowWindow(*mainWnd, SW_MINIMIZE);
         }
 
-        MessageBoxA(NULL, msg, "CLEO error", MB_SYSTEMMODAL | MB_TOPMOST | MB_ICONERROR | MB_OK);
+        auto caption = StringPrintf("CLEO v%s", CLEO_GetVersionStr());
+        MessageBoxA(NULL, msg, caption.c_str(), MB_SYSTEMMODAL | MB_TOPMOST | MB_ICONERROR | MB_OK);
 
         if (fullscreen)
         {

--- a/source/CGameVersionManager.cpp
+++ b/source/CGameVersionManager.cpp
@@ -109,6 +109,11 @@ namespace CLEO
             return CLEO_VERSION;
         }
 
+        LPCSTR WINAPI CLEO_GetVersionStr()
+        {
+            return CLEO_VERSION_STR;
+        }
+
         eGameVersion WINAPI CLEO_GetGameVersion()
         {
             return DetermineGameVersion();

--- a/source/cleo.def
+++ b/source/cleo.def
@@ -57,3 +57,4 @@ EXPORTS
 	_CLEO_TerminateScript@4					@54
 	_CLEO_GetGameDirectory@0				@55
 	_CLEO_GetUserDirectory@0				@56
+	_CLEO_GetVersionStr@0					@57


### PR DESCRIPTION
Removed word "error" suggesting CLEO's error, while it usually reports bugs in user's scripts.
Fixes #270