### PR TITLE
Removed VInjectible.

### DIFF
--- a/source/CCodeInjector.h
+++ b/source/CCodeInjector.h
@@ -124,12 +124,4 @@ namespace CLEO
             //if(force_vp) VirtualProtect(addr, sizeof(T) * n, oldProtect, &oldProtect);
         }
     };
-
-    // determines an object, that should be injected into the game engine
-    // on startup
-    class VInjectible
-    {
-    public:
-        virtual void Inject(CCodeInjector& inj) = 0;
-    };
 }

--- a/source/CCustomOpcodeSystem.h
+++ b/source/CCustomOpcodeSystem.h
@@ -9,7 +9,7 @@ namespace CLEO
 
     void ThreadJump(CRunningScript* thread, int off);
 
-    class CCustomOpcodeSystem : public VInjectible
+    class CCustomOpcodeSystem
     {
     public:
         static const size_t MinValidAddress = 0x10000; // used for validation of pointers received from scripts. First 64kb are for sure reserved by Windows.
@@ -32,7 +32,7 @@ namespace CLEO
 
         CCustomOpcodeSystem() = default;
         CCustomOpcodeSystem(const CCustomOpcodeSystem&) = delete; // no copying
-        virtual void Inject(CCodeInjector& inj);
+        void Inject(CCodeInjector& inj);
         void Init();
         ~CCustomOpcodeSystem();
 

--- a/source/CDmaFix.h
+++ b/source/CDmaFix.h
@@ -3,9 +3,9 @@
 
 namespace CLEO
 {
-    class CDmaFix : public VInjectible
+    class CDmaFix
     {
     public:
-        virtual void Inject(CCodeInjector& inj);
+        void Inject(CCodeInjector& inj);
     };
 }

--- a/source/CGameMenu.h
+++ b/source/CGameMenu.h
@@ -3,9 +3,9 @@
 
 namespace CLEO
 {
-    class CGameMenu : public VInjectible
+    class CGameMenu
     {
     public:
-        virtual void Inject(CCodeInjector& inj);
+        void Inject(CCodeInjector& inj);
     };
 }

--- a/source/CScriptEngine.h
+++ b/source/CScriptEngine.h
@@ -97,7 +97,7 @@ namespace CLEO
         std::string GetInfoStr(bool currLineInfo = true) const;
     };
 
-    class CScriptEngine : VInjectible
+    class CScriptEngine
     {
     public:
         bool gameInProgress = false;
@@ -124,7 +124,7 @@ namespace CLEO
         CScriptEngine(const CScriptEngine&) = delete; // no copying
         ~CScriptEngine();
         
-        virtual void Inject(CCodeInjector&);
+        void Inject(CCodeInjector&);
 
         void GameBegin(); // call after new game started
         void GameEnd();


### PR DESCRIPTION
Removed VInjectible class as polymorphism was not used in any way, so we had virtual tables for nothing. 