### PR TITLE
Added warning about memory allocation limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 5.1.1
 - added check for preceding **gosub** call in **0AA1 ([return_if_false](https://library.sannybuilder.com/#/sa/script/extensions/CLEO/0AA1))**
+- added warnings about exceeding memory allocations count/size limits with **allocate_memory**
 
 ## 5.1.0
 - fixed collision of GXT texts hook with SAMP and other mods

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 5.1.1
 - added check for preceding **gosub** call in **0AA1 ([return_if_false](https://library.sannybuilder.com/#/sa/script/extensions/CLEO/0AA1))**
 - added warnings about exceeding memory allocations count/size limits with **allocate_memory**
+- added listing of remaining memory blocks allocated by scripts to the cleo.log when closing or starting new game
 
 ## 5.1.0
 - fixed collision of GXT texts hook with SAMP and other mods

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 5.1.1
 - added check for preceding **gosub** call in **0AA1 ([return_if_false](https://library.sannybuilder.com/#/sa/script/extensions/CLEO/0AA1))**
-- added warnings about exceeding memory allocations count/size limits with **allocate_memory**
+- added limit for memory allocated per script (see `cleo_plugins\SA.MemoryOperations.ini`). Exceeding the limit will cause a warning in game
 - added listing of remaining memory blocks allocated by scripts to the cleo.log when closing or starting new game
 
 ## 5.1.0

--- a/cleo_plugins/MemoryOperations/MemoryOperations.vcxproj
+++ b/cleo_plugins/MemoryOperations/MemoryOperations.vcxproj
@@ -87,9 +87,11 @@
     </Link>
     <PostBuildEvent>
       <Command>taskkill /IM gta_sa.exe /F /FI "STATUS eq RUNNING"
+xcopy /Y "$(ProjectDir)*.ini" "$(OutDir)"
 if defined GTA_SA_DIR (
-  xcopy /Y "$(OutDir)$(TargetName).*" "$(GTA_SA_DIR)\cleo\cleo_plugins\"
-)</Command>
+xcopy /Y "$(OutDir)$(TargetName).*" "$(GTA_SA_DIR)\cleo\cleo_plugins\"
+)
+ </Command>
     </PostBuildEvent>
     <ResourceCompile>
       <PreprocessorDefinitions>TARGET_NAME=$(TargetFileName)</PreprocessorDefinitions>
@@ -117,9 +119,11 @@ if defined GTA_SA_DIR (
     </Link>
     <PostBuildEvent>
       <Command>taskkill /IM gta_sa.exe /F /FI "STATUS eq RUNNING"
+xcopy /Y "$(ProjectDir)*.ini" "$(OutDir)"
 if defined GTA_SA_DIR (
-  xcopy /Y "$(OutDir)$(TargetName).*" "$(GTA_SA_DIR)\cleo\cleo_plugins\"
-)</Command>
+xcopy /Y "$(OutDir)$(TargetName).*" "$(GTA_SA_DIR)\cleo\cleo_plugins\"
+)
+ </Command>
     </PostBuildEvent>
     <ResourceCompile>
       <PreprocessorDefinitions>TARGET_NAME=$(TargetFileName)</PreprocessorDefinitions>
@@ -162,6 +166,9 @@ if defined GTA_SA_DIR (
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\Resource.rc" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="SA.MemoryOperations.ini" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/cleo_plugins/MemoryOperations/MemoryOperations.vcxproj.filters
+++ b/cleo_plugins/MemoryOperations/MemoryOperations.vcxproj.filters
@@ -43,4 +43,7 @@
   <ItemGroup>
     <ResourceCompile Include="..\Resource.rc" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="SA.MemoryOperations.ini" />
+  </ItemGroup>
 </Project>

--- a/cleo_plugins/MemoryOperations/SA.MemoryOperations.ini
+++ b/cleo_plugins/MemoryOperations/SA.MemoryOperations.ini
@@ -1,0 +1,4 @@
+; exceeding the limits will result in warnings on screen
+[Limits]
+MemoryAllocations = 2000 ; maximum count of memory blocks currently allocated by single script. Set to 0 to disable the limit
+MemoryTotalSize = 16 ; maximum total size (megabytes) of all memory blocks currently allocated by single script. Set to 0 to disable the limit

--- a/cleo_sdk/CLEO.h
+++ b/cleo_sdk/CLEO.h
@@ -294,7 +294,7 @@ enum class eCallbackId : DWORD
 	GameProcessAfter = 14, // void WINAPI OnGameProcessAfter(); // called once every frame after game logic processing
 	GameEnd = 2, // void WINAPI OnGameEnd(); // game session ended
 	ScriptsLoaded = 3, // void WINAPI OnScriptsLoaded();
-	ScriptsFinalize = 4, // void WINAPI OnScriptsFinalize();
+	ScriptsFinalize = 4, // void WINAPI OnScriptsFinalize(); // called after all scripts has been deleted. Pointers to scripts are no longer valid!
 	ScriptRegister = 5, // void WINAPI OnScriptRegister(CRunningScript* pScript); // called after script creation
 	ScriptUnregister = 6, // void WINAPI OnScriptUnregister(CRunningScript* pScript); // called before script deletion
 	ScriptProcessBefore = 7, // bool WINAPI OnScriptProcessBefore(CRunningScript* pScript); // return false to skip this script processing

--- a/source/CScriptEngine.cpp
+++ b/source/CScriptEngine.cpp
@@ -391,7 +391,7 @@ namespace CLEO
                 const auto ext = FS::path(fileList.strings[i]).extension();
                 if (ext == cs_ext || ext == cs3_ext || ext == cs4_ext)
                 {
-                    TRACE(" - '%s'", fileList.strings[i]);
+                    TRACE(" %s", fileList.strings[i]);
                     found.emplace(fileList.strings[i]);
                 }
             }
@@ -830,6 +830,7 @@ namespace CLEO
 
     void CScriptEngine::RemoveAllCustomScripts(void)
     {
+        TRACE("");
         TRACE("Unloading scripts...");
 
         if (CustomMission)


### PR DESCRIPTION
<img width="825" height="38" alt="image" src="https://github.com/user-attachments/assets/dede70ed-77fc-481d-8283-76b5a58b1ff4" />

Default limit of 2000 allocations is about minute of calling **allocate_memory** each frame without releasing

Added more details about cleanup in cleo.log
```
23/07/2025 03:17:42.687 Cleaning up 7 allocated memory blocks:
23/07/2025 03:17:42.687  1 block (0.39 kB) in script 'dm_enh' from 'DYOM_Enhancer.cs'
23/07/2025 03:17:42.687  5 blocks (10.52 kB) in script 'main' from 'scr.scm'
23/07/2025 03:17:42.687  1 block (0.03 kB) in script 'noname' from 'scr.scm'
23/07/2025 03:17:42.687 
23/07/2025 03:17:42.687 Cleaning up 1 loaded libraries:
23/07/2025 03:17:42.687  modloader\$f92 limit adjuster\$fastman92limitadjuster.asi
```