### PR TITLE
Fix different behavior of scanf_s

### DIFF
--- a/cleo_plugins/FileSystemOperations/FileUtils.cpp
+++ b/cleo_plugins/FileSystemOperations/FileUtils.cpp
@@ -413,7 +413,7 @@ DWORD File::scan(DWORD handle, const char* format, void** outputParams)
 	int read = 0;
 	if (isLegacy(handle))
 	{
-		// fscanf not existent in game's code. Emulate it
+		// fscanf for game file streams not existent in game's code. Emulate it
 
 		size_t paramCount = 0;
 		const char* f = format;
@@ -441,7 +441,8 @@ DWORD File::scan(DWORD handle, const char* format, void** outputParams)
 
 			prevCharRead = charRead;
 			auto p = outputParams;
-			read = sscanf_s(readText.c_str(), newFormat.c_str(),
+			#pragma warning(suppress: 4996) // sscanf_s would expect additional arg after each %s arg
+			read = sscanf(readText.c_str(), newFormat.c_str(),
 				p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8], p[9], // 10
 				p[10], p[11], p[12], p[13], p[14], p[15], p[16], p[17], p[18], p[19], // 20
 				p[20], p[21], p[22], p[23], p[24], p[25], p[26], p[27], p[28], p[29], // 30
@@ -467,7 +468,8 @@ DWORD File::scan(DWORD handle, const char* format, void** outputParams)
 	else
 	{
 		auto p = outputParams;
-		read = 	fscanf_s(file, format, 
+		#pragma warning(suppress: 4996) // fscanf_s would expect additional arg after each %s arg
+		read = 	fscanf(file, format, 
 			p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8], p[9], // 10
 			p[10], p[11], p[12], p[13], p[14], p[15], p[16], p[17], p[18], p[19], // 20
 			p[20], p[21], p[22], p[23], p[24], p[25], p[26], p[27], p[28], p[29], // 30

--- a/cleo_plugins/Text/Text.cpp
+++ b/cleo_plugins/Text/Text.cpp
@@ -277,7 +277,8 @@ public:
 		}
 		CLEO_SkipUnusedVarArgs(thread); // and var args terminator
 
-		*readCount = sscanf_s(src, format,
+		#pragma warning(suppress: 4996) // sscanf_s would expect additional arg after each %s arg
+		*readCount = sscanf(src, format,
 			outputParams[0], outputParams[1], outputParams[2], outputParams[3], outputParams[4], outputParams[5],
 			outputParams[6], outputParams[7], outputParams[8], outputParams[9], outputParams[10], outputParams[11],
 			outputParams[12], outputParams[13], outputParams[14], outputParams[15], outputParams[16], outputParams[17],


### PR DESCRIPTION
Using safe version of sscanf or fscanf makes expected arguments count differ depending on format string.
Fixes unit tests.