### PR TITLE
Censoring user name in logs

### DIFF
--- a/source/CDebug.cpp
+++ b/source/CDebug.cpp
@@ -17,7 +17,7 @@ void CDebug::Trace(CLEO::eLogLevel level, const char* msg)
     OutputDebugString("\n");
 #endif
 
-    // censor user name in paths like "C:\Users\xxx\Documments..."
+    // censor user name in paths like "C:\Users\xxx\Documents..."
     const char* UsersDir = "\\users\\";
     std::string msgStr = msg;
     StringToLower(msgStr);

--- a/source/CDebug.cpp
+++ b/source/CDebug.cpp
@@ -17,6 +17,26 @@ void CDebug::Trace(CLEO::eLogLevel level, const char* msg)
     OutputDebugString("\n");
 #endif
 
+    // censor user name in paths like "C:\Users\xxx\Documments..."
+    const char* UsersDir = "\\users\\";
+    std::string msgStr = msg;
+    StringToLower(msgStr);
+    auto usersDirPos = strstr(msgStr.c_str(), UsersDir);
+    if (usersDirPos != nullptr)
+    {
+        size_t userBegin = (size_t)(usersDirPos - msgStr.c_str()) + strlen(UsersDir);
+        
+        size_t userEnd = msgStr.find_first_of("\\/*\"<>:|?", userBegin); // till next path separator or any invalid filepath character
+        if (userEnd == std::string::npos)
+        {
+            userEnd = msgStr.length();
+        }
+
+        msgStr = msg; // restore original case
+        msgStr.replace(userBegin, userEnd - userBegin, "[redacted]");
+        msg = msgStr.c_str();
+    }
+
     // output to callbacks
     if (CleoInstance.IsStarted())
     {

--- a/source/CScriptEngine.cpp
+++ b/source/CScriptEngine.cpp
@@ -1649,7 +1649,7 @@ namespace CLEO
         }
         catch (std::exception& e)
         {
-            LOG_WARNING(0, "Error during loading of custom script %s occured.\nError message: %s", szFileName, e.what());
+            LOG_WARNING(0, "Error during loading of custom script '%s' occured.\nError message: %s", szFileName, e.what());
         }
         catch (...)
         {


### PR DESCRIPTION
Example log output:
`03/03/2025 22:41:58.975 Error during loading of custom script c:\users\[redacted]\documents\gta san andreas user files\test.cs occured.`