### PR TITLE
Added warning about stream type to 0AC2-0AC5 commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - new opcode **2084 ([emulate_key_release](https://library.sannybuilder.com/#/sa/script/extensions/input/2084))**
 - new opcode **2085 ([get_controller_key](https://library.sannybuilder.com/#/sa/script/extensions/input/2085))**
 - new opcode **2086 ([get_key_name](https://library.sannybuilder.com/#/sa/script/extensions/input/2086))**
+- added warning message to commands **0AC2-0AC5** if used with non-3d audio streams
 
 ## 5.0.3
 - added **GxtHook.cleo** plugin to ignored list

--- a/cleo_plugins/Audio/Audio.cpp
+++ b/cleo_plugins/Audio/Audio.cpp
@@ -248,6 +248,12 @@ public:
     static OpcodeResult __stdcall opcode_0AC2(CLEO::CRunningScript* thread)
     {
         auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
+
+        if (stream && !stream->Is3d())
+        {
+            LOG_WARNING(thread, "3d audio stream command used with regular audio stream in script %s", ScriptInfoStr(thread).c_str());
+        }
+
         CVector pos;
         pos.x = OPCODE_READ_PARAM_FLOAT();
         pos.y = OPCODE_READ_PARAM_FLOAT();
@@ -264,6 +270,11 @@ public:
         auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
         auto handle = OPCODE_READ_PARAM_OBJECT_HANDLE();
 
+        if (stream && !stream->Is3d())
+        {
+            LOG_WARNING(thread, "3d audio stream command used with regular audio stream in script %s", ScriptInfoStr(thread).c_str());
+        }
+
         if (stream)
         {
             auto object = CPools::GetObject(handle);
@@ -279,6 +290,11 @@ public:
         auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
         auto handle = OPCODE_READ_PARAM_PED_HANDLE();
 
+        if (stream && !stream->Is3d())
+        {
+            LOG_WARNING(thread, "3d audio stream command used with regular audio stream in script %s", ScriptInfoStr(thread).c_str());
+        }
+
         if (stream)
         {
             auto ped = CPools::GetPed(handle);
@@ -293,6 +309,11 @@ public:
     {
         auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
         auto handle = OPCODE_READ_PARAM_VEHICLE_HANDLE();
+
+        if (stream && !stream->Is3d())
+        {
+            LOG_WARNING(thread, "3d audio stream command used with regular audio stream in script %s", ScriptInfoStr(thread).c_str());
+        }
 
         if (stream)
         {

--- a/cleo_plugins/Audio/Audio.cpp
+++ b/cleo_plugins/Audio/Audio.cpp
@@ -251,7 +251,7 @@ public:
 
         if (stream && !stream->Is3d())
         {
-            LOG_WARNING(thread, "3d audio stream command used with regular audio stream in script %s", ScriptInfoStr(thread).c_str());
+            LOG_WARNING(thread, "3d audio stream command used with non-3d audio stream in script %s", ScriptInfoStr(thread).c_str());
         }
 
         CVector pos;
@@ -272,7 +272,7 @@ public:
 
         if (stream && !stream->Is3d())
         {
-            LOG_WARNING(thread, "3d audio stream command used with regular audio stream in script %s", ScriptInfoStr(thread).c_str());
+            LOG_WARNING(thread, "3d audio stream command used with non-3d audio stream in script %s", ScriptInfoStr(thread).c_str());
         }
 
         if (stream)
@@ -292,7 +292,7 @@ public:
 
         if (stream && !stream->Is3d())
         {
-            LOG_WARNING(thread, "3d audio stream command used with regular audio stream in script %s", ScriptInfoStr(thread).c_str());
+            LOG_WARNING(thread, "3d audio stream command used with non-3d audio stream in script %s", ScriptInfoStr(thread).c_str());
         }
 
         if (stream)
@@ -312,7 +312,7 @@ public:
 
         if (stream && !stream->Is3d())
         {
-            LOG_WARNING(thread, "3d audio stream command used with regular audio stream in script %s", ScriptInfoStr(thread).c_str());
+            LOG_WARNING(thread, "3d audio stream command used with non-3d audio stream in script %s", ScriptInfoStr(thread).c_str());
         }
 
         if (stream)

--- a/cleo_plugins/Audio/C3DAudioStream.h
+++ b/cleo_plugins/Audio/C3DAudioStream.h
@@ -9,6 +9,7 @@ namespace CLEO
         C3DAudioStream(const char* filepath);
 
         // overloaded actions
+        virtual bool Is3d() const { return true; }
         virtual void Set3dPosition(const CVector& pos);
         virtual void Set3dSourceSize(float radius);
         virtual void SetHost(CEntity* host, const CVector& offset);

--- a/cleo_plugins/Audio/CAudioStream.h
+++ b/cleo_plugins/Audio/CAudioStream.h
@@ -48,6 +48,7 @@ namespace CLEO
         float GetVolume() const;
 
         // 3d
+        virtual bool Is3d() const { return false; }
         virtual void Set3dPosition(const CVector& pos);
         virtual void Set3dSourceSize(float radius);
         virtual void SetHost(CEntity* placable, const CVector& offset);


### PR DESCRIPTION
Print warning when plain audio stream is used as parameter in 3d audio stream commands