### PR TITLE
Implemented proper distance decay and source size handling for 3d sounds.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 - fixed sound glitches of 3d audio streams when playback starts or the camera mode changes
 - fixed possible crashes when car/object/ped with attached 3d audio stream is deleted
 - fixed CLEO sound artifacts when moving camera with mouse
+- updated distance decay for 3d CLEO sounds to match behavior of in-game sounds
+- implemented propper support for 3d CLEO sounds source size
+- CLEO sounds volume is now affected by wide screen and fades in same way as in-game sounds
+- updated "Audio_Demo" example script
 - reverted muting 'music' type audio streams for game speeds other than default introduced in 5.0.1
 - allow storing string result at static address (e.g. `get_name_of_vehicle_model 400 0xC16F98`)
 - fixed error in **0A92 ([stream_custom_script](https://sannybuilder.com/lib/sa/script/CLEO/0A92))** when game is installed in symlink or RAM Disk directory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 - fixed sound glitches of 3d audio streams when playback starts or the camera mode changes
 - fixed possible crashes when car/object/ped with attached 3d audio stream is deleted
 - fixed CLEO sound artifacts when moving camera with mouse
-- updated distance decay for 3d CLEO sounds to match behavior of in-game sounds
-- implemented propper support for 3d CLEO sounds source size
+- updated distance decay for 3d audio streams to match behavior of in-game sounds
+- implemented proper support for 3d audio streams source size
 - CLEO sounds volume is now affected by wide screen and fades in same way as in-game sounds
 - updated "Audio_Demo" example script
 - reverted muting 'music' type audio streams for game speeds other than default introduced in 5.0.1

--- a/cleo_plugins/Audio/Audio.vcxproj
+++ b/cleo_plugins/Audio/Audio.vcxproj
@@ -162,7 +162,7 @@ xcopy /Y "$(OutDir)$(TargetName).*" "$(GTA_SA_DIR)\cleo\cleo_plugins\" </Command
     <ClInclude Include="C3DAudioStream.h" />
     <ClInclude Include="CAudioStream.h" />
     <ClInclude Include="CSoundSystem.h" />
-    <ClInclude Include="CSlidingParam.h" />
+    <ClInclude Include="CInterpolatedValue.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="SA.Audio.ini" />

--- a/cleo_plugins/Audio/Audio.vcxproj
+++ b/cleo_plugins/Audio/Audio.vcxproj
@@ -162,6 +162,7 @@ xcopy /Y "$(OutDir)$(TargetName).*" "$(GTA_SA_DIR)\cleo\cleo_plugins\" </Command
     <ClInclude Include="C3DAudioStream.h" />
     <ClInclude Include="CAudioStream.h" />
     <ClInclude Include="CSoundSystem.h" />
+    <ClInclude Include="CSlidingParam.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="SA.Audio.ini" />

--- a/cleo_plugins/Audio/Audio.vcxproj.filters
+++ b/cleo_plugins/Audio/Audio.vcxproj.filters
@@ -61,7 +61,7 @@
     </ClInclude>
     <ClInclude Include="CAudioStream.h" />
     <ClInclude Include="C3DAudioStream.h" />
-    <ClInclude Include="CSlidingParam.h" />
+    <ClInclude Include="CInterpolatedValue.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="plugin_sdk">

--- a/cleo_plugins/Audio/Audio.vcxproj.filters
+++ b/cleo_plugins/Audio/Audio.vcxproj.filters
@@ -61,6 +61,7 @@
     </ClInclude>
     <ClInclude Include="CAudioStream.h" />
     <ClInclude Include="C3DAudioStream.h" />
+    <ClInclude Include="CSlidingParam.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="plugin_sdk">

--- a/cleo_plugins/Audio/C3DAudioStream.cpp
+++ b/cleo_plugins/Audio/C3DAudioStream.cpp
@@ -68,7 +68,7 @@ void C3DAudioStream::Process()
     // position and velocity
     CVector relPos = position - CSoundSystem::position;
     float distance = relPos.NormaliseAndMag();
-    float inFactor = CalculateDistanceDecay(max(distance - radius, 0.0f) * 5.0f); // use decay curve for blending inside-outside source effects
+    float inFactor = (float)CalculateDistanceDecay(max(distance - radius, 0.0f) * 5.0f); // use decay curve for blending inside-outside source effects
 
     // stereo panning
     float sign = dot(CSoundSystem::direction, relPos) > 0.0f ? 1.0f : -1.0f;
@@ -90,7 +90,7 @@ float C3DAudioStream::CalculateVolume()
     CVector relPos = position - CSoundSystem::position;
     float distance = relPos.NormaliseAndMag();
     distance = max(distance - radius, 0.0f);
-    float inFactor = CalculateDistanceDecay(distance * 5.0f); // use decay curve for blending inside-outside source effects
+    float inFactor = (float)CalculateDistanceDecay(distance * 5.0f); // use decay curve for blending inside-outside source effects
 
     double vol = Volume_3D_Adjust;
 
@@ -150,7 +150,7 @@ double C3DAudioStream::CalculateDistanceDecay(float distance)
     return exp(-0.008 * powf(distance, 1.5f)); // more natural feeling
 }
 
-double C3DAudioStream::CalculateDirectionDecay(const CVector& listenerDir, const CVector& relativePos)
+float C3DAudioStream::CalculateDirectionDecay(const CVector& listenerDir, const CVector& relativePos)
 {
     float factor = dot(listenerDir, relativePos);
     factor = 0.6f + 0.4f * factor; // 0.2 to 1.0

--- a/cleo_plugins/Audio/C3DAudioStream.cpp
+++ b/cleo_plugins/Audio/C3DAudioStream.cpp
@@ -1,6 +1,7 @@
 #include "C3DAudioStream.h"
 #include "CSoundSystem.h"
 #include "CLEO_Utils.h"
+#include "CCamera.h"
 
 using namespace CLEO;
 
@@ -15,7 +16,7 @@ C3DAudioStream::C3DAudioStream(const char* filepath) : CAudioStream()
         return;
     }
 
-    unsigned flags = BASS_SAMPLE_3D | BASS_SAMPLE_MONO | BASS_SAMPLE_SOFTWARE;
+    unsigned flags = BASS_SAMPLE_3D | BASS_SAMPLE_MONO | BASS_SAMPLE_SOFTWARE | BASS_STREAM_PRESCAN;
     if (CSoundSystem::useFloatAudio) flags |= BASS_SAMPLE_FLOAT;
 
     if (!(streamInternal = BASS_StreamCreateFile(FALSE, filepath, 0, 0, flags)) &&
@@ -26,7 +27,7 @@ C3DAudioStream::C3DAudioStream(const char* filepath) : CAudioStream()
     }
 
     BASS_ChannelGetAttribute(streamInternal, BASS_ATTRIB_FREQ, &rate);
-    BASS_ChannelSet3DAttributes(streamInternal, BASS_3DMODE_NORMAL, 3.0f, 1E+12f, -1, -1, -1.0f);
+    BASS_ChannelSet3DAttributes(streamInternal, BASS_3DMODE_NORMAL, -1.0f, -1.0f, -1, -1, -1.0f);
     BASS_ChannelSetAttribute(streamInternal, BASS_ATTRIB_VOL, 0.0f); // muted until processed
     ok = true;
 }
@@ -40,7 +41,7 @@ void C3DAudioStream::Set3dPosition(const CVector& pos)
 
 void C3DAudioStream::Set3dSourceSize(float radius)
 {
-    BASS_ChannelSet3DAttributes(streamInternal, BASS_3DMODE_NORMAL, radius, 1E+12f, -1, -1, -1.0f);
+    this->radius = std::max<float>(radius, 0.1f);
 }
 
 void C3DAudioStream::SetHost(CEntity* host, const CVector& offset)
@@ -61,8 +62,99 @@ void C3DAudioStream::SetHost(CEntity* host, const CVector& offset)
 
 void C3DAudioStream::Process()
 {
-    CAudioStream::Process();
     UpdatePosition();
+    CAudioStream::Process();
+
+    // position and velocity
+    CVector relPos = position - CSoundSystem::position;
+    float distance = relPos.NormaliseAndMag();
+    float inFactor = std::clamp(2.0f - distance / radius, 0.0f, 1.0f); // sound source size simulation
+
+    // stereo panning
+    float sign = dot(CSoundSystem::direction, relPos) > 0.0f ? 1.0f : -1.0f;
+    CVector centerPos = CSoundSystem::position + CSoundSystem::direction * distance * sign;
+    CVector percPos = lerp(position, centerPos, inFactor);
+
+    CVector percVel = lerp(velocity, CSoundSystem::velocity, inFactor);
+
+    BASS_ChannelSet3DPosition(streamInternal, &toBass(percPos), nullptr, &toBass(percVel));
+}
+
+float C3DAudioStream::CalculateVolume()
+{
+    if (!placed)
+    {
+        return 0.0f; // mute until processed
+    }
+
+    CVector relPos = position - CSoundSystem::position;
+    float distance = relPos.NormaliseAndMag();
+    distance = max(distance - radius, 0.0f);
+    float inFactor = CalculateDistanceDecay(distance * 5.0f); // use decay curve for blending inside-outside source effects
+
+    double vol = Volume_3D_Adjust;
+
+    switch (type)
+    {
+        case SoundEffect: vol *= CSoundSystem::masterVolumeSfx; break;
+        case Music: vol *= CSoundSystem::masterVolumeMusic; break;
+        case UserInterface: vol *= CSoundSystem::masterVolumeSfx; break;
+        default: vol *= 1.0f; break;
+    }
+
+    // distance decay
+    vol *= CalculateDistanceDecay(distance);
+
+    // "look" direction decay
+    vol *= lerp(CalculateDirectionDecay(CSoundSystem::direction, relPos), 1.0f, inFactor);
+
+    // screen black fade
+    if (type != UserInterface && !TheCamera.m_bIgnoreFadingStuffForMusic)
+    {
+        vol *= 1.0f - TheCamera.m_fFadeAlpha / 255.0f;
+    }
+
+    // music volume lowering in cutscenes, when characters talk, mission sounds are played etc.
+    if (type == Music) 
+    {
+        if (TheCamera.m_bWideScreenOn) vol *= 0.25f;
+    }
+
+    // stream's volume
+    vol *= volume.value();
+
+    return (float)vol;
+}
+
+float C3DAudioStream::CalculateSpeed()
+{
+    float masterSpeed;
+    switch (type)
+    {
+        case SoundEffect: masterSpeed = CSoundSystem::masterSpeed; break;
+        case Music: masterSpeed = CSoundSystem::masterSpeed; break;
+        case UserInterface: masterSpeed = 1.0f; break;
+        default: masterSpeed = 1.0f;
+    }
+
+    return masterSpeed * speed.value();
+}
+
+double C3DAudioStream::CalculateDistanceDecay(float distance)
+{
+    // exact match to ingame sounds
+    /*float factor = 1.0f / powf(1.0f + distance, 2); // inverse square
+    factor -= 0.00006f;
+    factor = std::clamp(factor, 0.0f, 1.0f);*/
+
+    return exp(-0.008 * powf(distance, 1.5f)); // more natural feeling
+}
+
+double C3DAudioStream::CalculateDirectionDecay(const CVector& listenerDir, const CVector& relativePos)
+{
+    float factor = dot(listenerDir, relativePos);
+    factor = 0.6f + 0.4f * factor; // 0.2 to 1.0
+    return factor;
 }
 
 void C3DAudioStream::UpdatePosition()
@@ -92,6 +184,7 @@ void C3DAudioStream::UpdatePosition()
         if (!hostValid)
         {
             hostType = ENTITY_TYPE_NOTHING;
+            placed = false;
             Stop();
             return;
         }
@@ -105,13 +198,12 @@ void C3DAudioStream::UpdatePosition()
 
     if (prevPos.Magnitude() > 0.0f) // not equal to 0,0,0
     {
-        CVector velocity = position - prevPos;
+        velocity = position - prevPos;
         velocity /= CSoundSystem::timeStep;
-        BASS_ChannelSet3DPosition(streamInternal, &toBass(position), nullptr, &toBass(velocity));
+        placed = true;
     }
     else
     {
-        BASS_ChannelSetAttribute(streamInternal, BASS_ATTRIB_VOL, 0.0f); // muted until next update
+        placed = false;
     }
 }
-

--- a/cleo_plugins/Audio/C3DAudioStream.cpp
+++ b/cleo_plugins/Audio/C3DAudioStream.cpp
@@ -68,7 +68,7 @@ void C3DAudioStream::Process()
     // position and velocity
     CVector relPos = position - CSoundSystem::position;
     float distance = relPos.NormaliseAndMag();
-    float inFactor = std::clamp(2.0f - distance / radius, 0.0f, 1.0f); // sound source size simulation
+    float inFactor = CalculateDistanceDecay(max(distance - radius, 0.0f) * 5.0f); // use decay curve for blending inside-outside source effects
 
     // stereo panning
     float sign = dot(CSoundSystem::direction, relPos) > 0.0f ? 1.0f : -1.0f;

--- a/cleo_plugins/Audio/C3DAudioStream.h
+++ b/cleo_plugins/Audio/C3DAudioStream.h
@@ -19,7 +19,7 @@ namespace CLEO
     protected:
         const float Volume_3D_Adjust = 0.5f; // match other ingame sound sources
         static double CalculateDistanceDecay(float distance);
-        static double CalculateDirectionDecay(const CVector& listenerDir, const CVector& relativePos);
+        static float CalculateDirectionDecay(const CVector& listenerDir, const CVector& relativePos);
 
         CEntity* host = nullptr;
         eEntityType hostType = ENTITY_TYPE_NOTHING;

--- a/cleo_plugins/Audio/C3DAudioStream.h
+++ b/cleo_plugins/Audio/C3DAudioStream.h
@@ -13,13 +13,22 @@ namespace CLEO
         virtual void Set3dSourceSize(float radius);
         virtual void SetHost(CEntity* host, const CVector& offset);
         virtual void Process();
+        virtual float CalculateVolume();
+        virtual float CalculateSpeed();
 
     protected:
+        const float Volume_3D_Adjust = 0.5f; // match other ingame sound sources
+        static double CalculateDistanceDecay(float distance);
+        static double CalculateDirectionDecay(const CVector& listenerDir, const CVector& relativePos);
+
         CEntity* host = nullptr;
         eEntityType hostType = ENTITY_TYPE_NOTHING;
         CVector offset = { 0.0f, 0.0f, 0.0f }; // offset in relation to host
+        float radius = 1.0f; // size of sound source
 
+        bool placed = false;
         CVector position = { 0.0f, 0.0f, 0.0f }; // last world position
+        CVector velocity = { 0.0f, 0.0f, 0.0f };
 
         C3DAudioStream(const C3DAudioStream&) = delete; // no copying!
         void UpdatePosition();

--- a/cleo_plugins/Audio/C3DAudioStream.h
+++ b/cleo_plugins/Audio/C3DAudioStream.h
@@ -32,8 +32,6 @@ namespace CLEO
 
         C3DAudioStream(const C3DAudioStream&) = delete; // no copying!
         void UpdatePosition();
-
-        static float audioDecay(float value) { return exp(-6.0f * value * value); } // bell-shaped 0.0-1.0 fade-out
     };
 }
 

--- a/cleo_plugins/Audio/C3DAudioStream.h
+++ b/cleo_plugins/Audio/C3DAudioStream.h
@@ -18,13 +18,13 @@ namespace CLEO
 
     protected:
         const float Volume_3D_Adjust = 0.5f; // match other ingame sound sources
-        static double CalculateDistanceDecay(float distance);
+        static double CalculateDistanceDecay(float radius, float distance);
         static float CalculateDirectionDecay(const CVector& listenerDir, const CVector& relativePos);
 
         CEntity* host = nullptr;
         eEntityType hostType = ENTITY_TYPE_NOTHING;
         CVector offset = { 0.0f, 0.0f, 0.0f }; // offset in relation to host
-        float radius = 1.0f; // size of sound source
+        float radius = 0.5f; // size of sound source
 
         bool placed = false;
         CVector position = { 0.0f, 0.0f, 0.0f }; // last world position
@@ -32,6 +32,8 @@ namespace CLEO
 
         C3DAudioStream(const C3DAudioStream&) = delete; // no copying!
         void UpdatePosition();
+
+        static float audioDecay(float value) { return exp(-6.0f * value * value); } // bell-shaped 0.0-1.0 fade-out
     };
 }
 

--- a/cleo_plugins/Audio/CAudioStream.h
+++ b/cleo_plugins/Audio/CAudioStream.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "CSoundSystem.h"
-#include "CSlidingParam.h"
+#include "CInterpolatedValue.h"
 #include "plugin.h"
 #include "bass.h"
 
@@ -62,8 +62,8 @@ namespace CLEO
         eStreamType type = eStreamType::SoundEffect;
         bool ok = false;
         float rate = 44100.0f; // file's sampling rate
-        CSlidingParam speed = { 1.0f };
-        CSlidingParam volume = { 1.0f };
+        CInterpolatedValue speed = { 1.0f };
+        CInterpolatedValue volume = { 1.0f };
 
         CAudioStream() = default;
         CAudioStream(const CAudioStream&) = delete; // no copying!

--- a/cleo_plugins/Audio/CAudioStream.h
+++ b/cleo_plugins/Audio/CAudioStream.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "CSoundSystem.h"
+#include "CSlidingParam.h"
 #include "plugin.h"
 #include "bass.h"
 
@@ -52,6 +53,8 @@ namespace CLEO
         virtual void SetHost(CEntity* placable, const CVector& offset);
 
         virtual void Process();
+        virtual float CalculateVolume();
+        virtual float CalculateSpeed();
 
     protected:
         HSTREAM streamInternal = 0;
@@ -59,20 +62,11 @@ namespace CLEO
         eStreamType type = eStreamType::SoundEffect;
         bool ok = false;
         float rate = 44100.0f; // file's sampling rate
-        float speed = 1.0f;
-        float volume = 1.0f;
-
-        // transitions
-        float volumeTarget = 1.0f;
-        float volumeTransitionStep = 1.0f;
-        float speedTarget = 1.0f;
-        float speedTransitionStep = 1.0f;
+        CSlidingParam speed = { 1.0f };
+        CSlidingParam volume = { 1.0f };
 
         CAudioStream() = default;
         CAudioStream(const CAudioStream&) = delete; // no copying!
-
-        void UpdateVolume();
-        void UpdateSpeed();
     };
 #pragma pack(pop)
 }

--- a/cleo_plugins/Audio/CInterpolatedValue.h
+++ b/cleo_plugins/Audio/CInterpolatedValue.h
@@ -1,9 +1,9 @@
 #pragma once
 
-class CSlidingParam
+class CInterpolatedValue
 {
 public:
-    CSlidingParam(float value)
+    CInterpolatedValue(float value)
     {
         currValue = value;
         targetValue = value;

--- a/cleo_plugins/Audio/CSlidingParam.h
+++ b/cleo_plugins/Audio/CSlidingParam.h
@@ -1,0 +1,55 @@
+#pragma once
+
+class CSlidingParam
+{
+public:
+    CSlidingParam(float value)
+    {
+        currValue = value;
+        targetValue = value;
+        step = 0.0f;
+    }
+
+    float value() const { return currValue; }
+
+    void setValue(float target, float transitionTime)
+    {
+        targetValue = target;
+
+        if (transitionTime <= 0.0f)
+        {
+            currValue = target;
+            return;
+        }
+
+        step = (targetValue - currValue) / transitionTime;
+    }
+
+    void update(float elapsedTime)
+    {
+        if (currValue == targetValue)
+        {
+            return; // done
+        }
+
+        currValue += step * elapsedTime;
+
+        // check progress
+        auto remaining = targetValue - currValue;
+        remaining *= (step > 0.0f) ? 1.0f : -1.0f;
+        if (remaining <= 0.0f) // overshoot
+        {
+            currValue = targetValue;
+        }
+    }
+
+    void finish()
+    {
+        currValue = targetValue;
+    }
+
+private:
+    float currValue = 0.0f;
+    float targetValue = 0.0f;
+    float step = 0.0f;
+};

--- a/cleo_plugins/Audio/CSoundSystem.h
+++ b/cleo_plugins/Audio/CSoundSystem.h
@@ -30,6 +30,7 @@ namespace CLEO
         static bool CSoundSystem::allowNetworkSources;
 
         static CVector position;
+        static CVector direction;
         static CVector velocity;
         static bool skipFrame; // do not apply changes during this frame
         static float timeStep; // delta time for current frame
@@ -57,7 +58,9 @@ namespace CLEO
         void Process();
     };
 
-    // convert GTA to BASS coordinate system
-    static BASS_3DVECTOR toBass(const CVector& v) { return BASS_3DVECTOR(v.x, v.z, v.y); }
-    bool isNetworkSource(const char* path);
+    static bool isNetworkSource(const char* path) { return _strnicmp("http:", path, 5) == 0 || _strnicmp("https:", path, 6) == 0; }
+    static float dot(CVector a, CVector b) { return a.x * b.x + a.y * b.y + a.z * b.z; }
+    static float lerp(float a, float b, float progress) { return a * (1.0f - progress) + b * progress; }
+    static CVector lerp(CVector a, CVector b, float progress) { return a * (1.0f - progress) + b * progress; }
+    static BASS_3DVECTOR toBass(const CVector& v) { return BASS_3DVECTOR(v.x, v.z, v.y); } // convert GTA to BASS coordinate system
 }

--- a/examples/Audio_Demo.txt
+++ b/examples/Audio_Demo.txt
@@ -4,7 +4,9 @@
 {$CLEO .cs}
 
 const Model_Speaker = 2229
+const Model_Toilet = 2984
 const Audio_Path = ".\cleo_tests\Audio\Ding.mp3" // this script's file relative location
+//const Audio_Path = "https://github.com/cleolibrary/CLEO5/blob/master/tests/cleo_tests/Audio/Speech.mp3?raw=true" // network path
 
 wait 1000
 
@@ -14,23 +16,19 @@ float value, valueCurr
 
 while true
     wait 0
-    print_formatted_now "CLEO5 Audio Plugin DEMO~n~Press key 1 - 7" {time} 0
+    print_formatted_now "CLEO5 Audio Plugin DEMO~n~Press key 1 - 8" {time} 0
     
     if
         test_cheat "1"
     then
         print_formatted_now "DEMO 1: Get progress" {time} 10000
-        START_TEST()
-
         if
-            not load_3d_audio_stream Audio_Path {store_to} soundStream
+            not soundStream, speakerObject = TEST_SETUP(Model_Speaker)
         then
-            print_formatted_now "~r~Failed to load audio file!" {time} 10000
-            END_TEST()
             continue
         end
-        set_play_3d_audio_stream_at_object soundStream {object} speakerObject
-        set_audio_stream_state soundStream AudioStreamAction.Play
+        
+        set_audio_stream_looped soundStream {state} false
 
         while is_audio_stream_playing soundStream
             valueCurr = get_audio_stream_progress soundStream
@@ -38,25 +36,18 @@ while true
             wait 0
         end
 
-        END_TEST()
+        TEST_CLEANUP(soundStream, speakerObject)
     end
     
     if
         test_cheat "2"
     then
         print_formatted_now "DEMO 2: Set volume" {time} 10000
-        START_TEST()
-
         if
-            not load_3d_audio_stream Audio_Path {store_to} soundStream
+            not soundStream, speakerObject = TEST_SETUP(Model_Speaker)
         then
-            print_formatted_now "~r~Failed to load audio file!" {time} 10000
-            END_TEST()
             continue
         end
-        set_play_3d_audio_stream_at_object soundStream {object} speakerObject
-        set_audio_stream_looped soundStream true
-        set_audio_stream_state soundStream AudioStreamAction.Play
 
         TIMERA = 1000
         repeat
@@ -72,25 +63,18 @@ while true
             wait 0
         until test_cheat "2"
 
-        END_TEST()
+        TEST_CLEANUP(soundStream, speakerObject)
     end
     
     if
         test_cheat "3"
     then
         print_formatted_now "Set volume with transition" {time} 10000
-        START_TEST()
-
         if
-            not load_3d_audio_stream Audio_Path {store_to} soundStream
+            not soundStream, speakerObject = TEST_SETUP(Model_Speaker)
         then
-            print_formatted_now "~r~Failed to load audio file!" {time} 10000
-            END_TEST()
             continue
         end
-        set_play_3d_audio_stream_at_object soundStream {object} speakerObject
-        set_audio_stream_looped soundStream true
-        set_audio_stream_state soundStream AudioStreamAction.Play
 
         TIMERA = 2000
         repeat
@@ -103,29 +87,22 @@ while true
             end
 
             valueCurr = get_audio_stream_volume soundStream
-            print_formatted_now "DEMO 3: Set volume: %.2f, Transition: 1.0s~n~Current volume: %.2f~n~Press 3 to stop" {time} 0 {args} value valueCurr
+            print_formatted_now "DEMO 3: Set volume: %.2f, Transition: 2.0s~n~Current volume: %.2f~n~Press 3 to stop" {time} 0 {args} value valueCurr
             wait 0
         until test_cheat "3"
         
-        END_TEST()
+        TEST_CLEANUP(soundStream, speakerObject)
     end
     
     if
         test_cheat "4"
     then
         print_formatted_now "DEMO 4: Set speed" {time} 10000
-        START_TEST()
-
         if
-            not load_3d_audio_stream Audio_Path {store_to} soundStream
+            not soundStream, speakerObject = TEST_SETUP(Model_Speaker)
         then
-            print_formatted_now "~r~Failed to load audio file!" {time} 10000
-            END_TEST()
             continue
         end
-        set_play_3d_audio_stream_at_object soundStream {object} speakerObject
-        set_audio_stream_looped soundStream true
-        set_audio_stream_state soundStream AudioStreamAction.Play
 
         TIMERA = 1000
         repeat
@@ -141,25 +118,18 @@ while true
             wait 0
         until test_cheat "4"
 
-        END_TEST()
+        TEST_CLEANUP(soundStream, speakerObject)
     end
     
     if
         test_cheat "5"
     then
         print_formatted_now "DEMO 5: Set speed with transition" {time} 10000
-        START_TEST()
-
         if
-            not load_3d_audio_stream Audio_Path {store_to} soundStream
+            not soundStream, speakerObject = TEST_SETUP(Model_Speaker)
         then
-            print_formatted_now "~r~Failed to load audio file!" {time} 10000
-            END_TEST()
             continue
         end
-        set_play_3d_audio_stream_at_object soundStream {object} speakerObject
-        set_audio_stream_looped soundStream true
-        set_audio_stream_state soundStream AudioStreamAction.Play
 
         TIMERA = 2000
         repeat
@@ -172,45 +142,36 @@ while true
             end
 
             valueCurr = get_audio_stream_speed soundStream
-            print_formatted_now "DEMO 5: Set speed: %.2f, Transition: 1.0s~n~Current speed: %.2f~n~Press 5 to stop" {time} 0 {args} value valueCurr
+            print_formatted_now "DEMO 5: Set speed: %.2f, Transition: 2.0s~n~Current speed: %.2f~n~Press 5 to stop" {time} 0 {args} value valueCurr
             wait 0
         until test_cheat "5"
 
-        END_TEST()
+        TEST_CLEANUP(soundStream, speakerObject)
     end
     
     if
         test_cheat "6"
     then
         print_formatted_now "DEMO 6: Doppler effect" {time} 10000
-        START_TEST()
-
         if
-            not load_3d_audio_stream Audio_Path {store_to} soundStream
+            not soundStream, speakerObject = TEST_SETUP(Model_Speaker)
         then
-            print_formatted_now "~r~Failed to load audio file!" {time} 10000
-            END_TEST()
             continue
         end
-        set_play_3d_audio_stream_at_object soundStream {object} speakerObject
-        set_audio_stream_looped soundStream true
-        set_audio_stream_volume soundStream {volume} 4.0
-        set_audio_stream_state soundStream AudioStreamAction.Play
-        wait 1000
-
+        
         int direction = 0
         repeat
             if
                 not camera_is_vector_move_running
             then
-                camera_set_vector_track {from} 230.0 2525.0 16.5 {to} 230.0 2525.0 16.5 {time} 1000 {ease} true
+                camera_set_vector_track {from} 230.0 2525.0 16.5 {to} 230.0 2525.0 16.5 {time} 2500 {ease} true
 
                 if
                     direction == 0
                 then
-                    camera_set_vector_move {from} 260.0 2522.0 18.0 {to} 200.0 2522.0 18.0 {time} 1000 {ease} true
+                    camera_set_vector_move {from} 260.0 2522.0 18.0 {to} 200.0 2522.0 18.0 {time} 2500 {ease} true
                 else
-                    camera_set_vector_move {from} 200.0 2522.0 18.0 {to} 260.0 2522.0 18.0 {time} 1000 {ease} true
+                    camera_set_vector_move {from} 200.0 2522.0 18.0 {to} 260.0 2522.0 18.0 {time} 2500 {ease} true
                 end
                 direction = 1 - direction
             end
@@ -219,34 +180,29 @@ while true
             print_formatted_now "DEMO 6: Doppler effect~n~Press 6 to stop" {time} 0
         until test_cheat "6"
 
-        END_TEST()
+        TEST_CLEANUP(soundStream, speakerObject)
     end
     
     if
         test_cheat "7"
     then
-        print_formatted_now "DEMO 7: Game speed changes" {time} 10000
-        START_TEST()
-
+        print_formatted_now "DEMO 7: Game speed" {time} 10000
         if
-            not load_3d_audio_stream Audio_Path {store_to} soundStream
+            not soundStream, speakerObject = TEST_SETUP(Model_Speaker)
         then
-            print_formatted_now "~r~Failed to load audio file!" {time} 10000
-            END_TEST()
             continue
         end
-        set_play_3d_audio_stream_at_object soundStream {object} speakerObject
-        set_audio_stream_looped soundStream true
-        set_audio_stream_state soundStream AudioStreamAction.Play
 
         // walk
-        set_player_control 0 {control} false
+        clear_char_tasks_immediately $scplayer
+        set_char_keep_task $scplayer {state} true
+        set_player_control $player1 {control} false
         flush_route
-        extend_route {xyz} 229.0 2525.0 15.5
-        extend_route {xyz} 230.0 2524.0 15.5
-        extend_route {xyz} 231.0 2525.0 15.5
-        extend_route {xyz} 230.0 2526.0 15.5
-        task_follow_point_route $scplayer {walk_speed} 6 {flag} 3
+        extend_route {xyz} 228.0 2525.0 15.5
+        extend_route {xyz} 230.0 2523.0 15.5
+        extend_route {xyz} 232.0 2525.0 15.5
+        extend_route {xyz} 230.0 2527.0 15.5
+        task_follow_point_route {handle} $scplayer {speed} MoveState.Run {mode} RouteMode.Loop
         task_look_at_object $scplayer {object} speakerObject {time} -1
 
         TIMERA = 2000
@@ -265,46 +221,100 @@ while true
 
         set_time_scale 1.0
         clear_char_tasks_immediately $scplayer
-        set_player_control 0 {control} true
-        END_TEST()
+        set_player_control $player1 {control} true
+        TEST_CLEANUP(soundStream, speakerObject)
+    end
+    
+    if
+        test_cheat "8"
+    then
+        print_formatted_now "DEMO 8: Free mode" {time} 10000
+        if
+            not soundStream, speakerObject = TEST_SETUP(Model_Toilet)
+        then
+            continue
+        end
+        
+        set_object_collision speakerObject {state} true
+        set_object_dynamic speakerObject {state} true
+        
+        clear_char_tasks_immediately $scplayer
+        restore_camera_jumpcut
+        
+        int modelId = get_weapontype_model {weaponType} WeaponType.Grenade
+        request_model {modelId} modelId
+        load_all_models_now
+        give_weapon_to_char $scplayer {weaponType} WeaponType.Grenade {ammo} 0xFFFFFF
+        mark_model_as_no_longer_needed {modelId} modelId
+        display_hud true
+
+        repeat
+            print_formatted_now "DEMO 8: Free mode~n~Press 8 to stop" {time} 0
+            wait 0
+        until test_cheat "8"
+
+        TEST_CLEANUP(soundStream, speakerObject)
     end
 end
 
 terminate_this_script
 
 
-:START_TEST
-    remove_all_char_weapons $scplayer
-    set_max_wanted_level 0
-
-    display_radar false
-    display_hud false
-
+function TEST_SETUP(objectModel: int): int, int
+    int soundStream
+    if
+        not soundStream = load_3d_audio_stream Audio_Path
+    then
+        print_help_formatted "~r~Failed to load audio file ~w~`%s`" {args} Audio_Path
+        cleo_return_with {conditionResult} false {retArgs} -1 -1
+    end
+    
     set_char_coordinates $scplayer {xyz} 230.0 2527.0 15.5
     set_char_heading $scplayer {heading} 180.0
     set_area_visible 0
     set_char_area_visible $scplayer {interiorId} 0
     task_scratch_head $scplayer
+    
+    remove_all_char_weapons $scplayer
+    
+    set_max_wanted_level 0
+    clear_wanted_level $player1
+    set_char_health $scplayer {health} 250
+    set_char_proofs $scplayer {bulletProof} true {fireProof} true {explosionProof} true {collisionProof} true {meleeProof} true
 
+    display_radar false
+    display_hud false
     set_fixed_camera_position {xyz} 230.0 2522.0 18.0 {ypr} 0.0 0.0 0.0
     point_camera_at_char $scplayer {mode} CameraMode.Fixed {switchStyle} SwitchType.JumpCut
+    
+    // create speaker object
+    request_model {modelId} objectModel
+    load_all_models_now
+    int speakerObject = create_object {modelId} objectModel {xyz} 230.25 2525.0 15.8
+    mark_model_as_no_longer_needed {modelId} objectModel
+    set_object_collision speakerObject {state} false
+    set_object_dynamic speakerObject {state} false
+    point_camera_at_point {xyz} 230.0 2525.0 16.5 {switchStyle} SwitchType.Jumpcut
+    
     wait 1000
     
-    // create speaker object (visual only)
-    request_model {modelId} Model_Speaker
-    load_all_models_now
-    speakerObject = create_object {modelId} Model_Speaker {xyz} 230.25 2525.0 16.0
-    mark_model_as_no_longer_needed {modelId} Model_Speaker
-    set_object_collision speakerObject {state} false
-    point_camera_at_point {xyz} 230.0 2525.0 16.5 {switchStyle} SwitchType.Interpolation
-return
+    set_play_3d_audio_stream_at_object soundStream {object} speakerObject
+    set_audio_stream_looped soundStream true
+    set_audio_stream_state soundStream AudioStreamAction.Play
+    
+    cleo_return_with {conditionResult} true {retArgs} soundStream speakerObject
+end
 
 
-:END_TEST
+function TEST_CLEANUP(soundStream: int, speakerObject: int)
+    remove_all_char_weapons $scplayer    
+    //set_max_wanted_level 6
+    set_char_proofs $scplayer {bulletProof} false {fireProof} false {explosionProof} false {collisionProof} false {meleeProof} false
+
     remove_audio_stream soundStream
     delete_object speakerObject
     camera_reset_new_scriptables
     restore_camera
     display_hud true
     display_radar true
-return
+end

--- a/examples/Audio_Demo.txt
+++ b/examples/Audio_Demo.txt
@@ -241,11 +241,18 @@ while true
         clear_char_tasks_immediately $scplayer
         restore_camera_jumpcut
         
-        int modelId = get_weapontype_model {weaponType} WeaponType.Grenade
+        int modelId = get_weapontype_model {weaponType} WeaponType.Satchel
         request_model {modelId} modelId
         load_all_models_now
-        give_weapon_to_char $scplayer {weaponType} WeaponType.Grenade {ammo} 0xFFFFFF
+        give_weapon_to_char $scplayer {weaponType} WeaponType.Satchel {ammo} 0xFFFFFF
         mark_model_as_no_longer_needed {modelId} modelId
+        
+        modelId = get_weapontype_model {weaponType} WeaponType.Detonator
+        request_model {modelId} modelId
+        load_all_models_now
+        give_weapon_to_char $scplayer {weaponType} WeaponType.Satchel {ammo} 0xFFFFFF
+        mark_model_as_no_longer_needed {modelId} modelId
+        
         display_hud true
 
         repeat


### PR DESCRIPTION
- updated distance decay for 3d CLEO sounds to match behavior of in-game sounds
- implemented proper support for 3d CLEO sounds source size
- CLEO sounds volume is now affected by wide screen and fades in same way as in-game sounds
- updated "Audio_Demo" example script
- Introduced CSlidingParam class to not repeat same code for each stream parameter supporting transitions (speed and volume)