### PR TITLE
Allow call_method_return with nullptr 'this' param

### DIFF
--- a/cleo_plugins/MemoryOperations/MemoryOperations.cpp
+++ b/cleo_plugins/MemoryOperations/MemoryOperations.cpp
@@ -534,7 +534,7 @@ public:
         }
         else
         {
-            obj = (void*)OPCODE_READ_PARAM_INT(); // at least one mod used 0AA8 with 0 as struct argument (effectively turning it into 0AA7 opcode...)
+            obj = (void*)OPCODE_READ_PARAM_INT(); // some mods got creative and used it as way to set ECX
         }
 
         auto numArgs = OPCODE_READ_PARAM_INT();

--- a/cleo_plugins/MemoryOperations/MemoryOperations.cpp
+++ b/cleo_plugins/MemoryOperations/MemoryOperations.cpp
@@ -526,7 +526,17 @@ public:
     static OpcodeResult __stdcall opcode_0AA8(CLEO::CRunningScript* thread)
     {
         auto func = OPCODE_READ_PARAM_PTR();
-        auto obj = OPCODE_READ_PARAM_PTR();
+
+        void* obj = nullptr;
+        if (!IsLegacyScript(thread))
+        {
+            obj = OPCODE_READ_PARAM_PTR();
+        }
+        else
+        {
+            obj = (void*)OPCODE_READ_PARAM_INT(); // at least one mod used 0AA8 with 0 as struct argument (effectively turning it into 0AA7 opcode...)
+        }
+
         auto numArgs = OPCODE_READ_PARAM_INT();
         auto numPop = OPCODE_READ_PARAM_INT();
 

--- a/tests/cleo_tests/MemoryOperations/0AA8.txt
+++ b/tests/cleo_tests/MemoryOperations/0AA8.txt
@@ -12,21 +12,21 @@ function tests
     return
         
     function test1
-        0@ = get_ped_pointer {char} $scplayer
-        1@ = call_method_return {address} 0x00411990 {struct} 0@ {numParams} 0 {pop} 0 // CEntity.GetMatrix()
-        2@ = read_memory_with_offset {address} 0@ {offset} 0x14 {size} 4 // CEntity::m_matrix
-        assert_eq(1@, 2@)
+        int charPtr = get_ped_pointer {char} $scplayer
+        int result = call_method_return {address} 0x00411990 {struct} charPtr {numParams} 0 {pop} 0 // CEntity.GetMatrix()
+        int matrixPtr = read_memory_with_offset {address} charPtr {offset} 0x14 {size} 4 // CEntity::m_matrix
+        assert_eq(result, matrixPtr)
     end
     
     function test2
-        0@ = call_method_return {address} 0x00826330 {struct} 0 {numParams} 1 {pop} 1 {funcParams} "test" // size_t strlen(const char *Str)
-        assert_eq(0@, 4)
+        int result = call_method_return {address} 0x00826330 {struct} 0 {numParams} 1 {pop} 1 {funcParams} "test" // size_t strlen(const char *Str)
+        assert_eq(result, 4)
     end
     
     function test3
-        0@ = get_label_pointer @ret_ecx
-        1@ = call_method_return {address} 0@ {struct} 10 {numParams} 0 {pop} 0
-        assert_eq(1@, 11)
+        int funcPtr = get_label_pointer @ret_ecx
+        int result = call_method_return {address} funcPtr {struct} 10 {numParams} 0 {pop} 0
+        assert_eq(result, 11)
     end
 end
 

--- a/tests/cleo_tests/MemoryOperations/0AA8.txt
+++ b/tests/cleo_tests/MemoryOperations/0AA8.txt
@@ -1,0 +1,38 @@
+{$CLEO .s}
+{$INCLUDE_ONCE ../cleo_tester.inc}
+
+script_name "0AA8"
+test("0AA8 (call_method_return)", tests)
+terminate_this_custom_script
+
+function tests
+    it("should call class getter method", test1)
+    it_cs4("should ignore null 'this' in legacy modes", test2)
+    it_cs4("should handle misused 'this' in legacy modes", test3)
+    return
+        
+    function test1
+        0@ = get_ped_pointer {char} $scplayer
+        1@ = call_method_return {address} 0x00411990 {struct} 0@ {numParams} 0 {pop} 0 // CEntity.GetMatrix()
+        2@ = read_memory_with_offset {address} 0@ {offset} 0x14 {size} 4 // CEntity::m_matrix
+        assert_eq(1@, 2@)
+    end
+    
+    function test2
+        0@ = call_method_return {address} 0x00826330 {struct} 0 {numParams} 1 {pop} 1 {funcParams} "test" // size_t strlen(const char *Str)
+        assert_eq(0@, 4)
+    end
+    
+    function test3
+        0@ = get_label_pointer @ret_ecx
+        1@ = call_method_return {address} 0@ {struct} 10 {numParams} 0 {pop} 0
+        assert_eq(1@, 11)
+    end
+end
+
+:ret_ecx
+hex
+    89 C8   // mov eax, ecx
+    40      // inc eax
+    C3      // retn
+end

--- a/tests/cleo_tests/cleo_tester.inc
+++ b/tests/cleo_tests/cleo_tester.inc
@@ -67,7 +67,7 @@ function _run_with_compat_mode(spec_name: string, callback: int, compat: int)
     then
         trace "~s~Test #%d %s" index spec_name
     else
-        trace "~s~Test #%d %s - COMPAT MODE %d" index spec_name compat
+        trace "~s~Test #%d %s - COMPAT MODE %p" index spec_name compat
     end
 
     wait 0


### PR DESCRIPTION
Enables **Turn Indicators** mod to work in cs4 mode
https://www.gtagarage.com/mods/show.php?id=14581 to work

That script misuses call method opcode hardly
![image](https://github.com/user-attachments/assets/9132c907-7a62-4e42-b862-f72a4993f14c)