### PR TITLE
Legacy behavior for INI read int/float when value does not contain number

### DIFF
--- a/cleo_plugins/IniFiles/IniFiles.cpp
+++ b/cleo_plugins/IniFiles/IniFiles.cpp
@@ -58,7 +58,8 @@ public:
 			// parse
 			char* end;
 			int value = strtol(str, &end, base);
-			if (end != str) // at least one number character consumed
+			if (end != str || // at least one number character consumed
+				IsLegacyScript(thread)) // old CLEO reported success anyway with value 0
 			{
 				OPCODE_WRITE_PARAM_INT(value);
 				OPCODE_CONDITION_RESULT(true);
@@ -130,7 +131,8 @@ public:
 				value = strtof(str, &end);
 			}
 
-			if (end != str) // at least one number character consumed
+			if (end != str || // at least one number character consumed
+				IsLegacyScript(thread)) // old CLEO reported success anyway with value 0
 			{
 				OPCODE_WRITE_PARAM_FLOAT(value);
 				OPCODE_CONDITION_RESULT(true);


### PR DESCRIPTION
Commands **read_int_from_ini_file** and **read_float_from_ini_file** called from scripts in legacy mode now returns success and value 0 in case of invalid data inside ini file.
Fixes #281

Test script.
```
{$CLEO .cs}

//set_current_directory 1

write_int_to_ini_file {value} 42 {path} "test.ini" {section} "t" {key} "iVal"
write_float_to_ini_file {value} 42.0 {path} "test.ini" {section} "t" {key} "fVal"
//write_string_to_ini_file {value} "forty two" {path} "test.ini" {section} "t" {key} "sVal" // CLEO4 crash

while true
    wait 100
    
    int iVal = 123
    int iResult = false
    if
        iVal = read_int_from_ini_file {path} "test.ini" {section} "t" {key} "iVal"
    then
        iResult = true
    end
    
    float fVal = 123
    int fResult = false
    if
        fVal = read_float_from_ini_file {path} "test.ini" {section} "t" {key} "fVal"
    then
        fResult = true
    end
    
    longString sVal = "default"
    int sResult = false
    if
        sVal = read_string_from_ini_file {path} "test.ini" {section} "t" {key} "sVal"
    then
        sResult = true
    end
    
    print_formatted_now {format} "INT - ok: %d, value: %d~n~FLOAT - ok: %d, value: %f~n~TXT - ok: %d, value: %s" {time} 1000 {args} iResult iVal fResult fVal sResult sVal
end
```