### PR TITLE
don't include tests in release archive

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,7 @@ jobs:
           copy cleo_plugins\.output\*.cleo .output\Release\cleo\cleo_plugins
           copy cleo_plugins\.output\*.ini .output\Release\cleo\cleo_plugins
           copy cleo_plugins\Audio\bass\bass.dll .output\Release\bass.dll
-          xcopy /E /I tests .output\Release\cleo
+          @REM xcopy /E /I tests .output\Release\cleo
           xcopy /E /I examples .output\Release\cleo_readme\examples
 
           @REM copy SDK


### PR DESCRIPTION
if someone needs tests (who?) they can download them using this batch script

```
curl -L https://github.com/cleolibrary/CLEO5/archive/refs/heads/master.zip -o CLEO5-master.zip
"C:\Program Files\7-Zip\7z.exe" x CLEO5-master.zip -aoa
cp -r CLEO5-master/tests cleo_tests
rm CLEO5-master.zip
rm -r CLEO5-master
```