### PR TITLE
Disable CI tests running again on PR creation/reopen.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,6 @@ on:
     paths-ignore:
     - ".github/*"
     - "*.md"
-  pull_request:
-    types: [opened, reopened]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Currently creating PR runs CI test job, which already is done for each commit, resulting in 2 jobs:
![image](https://github.com/user-attachments/assets/382a2d76-97e5-42b4-a105-865ff1678f42)
