### PR TITLE
CLEO.h refactor

### DIFF
--- a/cleo_plugins/Audio/Audio.cpp
+++ b/cleo_plugins/Audio/Audio.cpp
@@ -115,7 +115,7 @@ public:
 
  
     //0AAC=2,  %2d% = load_audiostream %1d%  // IF and SET
-    static OpcodeResult __stdcall opcode_0AAC(CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_0AAC(CLEO::CRunningScript* thread)
     {
         OPCODE_READ_PARAM_STRING_LEN(path, 511);
 
@@ -135,7 +135,7 @@ public:
     }
 
     //0AAD=2,set_audiostream %1d% perform_action %2d%
-    static OpcodeResult __stdcall opcode_0AAD(CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_0AAD(CLEO::CRunningScript* thread)
     {
         auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM()
         auto action = OPCODE_READ_PARAM_INT();
@@ -157,7 +157,7 @@ public:
     }
 
     //0AAE=1,release_audiostream %1d%
-    static OpcodeResult __stdcall opcode_0AAE(CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_0AAE(CLEO::CRunningScript* thread)
     {
         auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
 
@@ -167,7 +167,7 @@ public:
     }
 
     //0AAF=2,%2d% = get_audiostream_length %1d%
-    static OpcodeResult __stdcall opcode_0AAF(CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_0AAF(CLEO::CRunningScript* thread)
     {
         auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
 
@@ -179,7 +179,7 @@ public:
     }
 
     //0AB9=2,get_audio_stream_state %1d% store_to %2d%
-    static OpcodeResult __stdcall opcode_0AB9(CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_0AB9(CLEO::CRunningScript* thread)
     {
         auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
 
@@ -191,7 +191,7 @@ public:
     }
 
     //0ABB=2,%2d% = get_audio_stream_volume %1d%
-    static OpcodeResult __stdcall opcode_0ABB(CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_0ABB(CLEO::CRunningScript* thread)
     {
         auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
 
@@ -203,7 +203,7 @@ public:
     }
 
     //0ABC=2,set_audiostream %1d% volume %2d%
-    static OpcodeResult __stdcall opcode_0ABC(CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_0ABC(CLEO::CRunningScript* thread)
     {
         auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
         auto volume = OPCODE_READ_PARAM_FLOAT();
@@ -214,7 +214,7 @@ public:
     }
 
     //0AC0=2,loop_audiostream %1d% flag %2d%
-    static OpcodeResult __stdcall opcode_0AC0(CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_0AC0(CLEO::CRunningScript* thread)
     {
         auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
         auto loop = OPCODE_READ_PARAM_BOOL();
@@ -225,7 +225,7 @@ public:
     }
 
     //0AC1=2,%2d% = load_audiostream_with_3d_support %1d% //IF and SET
-    static OpcodeResult __stdcall opcode_0AC1(CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_0AC1(CLEO::CRunningScript* thread)
     {
         OPCODE_READ_PARAM_STRING_LEN(path, 511);
 
@@ -245,7 +245,7 @@ public:
     }
 
     //0AC2=4,set_3d_audiostream %1d% position %2d% %3d% %4d%
-    static OpcodeResult __stdcall opcode_0AC2(CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_0AC2(CLEO::CRunningScript* thread)
     {
         auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
         CVector pos;
@@ -259,7 +259,7 @@ public:
     }
 
     //0AC3=2,link_3d_audiostream %1d% to_object %2d%
-    static OpcodeResult __stdcall opcode_0AC3(CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_0AC3(CLEO::CRunningScript* thread)
     {
         auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
         auto handle = OPCODE_READ_PARAM_OBJECT_HANDLE();
@@ -274,7 +274,7 @@ public:
     }
 
     //0AC4=2,link_3d_audiostream %1d% to_actor %2d%
-    static OpcodeResult __stdcall opcode_0AC4(CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_0AC4(CLEO::CRunningScript* thread)
     {
         auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
         auto handle = OPCODE_READ_PARAM_PED_HANDLE();
@@ -289,7 +289,7 @@ public:
     }
 
     //0AC5=2,link_3d_audiostream %1d% to_vehicle %2d%
-    static OpcodeResult __stdcall opcode_0AC5(CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_0AC5(CLEO::CRunningScript* thread)
     {
         auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
         auto handle = OPCODE_READ_PARAM_VEHICLE_HANDLE();
@@ -304,7 +304,7 @@ public:
     }
 
     //2500=1,  is_audio_stream_playing %1d%
-    static OpcodeResult __stdcall opcode_2500(CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_2500(CLEO::CRunningScript* thread)
     {
         auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
 
@@ -316,7 +316,7 @@ public:
     }
 
     //2501=2,%2d% = get_audiostream_duration %1d%
-    static OpcodeResult __stdcall opcode_2501(CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_2501(CLEO::CRunningScript* thread)
     {
         auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
 
@@ -337,7 +337,7 @@ public:
     }
 
     //2502=2,get_audio_stream_speed %1d% store_to %2d%
-    static OpcodeResult __stdcall opcode_2502(CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_2502(CLEO::CRunningScript* thread)
     {
         auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
 
@@ -349,7 +349,7 @@ public:
     }
 
     //2503=2,set_audio_stream_speed %1d% speed %2d%
-    static OpcodeResult __stdcall opcode_2503(CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_2503(CLEO::CRunningScript* thread)
     {
         auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
         auto speed = OPCODE_READ_PARAM_FLOAT();
@@ -360,7 +360,7 @@ public:
     }
 
     //2504=3,set_audio_stream_volume_with_transition %1d% volume %2d% time_ms %2d%
-    static OpcodeResult __stdcall opcode_2504(CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_2504(CLEO::CRunningScript* thread)
     {
         auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
         auto volume = OPCODE_READ_PARAM_FLOAT();
@@ -372,7 +372,7 @@ public:
     }
 
     //2505=3,set_audio_stream_speed_with_transition %1d% speed %2d% time_ms %2d%
-    static OpcodeResult __stdcall opcode_2505(CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_2505(CLEO::CRunningScript* thread)
     {
         auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
         auto speed = OPCODE_READ_PARAM_FLOAT();
@@ -384,7 +384,7 @@ public:
     }
 
     //2506=2,set_audio_stream_source_size %1d% radius %2d%
-    static OpcodeResult __stdcall opcode_2506(CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_2506(CLEO::CRunningScript* thread)
     {
         auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
         auto radius = OPCODE_READ_PARAM_FLOAT();
@@ -395,7 +395,7 @@ public:
     }
 
     //2507=2,get_audio_stream_progress %1d% store_to %2d%
-    static OpcodeResult __stdcall opcode_2507(CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_2507(CLEO::CRunningScript* thread)
     {
         auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
 
@@ -407,7 +407,7 @@ public:
     }
 
     //2508=2,set_audio_stream_progress %1d% speed %2d%
-    static OpcodeResult __stdcall opcode_2508(CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_2508(CLEO::CRunningScript* thread)
     {
         auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
         auto speed = OPCODE_READ_PARAM_FLOAT();
@@ -418,7 +418,7 @@ public:
     }
 
     //2509=2,get_audio_stream_type %1d% store_to %2d%
-    static OpcodeResult __stdcall opcode_2509(CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_2509(CLEO::CRunningScript* thread)
     {
         auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
 
@@ -430,7 +430,7 @@ public:
     }
 
     //250A=2,set_audio_stream_type %1d% type %2d%
-    static OpcodeResult __stdcall opcode_250A(CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_250A(CLEO::CRunningScript* thread)
     {
         auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
         auto type = OPCODE_READ_PARAM_INT();
@@ -441,7 +441,7 @@ public:
     }
 
     //250B=2,get_audio_stream_progress_seconds %1d% store_to %2d%
-    static OpcodeResult __stdcall opcode_250B(CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_250B(CLEO::CRunningScript* thread)
     {
         auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
 
@@ -457,7 +457,7 @@ public:
     }
 
     //250C=2,set_audio_stream_progress_seconds %1d% value %2d%
-    static OpcodeResult __stdcall opcode_250C(CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_250C(CLEO::CRunningScript* thread)
     {
         auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
         auto progress = OPCODE_READ_PARAM_FLOAT();

--- a/cleo_plugins/DebugUtils/DebugUtils.cpp
+++ b/cleo_plugins/DebugUtils/DebugUtils.cpp
@@ -22,9 +22,9 @@ public:
 
     struct PausedScriptInfo 
     { 
-        CScriptThread* ptr;
+        CRunningScript* ptr;
         std::string msg;
-        PausedScriptInfo(CScriptThread* ptr, const char* msg) : ptr(ptr), msg(msg) {}
+        PausedScriptInfo(CRunningScript* ptr, const char* msg) : ptr(ptr), msg(msg) {}
     };
     static std::deque<PausedScriptInfo> pausedScripts;
 
@@ -75,7 +75,7 @@ public:
         CLEO_RegisterCallback(eCallbackId::Log, OnLog);
         CLEO_RegisterCallback(eCallbackId::DrawingFinished, OnDrawingFinished);
         CLEO_RegisterCallback(eCallbackId::ScriptProcessBefore, OnScriptProcess);
-        CLEO_RegisterCallback(eCallbackId::ScriptOpcodeProcess, OnScriptOpcodeProcess);
+        CLEO_RegisterCallback(eCallbackId::ScriptOpcodeProcessBefore, OnScriptOpcodeProcessBefore);
         CLEO_RegisterCallback(eCallbackId::ScriptsFinalize, OnScriptsFinalize);
     }
 
@@ -85,7 +85,7 @@ public:
         CLEO_UnregisterCallback(eCallbackId::Log, OnLog);
         CLEO_UnregisterCallback(eCallbackId::DrawingFinished, OnDrawingFinished);
         CLEO_UnregisterCallback(eCallbackId::ScriptProcessBefore, OnScriptProcess);
-        CLEO_UnregisterCallback(eCallbackId::ScriptOpcodeProcess, OnScriptOpcodeProcess);
+        CLEO_UnregisterCallback(eCallbackId::ScriptOpcodeProcessBefore, OnScriptOpcodeProcessBefore);
         CLEO_UnregisterCallback(eCallbackId::ScriptsFinalize, OnScriptsFinalize);
     }
 
@@ -187,7 +187,7 @@ public:
         currScript.Clear(); // make sure current script log does not persists to next render frame
     }
 
-    static bool WINAPI OnScriptProcess(CScriptThread* thread)
+    static bool WINAPI OnScriptProcess(CRunningScript* thread)
     {
         currScript.Begin(thread);
 
@@ -202,7 +202,7 @@ public:
         return true;
     }
 
-    static OpcodeResult WINAPI OnScriptOpcodeProcess(CRunningScript* thread, DWORD opcode)
+    static OpcodeResult WINAPI OnScriptOpcodeProcessBefore(CRunningScript* thread, DWORD opcode)
     {
         currScript.ProcessCommand(thread);
 
@@ -244,7 +244,7 @@ public:
     // ---------------------------------------------- opcodes -------------------------------------------------
 
     // 00C3=0, debug_on
-    static OpcodeResult __stdcall Opcode_DebugOn(CScriptThread* thread)
+    static OpcodeResult __stdcall Opcode_DebugOn(CRunningScript* thread)
     {
         CLEO_SetScriptDebugMode(thread, true);
 
@@ -252,7 +252,7 @@ public:
     }
 
     // 00C4=0, debug_off
-    static OpcodeResult __stdcall Opcode_DebugOff(CScriptThread* thread)
+    static OpcodeResult __stdcall Opcode_DebugOff(CRunningScript* thread)
     {
         CLEO_SetScriptDebugMode(thread, false);
 
@@ -260,7 +260,7 @@ public:
     }
 
     // 2100=-1, breakpoint ...
-    static OpcodeResult __stdcall Opcode_Breakpoint(CScriptThread* thread)
+    static OpcodeResult __stdcall Opcode_Breakpoint(CRunningScript* thread)
     {
         if (!CLEO_GetScriptDebugMode(thread))
         {
@@ -308,7 +308,7 @@ public:
     }
 
     // 2101=-1, trace %1s% ...
-    static OpcodeResult __stdcall Opcode_Trace(CScriptThread* thread)
+    static OpcodeResult __stdcall Opcode_Trace(CRunningScript* thread)
     {
         if (!CLEO_GetScriptDebugMode(thread))
         {
@@ -324,7 +324,7 @@ public:
     }
 
     // 2102=-1, log_to_file %1s% timestamp %2d% text %3s% ...
-    static OpcodeResult __stdcall Opcode_LogToFile(CScriptThread* thread)
+    static OpcodeResult __stdcall Opcode_LogToFile(CRunningScript* thread)
     {
         auto filestr = CLEO_ReadStringOpcodeParam(thread);
 
@@ -377,7 +377,7 @@ public:
     }
 
     // 0662=1, printstring %1s%
-    static OpcodeResult __stdcall Opcode_PrintString(CScriptThread* thread)
+    static OpcodeResult __stdcall Opcode_PrintString(CRunningScript* thread)
     {
         if (!CLEO_GetScriptDebugMode(thread))
         {
@@ -393,7 +393,7 @@ public:
     }
 
     // 0663=1, printint %1s% %2d%
-    static OpcodeResult __stdcall Opcode_PrintInt(CScriptThread* thread)
+    static OpcodeResult __stdcall Opcode_PrintInt(CRunningScript* thread)
     {
         if (!CLEO_GetScriptDebugMode(thread))
         {
@@ -412,7 +412,7 @@ public:
     }
 
     // 0664=1, printfloat %1s% %2f%
-    static OpcodeResult __stdcall Opcode_PrintFloat(CScriptThread* thread)
+    static OpcodeResult __stdcall Opcode_PrintFloat(CRunningScript* thread)
     {
         if (!CLEO_GetScriptDebugMode(thread))
         {

--- a/cleo_plugins/FileSystemOperations/FileSystemOperations.cpp
+++ b/cleo_plugins/FileSystemOperations/FileSystemOperations.cpp
@@ -496,7 +496,7 @@ public:
     }
 
     // 0B00=1,  delete_file %1s% //IF and SET
-    static OpcodeResult __stdcall Script_FS_DeleteFile(CScriptThread* thread)
+    static OpcodeResult __stdcall Script_FS_DeleteFile(CRunningScript* thread)
     {
         OPCODE_READ_PARAM_FILEPATH(filename);
 
@@ -552,7 +552,7 @@ public:
     }
 
     // 0B01=1, delete_directory %1s% with_all_files_and_subdirectories %2d% //IF and SET
-    static OpcodeResult __stdcall Script_FS_DeleteDirectory(CScriptThread* thread)
+    static OpcodeResult __stdcall Script_FS_DeleteDirectory(CRunningScript* thread)
     {
         OPCODE_READ_PARAM_FILEPATH(filename);
         auto deleteContents = OPCODE_READ_PARAM_BOOL();
@@ -574,7 +574,7 @@ public:
     }
 
     // 0B02=2, move_file %1s% to %2s% //IF and SET
-    static OpcodeResult __stdcall Script_FS_MoveFile(CScriptThread* thread)
+    static OpcodeResult __stdcall Script_FS_MoveFile(CRunningScript* thread)
     {
         OPCODE_READ_PARAM_FILEPATH(filepath);
         OPCODE_READ_PARAM_FILEPATH(newFilepath);
@@ -594,7 +594,7 @@ public:
     }
 
     // 0B03=2, move_directory %1s% to %2s% //IF and SET
-    static OpcodeResult __stdcall Script_FS_MoveDir(CScriptThread* thread)
+    static OpcodeResult __stdcall Script_FS_MoveDir(CRunningScript* thread)
     {
         OPCODE_READ_PARAM_FILEPATH(filepath);
         OPCODE_READ_PARAM_FILEPATH(newFilepath);
@@ -614,7 +614,7 @@ public:
     }
 
     // 0B04=2, copy_file %1s% to %2s% //IF and SET
-    static OpcodeResult __stdcall Script_FS_CopyFile(CScriptThread* thread)
+    static OpcodeResult __stdcall Script_FS_CopyFile(CRunningScript* thread)
     {
         OPCODE_READ_PARAM_FILEPATH(filepath);
         OPCODE_READ_PARAM_FILEPATH(newFilepath);
@@ -632,7 +632,7 @@ public:
     }
 
     // 0B05=2,  copy_directory %1d% to %2d% //IF and SET
-    static OpcodeResult __stdcall Script_FS_CopyDir(CScriptThread* thread)
+    static OpcodeResult __stdcall Script_FS_CopyDir(CRunningScript* thread)
     {
         OPCODE_READ_PARAM_FILEPATH(filepath);
         OPCODE_READ_PARAM_FILEPATH(newFilepath);

--- a/cleo_plugins/IniFiles/IniFiles.cpp
+++ b/cleo_plugins/IniFiles/IniFiles.cpp
@@ -56,7 +56,7 @@ public:
 		}
 	}
 
-	static OpcodeResult __stdcall Script_InifileGetInt(CScriptThread* thread)
+	static OpcodeResult __stdcall Script_InifileGetInt(CRunningScript* thread)
 		/****************************************************************
 		Opcode Format
 		0AF0=4,%4d% = get_int_from_ini_file %1s% section %2s% key %3s%
@@ -108,7 +108,7 @@ public:
 		return OR_CONTINUE;
 	}
 
-	static OpcodeResult __stdcall Script_InifileWriteInt(CScriptThread* thread)
+	static OpcodeResult __stdcall Script_InifileWriteInt(CRunningScript* thread)
 		/****************************************************************
 		Opcode Format
 		0AF1=4,write_int %1d% to_ini_file %2s% section %3s% key %4s%
@@ -127,7 +127,7 @@ public:
 		return OR_CONTINUE;
 	}
 
-	static OpcodeResult __stdcall Script_InifileGetFloat(CScriptThread* thread)
+	static OpcodeResult __stdcall Script_InifileGetFloat(CRunningScript* thread)
 		/****************************************************************
 		Opcode Format
 		0AF2=4,%4d% = get_float_from_ini_file %1s% section %2s% key %3s%
@@ -168,7 +168,7 @@ public:
 		return OR_CONTINUE;
 	}
 
-	static OpcodeResult __stdcall Script_InifileWriteFloat(CScriptThread* thread)
+	static OpcodeResult __stdcall Script_InifileWriteFloat(CRunningScript* thread)
 		/****************************************************************
 		Opcode Format
 		0AF3=4,write_float %1d% to_ini_file %2s% section %3s% key %4s%
@@ -187,7 +187,7 @@ public:
 		return OR_CONTINUE;
 	}
 
-	static OpcodeResult __stdcall Script_InifileReadString(CScriptThread* thread)
+	static OpcodeResult __stdcall Script_InifileReadString(CRunningScript* thread)
 		/****************************************************************
 		Opcode Format
 		0AF4=4,%4d% = read_string_from_ini_file %1s% section %2s% key %3s%
@@ -211,7 +211,7 @@ public:
 		return OR_CONTINUE;
 	}
 
-	static OpcodeResult __stdcall Script_InifileWriteString(CScriptThread* thread)
+	static OpcodeResult __stdcall Script_InifileWriteString(CRunningScript* thread)
 		/****************************************************************
 		Opcode Format
 		0AF5=4,write_string %1s% to_ini_file %2s% section %3s% key %4s%
@@ -228,7 +228,7 @@ public:
 		return OR_CONTINUE;
 	}
 
-	static OpcodeResult __stdcall Script_InifileDeleteSection(CScriptThread* thread)
+	static OpcodeResult __stdcall Script_InifileDeleteSection(CRunningScript* thread)
 		/****************************************************************
 		Opcode Format
 		2800=2,delete_section_from_ini_file %1s% section %2s%
@@ -243,7 +243,7 @@ public:
 		return OR_CONTINUE;
 	}
 
-	static OpcodeResult __stdcall Script_InifileDeleteKey(CScriptThread* thread)
+	static OpcodeResult __stdcall Script_InifileDeleteKey(CRunningScript* thread)
 		/****************************************************************
 		Opcode Format
 		2801=3,delete_key_from_ini_file %1s% section %2s%

--- a/cleo_plugins/Math/Math.cpp
+++ b/cleo_plugins/Math/Math.cpp
@@ -134,7 +134,7 @@ public:
         return OR_CONTINUE;
     }
 
-    static OpcodeResult __stdcall Script_IntOp_AND(CScriptThread* thread)
+    static OpcodeResult __stdcall Script_IntOp_AND(CRunningScript* thread)
         /****************************************************************
         Opcode Format
         0B10=3,%3d% = %1d% AND %2d%
@@ -149,7 +149,7 @@ public:
         return OR_CONTINUE;
     }
 
-    static OpcodeResult __stdcall Script_IntOp_OR(CScriptThread* thread)
+    static OpcodeResult __stdcall Script_IntOp_OR(CRunningScript* thread)
         /****************************************************************
         Opcode Format
         0B11=3,%3d% = %1d% OR %2d%
@@ -164,7 +164,7 @@ public:
         return OR_CONTINUE;
     }
 
-    static OpcodeResult __stdcall Script_IntOp_XOR(CScriptThread* thread)
+    static OpcodeResult __stdcall Script_IntOp_XOR(CRunningScript* thread)
         /****************************************************************
         Opcode Format
         0B12=3,%3d% = %1d% XOR %2d%
@@ -179,7 +179,7 @@ public:
         return OR_CONTINUE;
     }
 
-    static OpcodeResult __stdcall Script_IntOp_NOT(CScriptThread* thread)
+    static OpcodeResult __stdcall Script_IntOp_NOT(CRunningScript* thread)
         /****************************************************************
         Opcode Format
         0B13=2,%2d% = NOT %1d%
@@ -191,7 +191,7 @@ public:
         return OR_CONTINUE;
     }
 
-    static OpcodeResult __stdcall Script_IntOp_MOD(CScriptThread* thread)
+    static OpcodeResult __stdcall Script_IntOp_MOD(CRunningScript* thread)
         /****************************************************************
         Opcode Format
         0B14=3,%3d% = %1d% MOD %2d%
@@ -206,7 +206,7 @@ public:
         return OR_CONTINUE;
     }
 
-    static  OpcodeResult __stdcall Script_IntOp_SHR(CScriptThread* thread)
+    static  OpcodeResult __stdcall Script_IntOp_SHR(CRunningScript* thread)
         /****************************************************************
         Opcode Format
         0B15=3,%3d% = %1d% SHR %2d%
@@ -221,7 +221,7 @@ public:
         return OR_CONTINUE;
     }
 
-    static OpcodeResult __stdcall Script_IntOp_SHL(CScriptThread* thread)
+    static OpcodeResult __stdcall Script_IntOp_SHL(CRunningScript* thread)
         /****************************************************************
         Opcode Format
         0B16=3,%3d% = %1d% SHL %2d%
@@ -240,7 +240,7 @@ public:
     Now do them as real operators...
     *****************************************************************/
 
-    static OpcodeResult __stdcall Scr_IntOp_AND(CScriptThread* thread)
+    static OpcodeResult __stdcall Scr_IntOp_AND(CRunningScript* thread)
         /****************************************************************
         Opcode Format
         0B17=2,%1d% &= %2d%
@@ -253,7 +253,7 @@ public:
         return OR_CONTINUE;
     }
 
-    static OpcodeResult __stdcall Scr_IntOp_OR(CScriptThread* thread)
+    static OpcodeResult __stdcall Scr_IntOp_OR(CRunningScript* thread)
         /****************************************************************
         Opcode Format
         0B18=2,%1d% |= %2d%
@@ -266,7 +266,7 @@ public:
         return OR_CONTINUE;
     }
 
-    static OpcodeResult __stdcall Scr_IntOp_XOR(CScriptThread* thread)
+    static OpcodeResult __stdcall Scr_IntOp_XOR(CRunningScript* thread)
         /****************************************************************
         Opcode Format
         0B19=2,%1d% ^= %2d%
@@ -279,7 +279,7 @@ public:
         return OR_CONTINUE;
     }
 
-    static OpcodeResult __stdcall Scr_IntOp_NOT(CScriptThread* thread)
+    static OpcodeResult __stdcall Scr_IntOp_NOT(CRunningScript* thread)
         /****************************************************************
         Opcode Format
         0B1A=1,~%1d%
@@ -291,7 +291,7 @@ public:
         return OR_CONTINUE;
     }
 
-    static OpcodeResult __stdcall Scr_IntOp_MOD(CScriptThread* thread)
+    static OpcodeResult __stdcall Scr_IntOp_MOD(CRunningScript* thread)
         /****************************************************************
         Opcode Format
         0B1B=2,%1d% %= %2d%
@@ -304,7 +304,7 @@ public:
         return OR_CONTINUE;
     }
 
-    static OpcodeResult __stdcall Scr_IntOp_SHR(CScriptThread* thread)
+    static OpcodeResult __stdcall Scr_IntOp_SHR(CRunningScript* thread)
         /****************************************************************
         Opcode Format
         0B1C=2,%1d% >>= %2d%
@@ -317,7 +317,7 @@ public:
         return OR_CONTINUE;
     }
 
-    static OpcodeResult __stdcall Scr_IntOp_SHL(CScriptThread* thread)
+    static OpcodeResult __stdcall Scr_IntOp_SHL(CRunningScript* thread)
         /****************************************************************
         Opcode Format
         0B1D=2,%1d% <<= %2d%
@@ -330,7 +330,7 @@ public:
         return OR_CONTINUE;
     }
 
-    static OpcodeResult __stdcall Sign_Extend(CScriptThread* thread)
+    static OpcodeResult __stdcall Sign_Extend(CRunningScript* thread)
         /****************************************************************
         Opcode Format
         0B1E=2,sign_extend %1d% size %2d%
@@ -357,7 +357,7 @@ public:
     }
 
     //2700=2,  is_bit_set value %1d% bit_index %2d%
-    static OpcodeResult __stdcall opcode_2700(CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_2700(CRunningScript* thread)
     {
         auto value = OPCODE_READ_PARAM_UINT();
         auto bitIndex = OPCODE_READ_PARAM_INT();
@@ -375,7 +375,7 @@ public:
     }
 
     //2701=2,set_bit value %1d% bit_index %2d%
-    static OpcodeResult __stdcall opcode_2701(CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_2701(CRunningScript* thread)
     {
         auto value = OPCODE_READ_PARAM_OUTPUT_VAR_INT();
         auto bitIndex = OPCODE_READ_PARAM_INT();
@@ -392,7 +392,7 @@ public:
     }
 
     //2702=2,clear_bit value %1d% bit_index %2d%
-    static OpcodeResult __stdcall opcode_2702(CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_2702(CRunningScript* thread)
     {
         auto value = OPCODE_READ_PARAM_OUTPUT_VAR_INT();
         auto bitIndex = OPCODE_READ_PARAM_INT();
@@ -409,7 +409,7 @@ public:
     }
 
     //2703=3,toggle_bit value %1d% bit_index %2d% state %3d%
-    static OpcodeResult __stdcall opcode_2703(CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_2703(CRunningScript* thread)
     {
         auto value = OPCODE_READ_PARAM_OUTPUT_VAR_INT();
         auto bitIndex = OPCODE_READ_PARAM_INT();
@@ -431,7 +431,7 @@ public:
     }
 
     //2704=1,  is_truthy value %1d%
-    static OpcodeResult __stdcall opcode_2704(CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_2704(CRunningScript* thread)
     {
         auto paramType = OPCODE_PEEK_PARAM_TYPE();
 
@@ -448,7 +448,7 @@ public:
     }
 
     //2705=-1,pick_random_int values %d% store_to %d%
-    static OpcodeResult __stdcall opcode_2705(CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_2705(CRunningScript* thread)
     {
         auto valueCount = CLEO_GetVarArgCount(thread);
 
@@ -474,7 +474,7 @@ public:
     }
 
     //2706=-1,pick_random_float values %d% store_to %d%
-    static OpcodeResult __stdcall opcode_2706(CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_2706(CRunningScript* thread)
     {
         auto valueCount = CLEO_GetVarArgCount(thread);
 
@@ -500,7 +500,7 @@ public:
     }
 
     //2707=-1,pick_random_text values %d% store_to %d%
-    static OpcodeResult __stdcall opcode_2707(CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_2707(CRunningScript* thread)
     {
         auto valueCount = CLEO_GetVarArgCount(thread);
 

--- a/cleo_plugins/MemoryOperations/MemoryOperations.cpp
+++ b/cleo_plugins/MemoryOperations/MemoryOperations.cpp
@@ -867,7 +867,7 @@ public:
     }
 
     //2404=1,get_script_struct_just_created %1d%
-    static OpcodeResult __stdcall opcode_2404(CLEO::CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_2404(CLEO::CRunningScript* thread)
     {
         auto head = thread;
         while(head->Previous)
@@ -880,9 +880,9 @@ public:
     }
 
     //2405=1,  is_script_running %1d%
-    static OpcodeResult __stdcall opcode_2405(CLEO::CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_2405(CLEO::CRunningScript* thread)
     {
-        auto address = (CLEO::CScriptThread*)OPCODE_READ_PARAM_INT(); // allow invalid pointers too
+        auto address = (CLEO::CRunningScript*)OPCODE_READ_PARAM_INT(); // allow invalid pointers too
 
         auto running = CLEO_IsScriptRunning(address);
 
@@ -891,7 +891,7 @@ public:
     }
 
     //2406=1,  get_script_struct_from_filename %1s%
-    static OpcodeResult __stdcall opcode_2406(CLEO::CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_2406(CLEO::CRunningScript* thread)
     {
         OPCODE_READ_PARAM_STRING(filename);
 
@@ -903,7 +903,7 @@ public:
     }
 
     //2407=3,  is_memory_equal address_a %1d% address_b %2d% size %d3%
-    static OpcodeResult __stdcall opcode_2407(CLEO::CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_2407(CLEO::CRunningScript* thread)
     {
         auto addressA = OPCODE_READ_PARAM_PTR();
         auto addressB = OPCODE_READ_PARAM_PTR();
@@ -927,9 +927,9 @@ public:
     }
 
     //2408=1,terminate_script %1d%
-    static OpcodeResult __stdcall opcode_2408(CLEO::CScriptThread* thread)
+    static OpcodeResult __stdcall opcode_2408(CLEO::CRunningScript* thread)
     {
-        auto address = (CLEO::CScriptThread*)OPCODE_READ_PARAM_PTR();
+        auto address = (CLEO::CRunningScript*)OPCODE_READ_PARAM_PTR();
 
         CLEO_TerminateScript(address);
 

--- a/source/CCustomOpcodeSystem.cpp
+++ b/source/CCustomOpcodeSystem.cpp
@@ -61,7 +61,7 @@ namespace CLEO
 		{
 			// execute registered callbacks
 			OpcodeResult callbackResult = OR_NONE;
-			for (void* func : CleoInstance.GetCallbacks(eCallbackId::ScriptOpcodeProcessFinished))
+			for (void* func : CleoInstance.GetCallbacks(eCallbackId::ScriptOpcodeProcessAfter))
 			{
 				typedef OpcodeResult WINAPI callback(CRunningScript*, DWORD, OpcodeResult);
 				auto res = ((callback*)func)(thread, opcode, result);
@@ -93,7 +93,7 @@ namespace CLEO
 		}
 
 		// execute registered callbacks
-		for (void* func : CleoInstance.GetCallbacks(eCallbackId::ScriptOpcodeProcess))
+		for (void* func : CleoInstance.GetCallbacks(eCallbackId::ScriptOpcodeProcessBefore))
 		{
 			typedef OpcodeResult WINAPI callback(CRunningScript*, DWORD);
 			result = ((callback*)func)(thread, opcode);

--- a/source/CCustomOpcodeSystem.h
+++ b/source/CCustomOpcodeSystem.h
@@ -5,8 +5,6 @@
 
 namespace CLEO
 {
-    typedef OpcodeResult(__stdcall * CustomOpcodeHandler)(CRunningScript*);
-
     void ThreadJump(CRunningScript* thread, int off);
 
     class CCustomOpcodeSystem


### PR DESCRIPTION
* Removed (never tested) plain C support.
* Renamed ScriptOpcodeProcess* callbacks to fit general xBefore, xAfter naming convention. 
* Removed legacy typedefs.
* Merged duplicated _pOpcodeHandler and CustomOpcodeHandler typedefs.