### PR TITLE
custom implementation for terminate_all_scripts_with_this_name

### DIFF
--- a/cleo_plugins/MemoryOperations/MemoryOperations.cpp
+++ b/cleo_plugins/MemoryOperations/MemoryOperations.cpp
@@ -25,6 +25,8 @@ public:
         }
 
         //register opcodes
+        CLEO_RegisterOpcode(0x0459, opcode_0459); // terminate_all_scripts_with_this_name
+
         CLEO_RegisterOpcode(0x0A8C, opcode_0A8C); // write_memory
         CLEO_RegisterOpcode(0x0A8D, opcode_0A8D); // read_memory
 
@@ -215,6 +217,24 @@ public:
         }
 
         CLEO_SkipUnusedVarArgs(thread);
+        return OR_CONTINUE;
+    }
+
+    //0459=1,terminate_all_scripts_with_this_name %1s%
+    static OpcodeResult __stdcall opcode_0459(CLEO::CRunningScript* thread)
+    {
+        OPCODE_READ_PARAM_STRING(threadName);
+
+        while (true)
+        {
+            // we only want to terminate game scripts, not custom ones
+            auto found = CLEO_GetScriptByName(threadName, true, false, 0);
+            if (found == nullptr)
+                break;
+
+            CLEO_TerminateScript(found);
+        }
+
         return OR_CONTINUE;
     }
 

--- a/source/CScriptEngine.cpp
+++ b/source/CScriptEngine.cpp
@@ -1200,6 +1200,11 @@ namespace CLEO
         {
             for (auto script = *activeThreadQueue; script; script = script->GetNext())
             {
+                if (script->IsCustom()) 
+                {
+                    // skip custom scripts in the queue, they are handled separately
+                    continue;
+                }
                 if (_strnicmp(threadName, script->Name, sizeof(script->Name)) == 0)
                 {
                     if (resultIndex == 0) return script;


### PR DESCRIPTION
Calling **terminate_all_scripts_with_this_name** with the name that matches a custom script leads to nasty bugs. Native implementation moves custom script from active queue to inactive one. If a new script is now spawned (in any way: reloading the game, calling start_new_script, or triggering an external script), this struct will be picked from the inactive queue (with **bIsCustom** still set). It may cause all sorts of unexpected behavior, from CLEO5 warnings, to game crashes. See the repro script:

```
{$CLEO .cs}

script_name 'help'

while true
    wait 0
    if 
        test_cheat "repr"
    then
        terminate_all_scripts_with_this_name 'HELP' // current script is marked as inactive
        0ace: "the game is screwed, don't try to load another save"
    end
end
```
after using "REPR" cheat and loading another save the game crashes.


This PR ensures we only iterate game scripts when calling terminate_all_scripts_with_this_name and ignore all CLEO scripts.
In theory we _can_ process custom scripts with this opcode, but it may cause unexpected results when CLEO script name matches some name used in original scripts ('INT', 'APGATE', 'VALET', etc), so leaving it outside of the scope.

