### PR TITLE
Address translator cleanup. Use Plugin SDK whenever possible instead

### DIFF
--- a/cleo_sdk/CLEO.h
+++ b/cleo_sdk/CLEO.h
@@ -359,7 +359,7 @@ extern "C"
 	void WINAPI CLEO_SetScriptWorkDir(CRunningScript* thread, const char* path);
 
 	void WINAPI CLEO_SetThreadCondResult(CRunningScript* thread, BOOL result);
-	void WINAPI CLEO_ThreadJumpAtLabelPtr(CRunningScript* thread, int labelPtr);
+	void WINAPI CLEO_ThreadJumpAtLabelPtr(CRunningScript* thread, int offset);
 	void WINAPI CLEO_TerminateScript(CRunningScript* thread);
 
 	int WINAPI CLEO_GetOperandType(const CRunningScript* thread); // peek parameter data type. Returns int for legacy reason, should be eDataType.
@@ -491,6 +491,7 @@ public:
 	BYTE* GetBytePointer() const { return CurrentIP; }
 	void SetIp(void* ip) { CurrentIP = (BYTE*)ip; }
 	void SetBaseIp(void* ip) { BaseIP = ip; }
+	void Jump(int offset) { CLEO_ThreadJumpAtLabelPtr(this, offset); }
 	CRunningScript* GetNext() const { return Next; }
 	CRunningScript* GetPrev() const { return Previous; }
 	void SetIsExternal(bool b) { bIsExternal = b; }

--- a/cleo_sdk/CLEO_Utils.h
+++ b/cleo_sdk/CLEO_Utils.h
@@ -32,10 +32,13 @@ namespace CLEO
     Macros to use inside opcode handler functions. Performs types validation, printing warnings and suspending script on critical errors.
     Please mind those expand into multiple lines, so CAN NOT be used in places where single code line is expected! (like 'if' condition body without brackets)
     
-    OPCODE_CONDITION_RESULT(value) // set result
-    OPCODE_SKIP_PARAMS(count) // ignore X params
+    OPCODE_CONDITION_RESULT(value) // set command logical result
 
-    OPCODE_PEEK_PARAM_TYPE() // get param type without advancing the script
+    OPCODE_SKIP_PARAMS(count) // ignore X params
+    OPCODE_SKIP_VARARG_PARAMS(count) // ignore remaining variable arguments, including var arg terminator
+
+    OPCODE_PEEK_PARAM_TYPE() // get next param type without advancing the script
+    OPCODE_PEEK_VARARG_COUNT() // get count of remaining variable arguments
     
     // reading opcode input arguments
     OPCODE_READ_PARAM_BOOL()
@@ -768,7 +771,10 @@ namespace CLEO
     }
 
     #define OPCODE_SKIP_PARAMS(_count) CLEO_SkipOpcodeParams(thread, _count)
+    #define OPCODE_SKIP_VARARG_PARAMS() CLEO_SkipUnusedVarArgs(thread)
+
     #define OPCODE_PEEK_PARAM_TYPE() thread->PeekDataType()
+    #define OPCODE_PEEK_VARARG_COUNT() CLEO_GetVarArgCount(thread)
 
     // macros for reading opcode input params. Performs type validation, throws error and suspends script if user provided invalid argument type
     // TOD: add range checks for limited size types?

--- a/source/CCustomOpcodeSystem.h
+++ b/source/CCustomOpcodeSystem.h
@@ -5,34 +5,22 @@
 
 namespace CLEO
 {
-    void ThreadJump(CRunningScript* thread, int off);
-
     class CCustomOpcodeSystem
     {
     public:
-        static const size_t MinValidAddress = 0x10000; // used for validation of pointers received from scripts. First 64kb are for sure reserved by Windows.
+        static constexpr size_t Opcodes_Table_Size = 100; // opcodes per handler
+        static constexpr size_t Last_Original_Opcode = 0x0A4E; // GTA SA
+        static constexpr size_t Last_Custom_Opcode = 0x7FFF;
 
-        static const size_t LastOriginalOpcode = 0x0A4E; // GTA SA
-        static const size_t LastCustomOpcode = 0x7FFF;
-
-        // most recently processed
-        static CRunningScript* lastScript;
-        static WORD lastOpcode;
-        static WORD* lastOpcodePtr;
-        static WORD lastCustomOpcode;
-        static std::string lastErrorMsg;
-        static WORD prevOpcode; // previous
-        static BYTE handledParamCount; // read/writen since current opcode handling started
-
-        ScriptDeleteDelegate scriptDeleteDelegate;
-
-        void FinalizeScriptObjects();
+        ScriptDeleteDelegate scriptDeleteDelegate; // script deletion callbacks
 
         CCustomOpcodeSystem() = default;
         CCustomOpcodeSystem(const CCustomOpcodeSystem&) = delete; // no copying
         void Inject(CCodeInjector& inj);
         void Init();
-        ~CCustomOpcodeSystem();
+        ~CCustomOpcodeSystem() = default;
+
+        void GameEnd(); // cleanup current game session stuff
 
         static bool RegisterOpcode(WORD opcode, CustomOpcodeHandler callback);
 
@@ -67,35 +55,14 @@ namespace CLEO
 
         typedef OpcodeResult(__thiscall* OpcodeHandler)(CRunningScript* thread, WORD opcode);
 
-        static const size_t OriginalOpcodeHandlersCount = (LastOriginalOpcode / 100) + 1; // 100 opcodes peer handler
+        static constexpr size_t Original_Opcode_Handlers_Count = (Last_Original_Opcode / Opcodes_Table_Size) + 1;
         static OpcodeHandler originalOpcodeHandlers[OriginalOpcodeHandlersCount]; // backuped when patching
 
-        static const size_t CustomOpcodeHandlersCount = (LastCustomOpcode / 100) + 1; // 100 opcodes peer handler
+        static constexpr size_t Custom_Opcode_Handlers_Count = (Last_Custom_Opcode / Opcodes_Table_Size) + 1;
         static OpcodeHandler customOpcodeHandlers[CustomOpcodeHandlersCount]; // original + new opcodes
 
         static OpcodeResult __fastcall customOpcodeHandler(CRunningScript* thread, int dummy, WORD opcode); // universal CLEO's opcode handler
 
-        static CustomOpcodeHandler customOpcodeProc[LastCustomOpcode + 1]; // procedure for each opcode
+        static CustomOpcodeHandler customOpcodeProc[Last_Custom_Opcode + 1]; // procedure for each opcode
     };
-
-    // Read null-terminated string into the buffer
-    // returns pointer to string or nullptr on fail
-    // WARNING: returned pointer may differ from buff and contain string longer than buffSize (ptr to original data source)
-    const char* ReadStringParam(CRunningScript* thread, char* buff, int buffSize);
-
-    StringParamBufferInfo GetStringParamWriteBuffer(CRunningScript* thread); // consumes the param
-    int ReadFormattedString(CRunningScript* thread, char* buf, DWORD bufSize, const char* format);
-
-    bool WriteStringParam(CRunningScript* thread, const char* str);
-    bool WriteStringParam(const StringParamBufferInfo& target, const char* str);
-
-    void SkipUnusedVarArgs(CRunningScript* thread); // for var-args opcodes
-    DWORD GetVarArgCount(CRunningScript* thread); // for var-args opcodes
-
-    inline CRunningScript& operator>>(CRunningScript& thread, DWORD& uval);
-    inline CRunningScript& operator<<(CRunningScript& thread, DWORD uval);
-    inline CRunningScript& operator>>(CRunningScript& thread, int& nval);
-    inline CRunningScript& operator<<(CRunningScript& thread, int nval);
-    inline CRunningScript& operator>>(CRunningScript& thread, float& fval);
-    inline CRunningScript& operator<<(CRunningScript& thread, float fval);
 }

--- a/source/CCustomScript.cpp
+++ b/source/CCustomScript.cpp
@@ -357,12 +357,12 @@ std::string CCustomScript::GetInfoStr(bool currLineInfo) const
         }
         else
         {
-            auto offset = CLEO_GetScriptBaseRelativeOffset((CLEO::CRunningScript*)this, (BYTE*)CCustomOpcodeSystem::lastOpcodePtr);
+            auto offset = CLEO_GetScriptBaseRelativeOffset(this, CScriptEngine::lastOpcodePtr);
             ss << "offset {" << offset << "}"; // Sanny offsets style
             ss << " - ";
-            ss << std::hex << std::uppercase << std::setw(4) << std::setfill('0') << CCustomOpcodeSystem::lastOpcode;
+            ss << std::hex << std::uppercase << std::setw(4) << std::setfill('0') << CScriptEngine::lastOpcode;
 
-            auto commandName = CleoInstance.OpcodeInfoDb.GetCommandName(CCustomOpcodeSystem::lastOpcode);
+            auto commandName = CleoInstance.OpcodeInfoDb.GetCommandName(CScriptEngine::lastOpcode);
             if (commandName != nullptr)
             {
                 ss << ": " << commandName;
@@ -370,6 +370,18 @@ std::string CCustomScript::GetInfoStr(bool currLineInfo) const
             else
             {
                 ss << ": ...";
+            }
+
+            // add previously executed command info if available
+            if (CScriptEngine::prevOpcode != 0xFFFF)
+            {
+                ss << " \nPreviously called command: ";
+
+                auto commandName = CleoInstance.OpcodeInfoDb.GetCommandName(CScriptEngine::prevOpcode);
+                if (commandName)
+                    ss << commandName;
+                else
+                    ss << "[" << std::hex << std::uppercase << std::setw(4) << std::setfill('0') << CScriptEngine::prevOpcode << "]";
             }
         }
     }

--- a/source/CCustomScript.h
+++ b/source/CCustomScript.h
@@ -24,14 +24,6 @@ namespace CLEO
         std::string m_workDir;
 
     public:
-        inline SCRIPT_VAR* GetVarsPtr() { return LocalVar; }
-        inline bool IsOk() const { return m_ok; }
-        inline DWORD GetCodeSize() const { return m_codeSize; }
-        inline DWORD GetCodeChecksum() const { return m_codeChecksum; }
-        inline void EnableSaving(bool en = true) { m_saveEnabled = en; }
-        inline void SetCompatibility(eCLEO_Version ver) { m_compatVer = ver; }
-        inline eCLEO_Version GetCompatibility() const { return m_compatVer; }
-
         CCustomScript(const char* szFileName, bool bIsMiss = false, CRunningScript* parent = nullptr, int label = 0);
         CCustomScript(const CCustomScript&) = delete; // no copying
         ~CCustomScript();
@@ -40,6 +32,13 @@ namespace CLEO
         void RemoveScriptFromList(CRunningScript** queuelist);
 
         void ShutdownThisScript();
+
+        inline bool IsOk() const { return m_ok; }
+        inline DWORD GetCodeSize() const { return m_codeSize; }
+        inline DWORD GetCodeChecksum() const { return m_codeChecksum; }
+        inline void EnableSaving(bool en = true) { m_saveEnabled = en; }
+        inline void SetCompatibility(eCLEO_Version ver) { m_compatVer = ver; }
+        inline eCLEO_Version GetCompatibility() const { return m_compatVer; }
 
         // debug related utils enabled?
         bool GetDebugMode() const;

--- a/source/CleoBase.cpp
+++ b/source/CleoBase.cpp
@@ -161,7 +161,6 @@ namespace CLEO
 
             ScriptEngine.InjectLate(CodeInjector);
 
-            CodeInjector.InjectFunction(GetScriptStringParam, gaddrof(::CRunningScript::ReadTextLabelFromScript));
             CodeInjector.ReplaceFunction(OnDebugDisplayTextBuffer_Idle, VersionManager.TranslateMemoryAddress(MA_CALL_DEBUG_DISPLAY_TEXT_BUFFER_IDLE), &GameRestartDebugDisplayTextBuffer_IdleOrig);
             CodeInjector.ReplaceFunction(OnDebugDisplayTextBuffer_Frontend, VersionManager.TranslateMemoryAddress(MA_CALL_DEBUG_DISPLAY_TEXT_BUFFER_FRONTEND), &GameRestartDebugDisplayTextBuffer_FrontendOrig);
             CodeInjector.ReplaceFunction(OnUpdateGameLogics, VersionManager.TranslateMemoryAddress(MA_CALL_UPDATE_GAME_LOGICS), &UpdateGameLogics_Orig);
@@ -207,7 +206,7 @@ namespace CLEO
         TRACE("Ending current game");
         CleoInstance.CallCallbacks(eCallbackId::GameEnd); // execute registered callbacks
         ScriptEngine.GameEnd();
-        OpcodeSystem.FinalizeScriptObjects();
+        OpcodeSystem.GameEnd();
 
         saveSlot = -1;
     }


### PR DESCRIPTION
* Added MA_OPCODE_HANDLER_REF_2 to address translator
* Tided up core opcodes. Declared in header, moved into CCustomOpcodeSystem class
* Core opcodes now using utils macros to handle parameters (extra error checks)
* Added check if gosub was called to the **return_if_false** command
* Added unit tests for almost all CLEO Core commands (except **load_and_launch_mission_internal** and **save_this_custom_script**)
* **OPCODE_READ_PARAM_ANY32** macro now returns **SCRIPT_VAR** instead of **DWORD**
* Added **OPCODE_SKIP_VARARG_PARAMS** and **OPCODE_PEEK_VARARG_COUNT** util macros
* Removed **<<** and **>>** operators from **CRunningScript**
* Fixed **CLEO_GetVarArgCount** advancing counter of processed params
* Moved orphaned functions from global scope into proper classes
* Resetting previous opcode info when starting to process another script
* Added previous command info to all error messsages
* Added detailed error message when script execution runs into extra SCM data block
* CLEO's **CRunningScript** renamed to **Script**. Replaced variables named **thread** with **script**

All unit test passing.
No problems with DYOM, RZL-Trainer or Tuning Mod
