### PR TITLE
update INI commands to allow deleting sections or keys from ini files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,8 @@
   - **2000 ([get_cleo_arg_count](https://library.sannybuilder.com/#/sa/CLEO/2000))**
   - **2002 ([cleo_return_with](https://library.sannybuilder.com/#/sa/CLEO/2002))**
   - **2003 ([cleo_return_fail](https://library.sannybuilder.com/#/sa/CLEO/2003))**
+  - **2800 ([delete_section_from_ini_file](https://library.sannybuilder.com/#/sa/ini/2800))**
+  - **2801 ([delete_key_from_ini_file](https://library.sannybuilder.com/#/sa/ini/2801))**
   - 'argument count' parameter of **0AB1 (cleo_call)** is now optional. `cleo_call @LABEL args 0` can be written as `cleo_call @LABEL`
   - 'argument count' parameter of **0AB2 (cleo_return)** is now optional. `cleo_return 0` can be written as `cleo_return`
   - SCM functions can return string literals and string variables
@@ -132,6 +134,7 @@
   - CLEO_IsScriptRunning
   - CLEO_TerminateScript
   - CLEO_GetScriptVersion
+  - CLEO_SetScriptVersion
   - CLEO_GetScriptInfoStr
   - CLEO_GetScriptFilename
   - CLEO_GetScriptWorkDir

--- a/cleo_plugins/IniFiles/IniFiles.cpp
+++ b/cleo_plugins/IniFiles/IniFiles.cpp
@@ -118,7 +118,7 @@ public:
 		auto value = OPCODE_READ_PARAM_INT();
 		OPCODE_READ_PARAM_FILEPATH_INI(path);
 		OPCODE_READ_PARAM_STRING(section);
-        OPCODE_READ_PARAM_STRING_OR_ZERO(key);	// 0 deletes the whole section
+		OPCODE_READ_PARAM_STRING_OR_ZERO(key);	// 0 deletes the whole section
 
 		char strValue[32];
 		_itoa(value, strValue, 10);

--- a/cleo_sdk/CLEO.h
+++ b/cleo_sdk/CLEO.h
@@ -472,7 +472,7 @@ void WINAPI CLEO_UnregisterCallback(eCallbackId id, void* func);
 // script utils
 BOOL WINAPI CLEO_IsScriptRunning(const CRunningScript* thread); // check if script is active
 void WINAPI CLEO_GetScriptInfoStr(CRunningScript* thread, bool currLineInfo, char* buf, DWORD bufSize); // short text for displaying in error\log messages
-void WINAPI CLEO_GetScriptParamInfoStr(int idexOffset, char* buf, DWORD bufSize); // short text with current+offset opcode parameter info (index and name if available)
+void WINAPI CLEO_GetScriptParamInfoStr(int idexOffset, char* buf, DWORD bufSize); // short text with last processed + idexOffset opcode's parameter info (index and name if available)
 eCLEO_Version WINAPI CLEO_GetScriptVersion(const CRunningScript* thread); // get compatible version
 void WINAPI CLEO_SetScriptVersion(CRunningScript* thread, eCLEO_Version version); // set compatible version
 LPCSTR WINAPI CLEO_GetScriptFilename(const CRunningScript* thread); // returns nullptr if provided script ptr is not valid

--- a/cleo_sdk/CLEO.h
+++ b/cleo_sdk/CLEO.h
@@ -473,7 +473,8 @@ void WINAPI CLEO_UnregisterCallback(eCallbackId id, void* func);
 BOOL WINAPI CLEO_IsScriptRunning(const CRunningScript* thread); // check if script is active
 void WINAPI CLEO_GetScriptInfoStr(CRunningScript* thread, bool currLineInfo, char* buf, DWORD bufSize); // short text for displaying in error\log messages
 void WINAPI CLEO_GetScriptParamInfoStr(int idexOffset, char* buf, DWORD bufSize); // short text with current+offset opcode parameter info (index and name if available)
-eCLEO_Version WINAPI CLEO_GetScriptVersion(const CRunningScript* thread); // compatibility mode
+eCLEO_Version WINAPI CLEO_GetScriptVersion(const CRunningScript* thread); // get compatible version
+void WINAPI CLEO_SetScriptVersion(CRunningScript* thread, eCLEO_Version version); // set compatible version
 LPCSTR WINAPI CLEO_GetScriptFilename(const CRunningScript* thread); // returns nullptr if provided script ptr is not valid
 
 LPCSTR WINAPI CLEO_GetScriptWorkDir(const CRunningScript* thread);

--- a/cleo_sdk/CLEO_Utils.h
+++ b/cleo_sdk/CLEO_Utils.h
@@ -604,7 +604,7 @@ namespace CLEO
 
         if (!_paramWasString())
         {
-            SHOW_ERROR("Input argument %s expected to be string, got %s in script %s\nScript suspended.", GetParamInfo().c_str(), ToKindStr(_lastParamType, _lastParamArrayType), ScriptInfoStr(thread).c_str());
+            SHOW_ERROR("Input argument %s expected to be string, got %s in script %s\nScript suspended.", GetParamInfo(1).c_str(), ToKindStr(_lastParamType, _lastParamArrayType), ScriptInfoStr(thread).c_str());
             thread->Suspend();
             _lastParamType = DT_INVALID; // mark error
             return nullptr;

--- a/source/CCustomOpcodeSystem.cpp
+++ b/source/CCustomOpcodeSystem.cpp
@@ -1940,7 +1940,7 @@ extern "C"
 
 	void WINAPI CLEO_GetScriptParamInfoStr(int idexOffset, char* buf, DWORD bufSize)
 	{
-		auto curr = idexOffset - 1 + CleoInstance.OpcodeSystem.handledParamCount;
+		auto curr = idexOffset + CleoInstance.OpcodeSystem.handledParamCount;
 		auto name = CleoInstance.OpcodeInfoDb.GetArgumentName(CleoInstance.OpcodeSystem.lastOpcode, curr);
 
 		curr++; // 1-based argument index display

--- a/source/CCustomOpcodeSystem.cpp
+++ b/source/CCustomOpcodeSystem.cpp
@@ -1940,7 +1940,7 @@ extern "C"
 
 	void WINAPI CLEO_GetScriptParamInfoStr(int idexOffset, char* buf, DWORD bufSize)
 	{
-		auto curr = idexOffset + CleoInstance.OpcodeSystem.handledParamCount;
+		auto curr = idexOffset - 1 + CleoInstance.OpcodeSystem.handledParamCount;
 		auto name = CleoInstance.OpcodeInfoDb.GetArgumentName(CleoInstance.OpcodeSystem.lastOpcode, curr);
 
 		curr++; // 1-based argument index display

--- a/source/CScriptEngine.cpp
+++ b/source/CScriptEngine.cpp
@@ -268,6 +268,14 @@ namespace CLEO
                 return CleoInstance.ScriptEngine.NativeScriptsVersion;
         }
 
+        void WINAPI CLEO_SetScriptVersion(CRunningScript* thread, eCLEO_Version version)
+        {
+            if (thread->IsCustom())
+                ((CCustomScript*)thread)->SetCompatibility(version);
+            else
+                CleoInstance.ScriptEngine.NativeScriptsVersion = version;
+        }
+
         LPCSTR WINAPI CLEO_GetScriptFilename(const CRunningScript* thread)
         {
             if (!CleoInstance.ScriptEngine.IsValidScriptPtr(thread))

--- a/source/cleo.def
+++ b/source/cleo.def
@@ -58,3 +58,4 @@ EXPORTS
 	_CLEO_GetGameDirectory@0				@55
 	_CLEO_GetUserDirectory@0				@56
 	_CLEO_GetVersionStr@0					@57
+	_CLEO_SetScriptVersion@8				@58

--- a/tests/cleo_tests/IniFiles/0AF1.txt
+++ b/tests/cleo_tests/IniFiles/0AF1.txt
@@ -3,8 +3,8 @@
 
 script_name "0AF1"
 test("0AF1 (write_int_to_ini_file)", tests)
-terminate_this_custom_script
 
+terminate_this_custom_script
 
 const Test_Path = "cleo\cleo_test_file.ini"
 
@@ -17,81 +17,81 @@ function tests
     it("should create new file", test3)
     it("should add to existing file", test4)
     it("should overwrite value", test5)
-    it("should delete section", test6)
+    it_cs4("should delete section with 0", test6)
     return
-    
+
     :cleanup
-        delete_file {path} Test_Path
+    delete_file {path} Test_Path
     return
-    
+
     function test1
         write_int_to_ini_file {value} 42 {path} "CLEO.asi" {section} "test" {key} "test"
         assert_result_false()
     end
-    
+
     function test2
         write_int_to_ini_file {value} 42 {path} "cleo" {section} "test" {key} "test"
         assert_result_false()
     end
-    
+
     function test3
         does_file_exist {path} Test_Path
         assert_result_false()
-        
+
         write_int_to_ini_file {value} 42 {path} Test_Path {section} "test" {key} "test"
         assert_result_true()
-        
+
         does_file_exist {path} Test_Path
         assert_result_true()
-        
+
         int value = read_int_from_ini_file {path} Test_Path {section} "test" {key} "test"
         assert_eq(value, 42)
     end
-    
+
     function test4
         does_file_exist {path} Test_Path
-        assert_result_false()
-    
+        assert_result_false() 
+
         write_int_to_ini_file {value} 42 {path} Test_Path {section} "test" {key} "testA"
         assert_result_true()
-        
+
         write_int_to_ini_file {value} 50 {path} Test_Path {section} "test" {key} "testB"
         assert_result_true()
-        
+
         int value = read_int_from_ini_file {path} Test_Path {section} "test" {key} "testA"
         assert_eq(value, 42)
-        
+
         value = read_int_from_ini_file {path} Test_Path {section} "test" {key} "testB"
         assert_eq(value, 50)
     end
-    
+
     function test5
         does_file_exist {path} Test_Path
         assert_result_false()
-    
+
         write_int_to_ini_file {value} 42 {path} Test_Path {section} "test" {key} "test"
         assert_result_true()
-        
+
         write_int_to_ini_file {value} 50 {path} Test_Path {section} "test" {key} "test"
         assert_result_true()
-                
+
         int value = read_int_from_ini_file {path} Test_Path {section} "test" {key} "test"
         assert_eq(value, 50)
     end
-    
+
     function test6
         does_file_exist {path} Test_Path
         assert_result_false()
-    
+
         write_int_to_ini_file {value} 42 {path} Test_Path {section} "test" {key} "test"
         assert_result_true()
-        
+
         int value = read_int_from_ini_file {path} Test_Path {section} "test" {key} "test"
         assert_eq(value, 42)
-        
+
         write_int_to_ini_file {value} 42 {path} Test_Path {section} "test" {key} 0
         assert_result_true()
-                
+
         value = read_int_from_ini_file {path} Test_Path {section} "test" {key} "test"
         assert_result_false()
     end

--- a/tests/cleo_tests/IniFiles/0AF1.txt
+++ b/tests/cleo_tests/IniFiles/0AF1.txt
@@ -17,6 +17,7 @@ function tests
     it("should create new file", test3)
     it("should add to existing file", test4)
     it("should overwrite value", test5)
+    it("should delete section", test6)
     return
     
     :cleanup
@@ -24,7 +25,7 @@ function tests
     return
     
     function test1
-        write_int_to_ini_file {value} 42 {path} "gta_sa.exe" {section} "test" {key} "test"
+        write_int_to_ini_file {value} 42 {path} "CLEO.asi" {section} "test" {key} "test"
         assert_result_false()
     end
     
@@ -76,6 +77,23 @@ function tests
                 
         int value = read_int_from_ini_file {path} Test_Path {section} "test" {key} "test"
         assert_eq(value, 50)
+    end
+    
+    function test6
+        does_file_exist {path} Test_Path
+        assert_result_false()
+    
+        write_int_to_ini_file {value} 42 {path} Test_Path {section} "test" {key} "test"
+        assert_result_true()
+        
+        int value = read_int_from_ini_file {path} Test_Path {section} "test" {key} "test"
+        assert_eq(value, 42)
+        
+        write_int_to_ini_file {value} 42 {path} Test_Path {section} "test" {key} 0
+        assert_result_true()
+                
+        value = read_int_from_ini_file {path} Test_Path {section} "test" {key} "test"
+        assert_result_false()
     end
 
 end

--- a/tests/cleo_tests/IniFiles/0AF1.txt
+++ b/tests/cleo_tests/IniFiles/0AF1.txt
@@ -3,7 +3,6 @@
 
 script_name "0AF1"
 test("0AF1 (write_int_to_ini_file)", tests)
-
 terminate_this_custom_script
 
 const Test_Path = "cleo\cleo_test_file.ini"

--- a/tests/cleo_tests/IniFiles/0AF3.txt
+++ b/tests/cleo_tests/IniFiles/0AF3.txt
@@ -16,7 +16,7 @@ function tests
     it("should create new file", test3)
     it("should add to existing file", test4)
     it("should overwrite value", test5)
-    it("should delete section", test6)
+    it_cs4("should delete section with 0", test6)
     return
 
     :cleanup
@@ -85,7 +85,7 @@ function tests
         write_float_to_ini_file {value} 42.0 {path} Test_Path {section} "test" {key} "test"
         assert_result_true()
 
-        int value = read_float_from_ini_file {path} Test_Path {section} "test" {key} "test"
+        float value = read_float_from_ini_file {path} Test_Path {section} "test" {key} "test"
         assert_eqf(value, 42.0)
 
         write_float_to_ini_file {value} 42.0 {path} Test_Path {section} "test" {key} 0

--- a/tests/cleo_tests/IniFiles/0AF3.txt
+++ b/tests/cleo_tests/IniFiles/0AF3.txt
@@ -5,7 +5,6 @@ script_name "0AF3"
 test("0AF3 (write_float_to_ini_file)", tests)
 terminate_this_custom_script
 
-
 const Test_Path = "cleo\cleo_test_file.ini"
 
 function tests
@@ -17,65 +16,83 @@ function tests
     it("should create new file", test3)
     it("should add to existing file", test4)
     it("should overwrite value", test5)
+    it("should delete section", test6)
     return
-    
+
     :cleanup
-        delete_file {path} Test_Path
+    delete_file {path} Test_Path
     return
-    
+
     function test1
-        write_float_to_ini_file {value} 42.0 {path} "gta_sa.exe" {section} "test" {key} "test"
+        write_float_to_ini_file {value} 42.0 {path} "CLEO.asi" {section} "test" {key} "test"
         assert_result_false()
     end
-    
+
     function test2
         write_float_to_ini_file {value} 42.0 {path} "cleo" {section} "test" {key} "test"
         assert_result_false()
     end
-    
+
     function test3
         does_file_exist {path} Test_Path
         assert_result_false()
-        
+
         write_float_to_ini_file {value} 42.0 {path} Test_Path {section} "test" {key} "test"
         assert_result_true()
-        
+
         does_file_exist {path} Test_Path
         assert_result_true()
-        
+
         int value = read_float_from_ini_file {path} Test_Path {section} "test" {key} "test"
         assert_eqf(value, 42.0)
     end
-    
+
     function test4
         does_file_exist {path} Test_Path
         assert_result_false()
-    
+
         write_float_to_ini_file {value} 42.0 {path} Test_Path {section} "test" {key} "testA"
         assert_result_true()
-        
+
         write_float_to_ini_file {value} 50.0 {path} Test_Path {section} "test" {key} "testB"
         assert_result_true()
-        
+
         int value = read_float_from_ini_file {path} Test_Path {section} "test" {key} "testA"
         assert_eqf(value, 42.0)
-        
+
         value = read_float_from_ini_file {path} Test_Path {section} "test" {key} "testB"
         assert_eqf(value, 50.0)
     end
-    
+
     function test5
         does_file_exist {path} Test_Path
         assert_result_false()
-    
+
         write_float_to_ini_file {value} 42.0 {path} Test_Path {section} "test" {key} "test"
         assert_result_true()
-        
+
         write_float_to_ini_file {value} 50.0 {path} Test_Path {section} "test" {key} "test"
         assert_result_true()
-                
+
         int value = read_float_from_ini_file {path} Test_Path {section} "test" {key} "test"
         assert_eqf(value, 50.0)
+    end
+
+    function test6
+        does_file_exist {path} Test_Path
+        assert_result_false()
+
+        write_float_to_ini_file {value} 42.0 {path} Test_Path {section} "test" {key} "test"
+        assert_result_true()
+
+        int value = read_float_from_ini_file {path} Test_Path {section} "test" {key} "test"
+        assert_eqf(value, 42.0)
+
+        write_float_to_ini_file {value} 42.0 {path} Test_Path {section} "test" {key} 0
+        assert_result_true()
+
+        value = read_float_from_ini_file {path} Test_Path {section} "test" {key} "test"
+        assert_result_false()
     end
 
 end

--- a/tests/cleo_tests/IniFiles/0AF5.txt
+++ b/tests/cleo_tests/IniFiles/0AF5.txt
@@ -5,7 +5,6 @@ script_name "0AF5"
 test("0AF5 (write_string_to_ini_file)", tests)
 terminate_this_custom_script
 
-
 const Test_Path = "cleo\cleo_test_file.ini"
 
 function tests
@@ -17,65 +16,101 @@ function tests
     it("should create new file", test3)
     it("should add to existing file", test4)
     it("should overwrite value", test5)
+    it("should delete section", test6)
+    it("should delete key", test7)
     return
-    
+
     :cleanup
-        delete_file {path} Test_Path
+    delete_file {path} Test_Path
     return
-    
+
     function test1
-        write_string_to_ini_file {value} "value_one" {path} "gta_sa.exe" {section} "test" {key} "test"
+        write_string_to_ini_file {value} "value_one" {path} "CLEO.asi" {section} "test" {key} "test"
         assert_result_false()
     end
-    
+
     function test2
         write_string_to_ini_file {value} "value_one" {path} "cleo" {section} "test" {key} "test"
         assert_result_false()
     end
-    
+
     function test3
         does_file_exist {path} Test_Path
         assert_result_false()
-        
+
         write_string_to_ini_file {value} "value_one" {path} Test_Path {section} "test" {key} "test"
         assert_result_true()
-        
+
         does_file_exist {path} Test_Path
         assert_result_true()
-        
+
         longstring value = read_string_from_ini_file {path} Test_Path {section} "test" {key} "test"
         assert_eqs(value, "value_one")
     end
-    
+
     function test4
         does_file_exist {path} Test_Path
         assert_result_false()
-    
+
         write_string_to_ini_file {value} "value_one" {path} Test_Path {section} "test" {key} "testA"
         assert_result_true()
-        
+
         write_string_to_ini_file {value} "value_two" {path} Test_Path {section} "test" {key} "testB"
         assert_result_true()
-        
+
         longstring value = read_string_from_ini_file {path} Test_Path {section} "test" {key} "testA"
         assert_eqs(value, "value_one")
-        
+
         value = read_string_from_ini_file {path} Test_Path {section} "test" {key} "testB"
         assert_eqs(value, "value_two")
     end
-    
+
     function test5
         does_file_exist {path} Test_Path
         assert_result_false()
-    
+
         write_string_to_ini_file {value} "value_one" {path} Test_Path {section} "test" {key} "test"
         assert_result_true()
-        
+
         write_string_to_ini_file {value} "value_two" {path} Test_Path {section} "test" {key} "test"
         assert_result_true()
-                
+
         longstring value = read_string_from_ini_file {path} Test_Path {section} "test" {key} "test"
         assert_eqs(value, "value_two")
+    end
+
+    function test6
+        does_file_exist {path} Test_Path
+        assert_result_false()
+
+        write_string_to_ini_file {value} "value_one" {path} Test_Path {section} "test" {key} "test"
+        assert_result_true()
+
+        longstring value = read_string_from_ini_file {path} Test_Path {section} "test" {key} "test"
+        assert_eqs(value, "value_one")
+
+        write_string_to_ini_file {value} "value_one" {path} Test_Path {section} "test" {key} 0
+        assert_result_true()
+
+        value = read_string_from_ini_file {path} Test_Path {section} "test" {key} "test"
+        assert_result_false()
+    end
+
+    function test7
+        does_file_exist {path} Test_Path
+        assert_result_false()
+
+        write_string_to_ini_file {value} "value_one" {path} Test_Path {section} "test" {key} "test"
+        assert_result_true()
+
+        longstring value = read_string_from_ini_file {path} Test_Path {section} "test" {key} "test"
+        assert_eqs(value, "value_one")
+
+        write_string_to_ini_file {value} 0 {path} Test_Path {section} "test" {key} "test"
+        assert_result_true()
+
+        value = read_string_from_ini_file {path} Test_Path {section} "test" {key} "test"
+        assert_result_false()
     end
 
 end

--- a/tests/cleo_tests/IniFiles/0AF5.txt
+++ b/tests/cleo_tests/IniFiles/0AF5.txt
@@ -16,8 +16,8 @@ function tests
     it("should create new file", test3)
     it("should add to existing file", test4)
     it("should overwrite value", test5)
-    it("should delete section", test6)
-    it("should delete key", test7)
+    it_cs4("should delete section", test6)
+    it_cs4("should delete key", test7)
     return
 
     :cleanup

--- a/tests/cleo_tests/IniFiles/2800.txt
+++ b/tests/cleo_tests/IniFiles/2800.txt
@@ -1,0 +1,38 @@
+{$CLEO .s}
+{$INCLUDE_ONCE ../cleo_tester.inc}
+
+script_name "2800"
+test("2800 (delete_section_from_ini_file)", tests)
+terminate_this_custom_script
+
+const Test_Path = "cleo\cleo_test_file.ini"
+
+function tests
+    before_each(@cleanup)
+    after_each(@cleanup)
+
+    it("should delete section from ini", test1)
+    return
+
+    :cleanup
+    delete_file {path} Test_Path
+    return
+
+    function test1
+        write_string_to_ini_file {value} "value1" {path} Test_Path {section} "test" {key} "key1"
+        assert_result_true()
+        
+        write_string_to_ini_file {value} "value2" {path} Test_Path {section} "test" {key} "key2"
+        assert_result_true()
+
+        delete_section_from_ini_file {path} Test_Path {section} "test"
+        assert_result_true()
+
+        longstring value1 = read_string_from_ini_file {path} Test_Path {section} "test" {key} "key1"
+        assert_result_false()
+        
+        longstring value2 = read_string_from_ini_file {path} Test_Path {section} "test" {key} "key2"
+        assert_result_false()
+    end
+
+end

--- a/tests/cleo_tests/IniFiles/2801.txt
+++ b/tests/cleo_tests/IniFiles/2801.txt
@@ -1,0 +1,38 @@
+{$CLEO .s}
+{$INCLUDE_ONCE ../cleo_tester.inc}
+
+script_name "2801"
+test("2801 (delete_key_from_ini_file)", tests)
+terminate_this_custom_script
+
+const Test_Path = "cleo\cleo_test_file.ini"
+
+function tests
+    before_each(@cleanup)
+    after_each(@cleanup)
+
+    it("should delete key from ini", test1)
+    return
+
+    :cleanup
+    delete_file {path} Test_Path
+    return
+
+    function test1
+        write_string_to_ini_file {value} "value1" {path} Test_Path {section} "test" {key} "key1"
+        assert_result_true()
+
+        write_string_to_ini_file {value} "value2" {path} Test_Path {section} "test" {key} "key2"
+        assert_result_true()
+
+        delete_key_from_ini_file {path} Test_Path {section} "test" {key} "key1"
+        assert_result_true()
+
+        longstring value1 = read_string_from_ini_file {path} Test_Path {section} "test" {key} "key1"
+        assert_result_false()
+
+        longstring value2 = read_string_from_ini_file {path} Test_Path {section} "test" {key} "key2"
+        assert_result_true()
+    end
+
+end

--- a/tests/cleo_tests/cleo_tester.inc
+++ b/tests/cleo_tests/cleo_tester.inc
@@ -41,52 +41,21 @@ function test(suite_name: string, callback: int)
     cleo_call callback
 end
 
-function set_current_script_compat_to(compat: int)
-    int lib, proc, ver
-    if
-        lib = load_dynamic_library "root:\CLEO.asi"
-    then
-        if
-            proc = get_dynamic_library_procedure "_CLEO_SetScriptVersion@8" {library} lib
-        then
-            int cur_script = get_this_script_struct
-            call_function {address} proc {numParams} 2 {pop} 0 {funcParams} compat cur_script
-        else
-            trace "Can't find SetScriptVersion in CLEO.asi"
-            breakpoint
-        end
-
-        free_dynamic_library lib
-    else
-        trace "Can't load CLEO.asi"
-        breakpoint
-    end
-end
-
-function set_current_script_compat
-    int compat = _cleo_tester_read_var(VAR_COMPAT)
-    set_current_script_compat_to(compat)
-end
-
-function restore_current_script_compat
-    set_current_script_compat_to(DEFAULT_COMPAT)
-end
-
 /// registers new unit test in a test suite
 /// use assert_*(...) to validate result
 function it(spec_name: string, callback: int)
-    run_with_compat_mode(spec_name, callback, DEFAULT_COMPAT)
+    _run_with_compat_mode(spec_name, callback, DEFAULT_COMPAT)
 end
 
 /// registers new unit test in a test suite - runs in CS4 mode
 /// use assert_*(...) to validate result
 function it_cs4(spec_name: string, callback: int)
-    run_with_compat_mode(spec_name, callback, CLEO4_COMPAT)
+    _run_with_compat_mode(spec_name, callback, CLEO4_COMPAT)
 end
 
 /// registers new unit test in a test suite
 /// use assert_*(...) to validate result
-function run_with_compat_mode(spec_name: string, callback: int, compat: int)
+function _run_with_compat_mode(spec_name: string, callback: int, compat: int)
     int index = _cleo_tester_read_var(VAR_TEST_INDEX)
     _cleo_tester_write_var(VAR_COMPAT, compat)
 
@@ -123,10 +92,10 @@ function run_with_compat_mode(spec_name: string, callback: int, compat: int)
         :_cleo_tester_before_each
         gosub @_cleo_tester_stub
 
-        set_current_script_compat()
+        _set_current_script_compat()
         :_cleo_tester_run
         cleo_call @_cleo_tester_stub {numParams} 32 {params} 0@ 1@ 2@ 3@ 4@ 5@ 6@ 7@ 8@ 9@ 10@ 11@ 12@ 13@ 14@ 15@ 16@ 17@ 18@ 19@ 20@ 21@ 22@ 23@ 24@ 25@ 26@ 27@ 28@ 29@ 30@ 31@
-        restore_current_script_compat()
+        _restore_current_script_compat()
 
         :_cleo_tester_after_each
         gosub @_cleo_tester_stub
@@ -396,5 +365,37 @@ end
 function after_each(callback: int)
     _cleo_tester_write_var(VAR_AFTER_EACH, callback)
 end
+
+function _set_current_script_compat_to(compat: int)
+    int lib, proc, ver
+    if
+        lib = load_dynamic_library "root:\CLEO.asi"
+    then
+        if
+            proc = get_dynamic_library_procedure "_CLEO_SetScriptVersion@8" {library} lib
+        then
+            int cur_script = get_this_script_struct
+            call_function {address} proc {numParams} 2 {pop} 0 {funcParams} compat cur_script
+        else
+            trace "Can't find SetScriptVersion in CLEO.asi"
+            breakpoint
+        end
+
+        free_dynamic_library lib
+    else
+        trace "Can't load CLEO.asi"
+        breakpoint
+    end
+end
+
+function _set_current_script_compat
+    int compat = _cleo_tester_read_var(VAR_COMPAT)
+    _set_current_script_compat_to(compat)
+end
+
+function _restore_current_script_compat
+    _set_current_script_compat_to(DEFAULT_COMPAT)
+end
+
 
 :_cleo_tester_skip_fns

--- a/tests/cleo_tests/cleo_tester.inc
+++ b/tests/cleo_tests/cleo_tester.inc
@@ -4,6 +4,11 @@ const VAR_BEFORE_EACH = 1
 const VAR_AFTER_EACH = 2
 const VAR_SPEC = 3
 const VAR_ASSERT_INDEX = 4
+const VAR_COMPAT = 5
+
+const CLEO5_COMPAT = 0x05000000
+const CLEO4_COMPAT = 0x04040000
+const DEFAULT_COMPAT = CLEO5_COMPAT
 
 jump @_cleo_tester_skip_fns
 
@@ -24,57 +29,112 @@ end
 /// use it(...) for individual unit tests
 function test(suite_name: string, callback: int)
     debug_on
-    
+
     int suite_name_buf = get_label_pointer @_cleo_tester_test_name
     copy_memory {src} suite_name {dest} suite_name_buf {size} 255 // used in an it trace
     trace "" // separator
     trace "Testing %s" suite_name
-    
+
     _cleo_tester_write_var(VAR_BEFORE_EACH, @_cleo_tester_stub)
     _cleo_tester_write_var(VAR_AFTER_EACH, @_cleo_tester_stub)
     _cleo_tester_write_var(VAR_TEST_INDEX, 1)
     cleo_call callback
 end
 
+function set_current_script_compat_to(compat: int)
+    int lib, proc, ver
+    if
+        lib = load_dynamic_library "root:\CLEO.asi"
+    then
+        if
+            proc = get_dynamic_library_procedure "_CLEO_SetScriptVersion@8" {library} lib
+        then
+
+            int cur_script = get_this_script_struct
+            // set compatibility mode with CLEO 4.4
+            call_function {address} proc {numParams} 2 {pop} 0 {funcParams} compat cur_script
+
+        else
+            trace "Can't find SetScriptVersion in CLEO.asi"
+            breakpoint
+        end
+
+        free_dynamic_library lib
+    else
+        trace "Can't load CLEO.asi"
+        breakpoint
+    end
+end
+
+function set_current_script_compat
+    int compat = _cleo_tester_read_var(VAR_COMPAT)
+    set_current_script_compat_to(compat)
+end
+
+function restore_current_script_compat
+    set_current_script_compat_to(DEFAULT_COMPAT)
+end
+
 /// registers new unit test in a test suite
 /// use assert_*(...) to validate result
 function it(spec_name: string, callback: int)
+    run_with_compat_mode(spec_name, callback, DEFAULT_COMPAT)
+end
+
+/// registers new unit test in a test suite - runs in CS4 mode
+/// use assert_*(...) to validate result
+function it_cs4(spec_name: string, callback: int)
+    run_with_compat_mode(spec_name, callback, CLEO4_COMPAT)
+end
+
+/// registers new unit test in a test suite
+/// use assert_*(...) to validate result
+function run_with_compat_mode(spec_name: string, callback: int, compat: int)
     int index = _cleo_tester_read_var(VAR_TEST_INDEX)
+    _cleo_tester_write_var(VAR_COMPAT, compat)
 
     int spec_name_buf = get_label_pointer @_cleo_tester_spec_name
     copy_memory {src} spec_name {dest} spec_name_buf {size} 255 // used in a failed assert
     int test_name = get_label_pointer @_cleo_tester_test_name
-    trace "~s~Test #%d %s" index spec_name
+
+    if compat == DEFAULT_COMPAT
+    then
+        trace "~s~Test #%d %s" index spec_name
+    else
+        trace "~s~Test #%d %s - COMPAT MODE %d" index spec_name compat
+    end
 
     wait 0
     _cleo_tester_write_var(VAR_SPEC, callback)
     _cleo_tester_write_var(VAR_ASSERT_INDEX, 0)
-    
+
     run_spec()
 
     //trace "~g~~h~~h~Test #%d PASSED" index
     index++
     _cleo_tester_write_var(VAR_TEST_INDEX, index)
-    
+
     return
 
     function run_spec
         // this function should use 0 local variables
-    
+
         inject_offset(@_cleo_tester_before_each, VAR_BEFORE_EACH)
         inject_offset(@_cleo_tester_after_each, VAR_AFTER_EACH)
         inject_offset(@_cleo_tester_run, VAR_SPEC)
-        
+
         :_cleo_tester_before_each
         gosub @_cleo_tester_stub
 
+        set_current_script_compat()
         :_cleo_tester_run
         cleo_call @_cleo_tester_stub {numParams} 32 {params} 0@ 1@ 2@ 3@ 4@ 5@ 6@ 7@ 8@ 9@ 10@ 11@ 12@ 13@ 14@ 15@ 16@ 17@ 18@ 19@ 20@ 21@ 22@ 23@ 24@ 25@ 26@ 27@ 28@ 29@ 30@ 31@
-        
+        restore_current_script_compat()
+
         :_cleo_tester_after_each
         gosub @_cleo_tester_stub
     end
-    
+
     // self-patch script code with new gosub/call offset
     function inject_offset(label: int, var_index: int)
         int function_offset = _cleo_tester_read_var(var_index)
@@ -88,7 +148,7 @@ return
 
 :_cleo_tester_shared_vars
 hex
-    00(20) // 5 variables
+    00(24) // 6 variables
 end
 :_cleo_tester_test_name
 hex
@@ -123,211 +183,211 @@ end
 /// checks if bool value is true (different than 0)
 function assert_true(flag: int)
     _cleo_tester_increment_assert()
-	if
-		flag == false
-	then
+    if
+        flag == false
+    then
         _cleo_tester_fail()
         trace "~g~~h~~h~TRUE~s~ expected~n~~r~~h~~h~%d~s~ occured" flag
         breakpoint
         terminate_this_custom_script
-	end
+    end
 end
 
 /// checks if bool value is false
 function assert_false(flag: int)
     _cleo_tester_increment_assert()
-	if
-		flag <> false
-	then
+    if
+        flag <> false
+    then
         _cleo_tester_fail()
         trace "~g~~h~~h~FALSE~s~ expected~n~~r~~h~~h~%d~s~ occured" flag
         breakpoint
         terminate_this_custom_script
-	end
+    end
 end
 
 /// checks if condition result value is true
 :assert_result_true
-    goto_if_false @_assert_result_true
-    _cleo_tester_increment_assert()
-    return
+goto_if_false @_assert_result_true
+_cleo_tester_increment_assert()
+return
 
-    :_assert_result_true
-    _cleo_tester_increment_assert()
-    _cleo_tester_fail()
-    trace "~s~Condition result is ~r~~h~~h~FALSE~s~, expected ~g~~h~~h~TRUE~s~"
-    breakpoint
-    terminate_this_custom_script
+:_assert_result_true
+_cleo_tester_increment_assert()
+_cleo_tester_fail()
+trace "~s~Condition result is ~r~~h~~h~FALSE~s~, expected ~g~~h~~h~TRUE~s~"
+breakpoint
+terminate_this_custom_script
 return
 
 /// checks if condition result value is false
 :assert_result_false
-    goto_if_false @_assert_result_false
+goto_if_false @_assert_result_false
 
-    _cleo_tester_increment_assert()
-    _cleo_tester_fail()
-    trace "~s~Condition result is ~r~~h~~h~TRUE~s~, expected ~g~~h~~h~FALSE~s~"
-    breakpoint
-    terminate_this_custom_script
-    
-    :_assert_result_false
-    _cleo_tester_increment_assert()
+_cleo_tester_increment_assert()
+_cleo_tester_fail()
+trace "~s~Condition result is ~r~~h~~h~TRUE~s~, expected ~g~~h~~h~FALSE~s~"
+breakpoint
+terminate_this_custom_script
+
+:_assert_result_false
+_cleo_tester_increment_assert()
 return
 
 /// checks if two int values are equal, otherwise stops the test execution
 function assert_eq(actual: int, expected: int)
     _cleo_tester_increment_assert()
-	if
-		actual <> expected
-	then
+    if
+        actual <> expected
+    then
         _cleo_tester_fail()
         trace "~g~~h~~h~%08X~s~ expected~n~~r~~h~~h~%08X~s~ occured" expected actual
         breakpoint
         terminate_this_custom_script
-	end
+    end
 end
 
 /// checks if two int values are not equal, otherwise stops the test execution
 function assert_neq(actual: int, expected: int)
-	if
-		actual == expected
-	then
+    if
+        actual == expected
+    then
         _cleo_tester_fail()
         trace "~s~Expected value different than ~r~~h~~h~%08X~s~" actual
         breakpoint
         terminate_this_custom_script
-	end
+    end
 end
 
 /// checks if int value is within specified range, otherwise stops the test execution
 function assert_range(actual: int, expectedMin: int, expectedMax: int)
     _cleo_tester_increment_assert()
-	if or
-		actual < expectedMin
-		actual > expectedMax
-	then
+    if or
+        actual < expectedMin
+        actual > expectedMax
+    then
         _cleo_tester_fail()
         trace "~g~~h~~h~%08X to %08X~s~ expected~n~~r~~h~~h~%08X~s~ occured" expectedMin expectedMax actual
         breakpoint
         terminate_this_custom_script
-	end
+    end
 end
 
 /// checks if two float values are equal, otherwise stops the test execution
 function assert_eqf(actual: float, expected: float)
     _cleo_tester_increment_assert()
-	if
-		actual <> expected
-	then
+    if
+        actual <> expected
+    then
         _cleo_tester_fail()
         trace "~g~~h~~h~%f~s~ expected~n~~r~~h~~h~%f~s~ occured" expected actual
         breakpoint
         terminate_this_custom_script
-	end
+    end
 end
 
 /// checks if two float values are not equal, otherwise stops the test execution
 function assert_neqf(actual: float, expected: float)
     _cleo_tester_increment_assert()
-	if
-		actual == expected
-	then
+    if
+        actual == expected
+    then
         _cleo_tester_fail()
         trace "~s~Expected value different than ~r~~h~~h~%f~s~" actual
         breakpoint
         terminate_this_custom_script
-	end
+    end
 end
 
 /// checks if float value is within specified range, otherwise stops the test execution
 function assert_rangef(actual: float, expectedMin: float, expectedMax: float)
     _cleo_tester_increment_assert()
-	if or
-		actual < expectedMin
-		actual > expectedMax
-	then
+    if or
+        actual < expectedMin
+        actual > expectedMax
+    then
         _cleo_tester_fail()
         trace "~g~~h~~h~%f to %f~s~ expected~n~~r~~h~~h~%f~s~ occured" expectedMin expectedMax actual
         breakpoint
         terminate_this_custom_script
-	end
+    end
 end
 
 /// checks if value is a valid pointer, otherwise stops the test execution
 function assert_ptr(ptr: int)
     _cleo_tester_increment_assert()
-	if
-		ptr <= 0x10000 // possibly valid pointer
-	then
+    if
+        ptr <= 0x10000 // possibly valid pointer
+    then
         _cleo_tester_fail()
         trace "%08X is not valid pointer" ptr
         breakpoint
         terminate_this_custom_script
-	end
+    end
 end
 
 /// checks if value is not 0, otherwise stops the test execution
 function assert(flag: int)
     _cleo_tester_increment_assert()
-	if
-		flag == 0
-	then
+    if
+        flag == 0
+    then
         _cleo_tester_fail()
         breakpoint
         terminate_this_custom_script
-	end
+    end
 end
 
 /// checks if two string values are equal, otherwise stops the test execution
 function assert_eqs(actual: string, expected: string)
     _cleo_tester_increment_assert()
-	if
-		not is_text_equal {text} actual {another} expected {ignoreCase} false
-	then
+    if
+        not is_text_equal {text} actual {another} expected {ignoreCase} false
+    then
         _cleo_tester_fail()
         trace "`~g~~h~~h~%s~s~` expected~n~`~r~~h~~h~%s~s~` occured" expected actual
         breakpoint
         terminate_this_custom_script
-	end
+    end
 end
 
 /// checks if two string values are not equal, otherwise stops the test execution
 function assert_neqs(actual: string, expected: string)
     _cleo_tester_increment_assert()
-	if
-		is_text_equal {text} actual {another} expected {ignoreCase} false
-	then
+    if
+        is_text_equal {text} actual {another} expected {ignoreCase} false
+    then
         _cleo_tester_fail()
         trace "~s~Expected value different than `~r~~h~~h~%s~s~`" actual
         breakpoint
         terminate_this_custom_script
-	end
+    end
 end
 
 /// checks if string starts with prefix, otherwise stops the test execution
 function assert_prefix(actual: string, expectedPrefix: string, ignoreCase: int)
     _cleo_tester_increment_assert()
-	if
-	   not is_text_prefix {text} actual {prefix} expectedPrefix {ignoreCase} ignoreCase
-	then
+    if
+        not is_text_prefix {text} actual {prefix} expectedPrefix {ignoreCase} ignoreCase
+    then
         _cleo_tester_fail()
         trace "`~g~~h~~h~%s~s~` prefix expected~n~`~r~~h~~h~%s~s~` text occured" expectedPrefix actual
         breakpoint
         terminate_this_custom_script
-	end
+    end
 end
 
 /// checks if string ends with suffix, otherwise stops the test execution
 function assert_suffix(actual: string, expectedSuffix: string, ignoreCase: int)
     _cleo_tester_increment_assert()
-	if
-	   not is_text_suffix {text} actual {prefix} expectedSuffix {ignoreCase} ignoreCase
-	then
+    if
+        not is_text_suffix {text} actual {prefix} expectedSuffix {ignoreCase} ignoreCase
+    then
         _cleo_tester_fail()
         trace "`~g~~h~~h~%s~s~` suffix expected~n~`~r~~h~~h~%s~s~` text occured" expectedSuffix actual
         breakpoint
         terminate_this_custom_script
-	end
+    end
 end
 
 /// registers a callback that runs before each unit test (test setup)
@@ -339,6 +399,5 @@ end
 function after_each(callback: int)
     _cleo_tester_write_var(VAR_AFTER_EACH, callback)
 end
-
 
 :_cleo_tester_skip_fns

--- a/tests/cleo_tests/cleo_tester.inc
+++ b/tests/cleo_tests/cleo_tester.inc
@@ -49,11 +49,8 @@ function set_current_script_compat_to(compat: int)
         if
             proc = get_dynamic_library_procedure "_CLEO_SetScriptVersion@8" {library} lib
         then
-
             int cur_script = get_this_script_struct
-            // set compatibility mode with CLEO 4.4
             call_function {address} proc {numParams} 2 {pop} 0 {funcParams} compat cur_script
-
         else
             trace "Can't find SetScriptVersion in CLEO.asi"
             breakpoint


### PR DESCRIPTION
* calling [WritePrivateProfileStringA ](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-writeprivateprofilestringa) with NULL for key or value allows deleting the whole section or the key respectively. Since 0 is a valid int/float value, only allow `0` in value position for `write_string_to_ini_file` - ONLY in CLEO 4.4 compatible mode
* updated / fixed tests. use of "gta_sa.exe" in some tests caused my local gta_sa.exe to be corrupted as I run the game from gta_sa_compact.exe.
* added new SDK method to set script compat mode
* updated test framework with new `it_cs4` function to test code in CS4 compat mode
* added 2 new commands in ini extension: [DELETE_SECTION_FROM_INI_FILE ](https://library.sannybuilder.com/#/sa/script/extensions/ini/2800) and [DELETE_KEY_FROM_INI_FILE](https://library.sannybuilder.com/#/sa/script/extensions/ini/2801)