### PR TITLE
clang-format validation and formatting

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,21 @@
+name: Clang-Format Checker
+
+on:
+  push:
+    branches: master
+  pull_request:
+    branches: master
+
+jobs:
+  check-formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v5
+
+      - name: Run clang-format style check
+        uses: jidicula/clang-format-action@v4.15.0
+        with:
+          clang-format-version: 20
+          fallback-style: llvm
+          exclude-regex: third_party/.*

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -23,7 +23,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           submodules: "recursive"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: "recursive"
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: "recursive"
 

--- a/cleo_plugins/Audio/Audio.cpp
+++ b/cleo_plugins/Audio/Audio.cpp
@@ -1,499 +1,519 @@
+#include "CAudioStream.h"
 #include "CLEO.h"
 #include "CLEO_Utils.h"
-#include "plugin.h"
-#include "CTheScripts.h"
 #include "CSoundSystem.h"
-#include "CAudioStream.h"
+#include "CTheScripts.h"
+#include "plugin.h"
 
 using namespace CLEO;
 using namespace plugin;
 
-#define VALIDATE_STREAM() if(stream != nullptr && !soundSystem.HasStream(stream)) { SHOW_ERROR("Invalid or already closed '0x%X' audio stream handle param in script %s \nScript suspended.", stream, ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
+#define VALIDATE_STREAM()                                                      \
+  if (stream != nullptr && !soundSystem.HasStream(stream)) {                   \
+    SHOW_ERROR("Invalid or already closed '0x%X' audio stream handle param "   \
+               "in script %s \nScript suspended.",                             \
+               stream, ScriptInfoStr(thread).c_str());                         \
+    return thread->Suspend();                                                  \
+  }
 
-class Audio 
-{
+class Audio {
 public:
-    static CSoundSystem soundSystem;
+  static CSoundSystem soundSystem;
 
-    enum eStreamAction
-    {
-        Stop,
-        Play,
-        Pause,
-        Resume,
-    };
+  enum eStreamAction {
+    Stop,
+    Play,
+    Pause,
+    Resume,
+  };
 
-    Audio()
-    {
-        if (!PluginCheckCleoVersion()) return;
+  Audio() {
+    if (!PluginCheckCleoVersion())
+      return;
 
-        // register opcodes
-        CLEO_RegisterOpcode(0x0AAC, opcode_0AAC); // load_audiostream
-        CLEO_RegisterOpcode(0x0AAD, opcode_0AAD); // set_audio_stream_state
-        CLEO_RegisterOpcode(0x0AAE, opcode_0AAE); // remove_audio_stream
-        CLEO_RegisterOpcode(0x0AAF, opcode_0AAF); // get_audiostream_length
-        
-        CLEO_RegisterOpcode(0x0AB9, opcode_0AB9); // get_audio_stream_state
+    // register opcodes
+    CLEO_RegisterOpcode(0x0AAC, opcode_0AAC); // load_audiostream
+    CLEO_RegisterOpcode(0x0AAD, opcode_0AAD); // set_audio_stream_state
+    CLEO_RegisterOpcode(0x0AAE, opcode_0AAE); // remove_audio_stream
+    CLEO_RegisterOpcode(0x0AAF, opcode_0AAF); // get_audiostream_length
 
-        CLEO_RegisterOpcode(0x0ABB, opcode_0ABB); // get_audio_stream_volume
-        CLEO_RegisterOpcode(0x0ABC, opcode_0ABC); // set_audio_stream_volume
+    CLEO_RegisterOpcode(0x0AB9, opcode_0AB9); // get_audio_stream_state
 
-        CLEO_RegisterOpcode(0x0AC0, opcode_0AC0); // loop_audiostream
-        CLEO_RegisterOpcode(0x0AC1, opcode_0AC1); // load_audiostream_with_3d_support
-        CLEO_RegisterOpcode(0x0AC2, opcode_0AC2); // set_play_3d_audio_stream_at_coords
-        CLEO_RegisterOpcode(0x0AC3, opcode_0AC3); // set_play_3d_audio_stream_at_object
-        CLEO_RegisterOpcode(0x0AC4, opcode_0AC4); // set_play_3d_audio_stream_at_char
-        CLEO_RegisterOpcode(0x0AC5, opcode_0AC5); // set_play_3d_audio_stream_at_vehicle
+    CLEO_RegisterOpcode(0x0ABB, opcode_0ABB); // get_audio_stream_volume
+    CLEO_RegisterOpcode(0x0ABC, opcode_0ABC); // set_audio_stream_volume
 
-        CLEO_RegisterOpcode(0x2500, opcode_2500); // is_audio_stream_playing
-        CLEO_RegisterOpcode(0x2501, opcode_2501); // get_audiostream_duration
-        CLEO_RegisterOpcode(0x2502, opcode_2502); // get_audio_stream_speed
-        CLEO_RegisterOpcode(0x2503, opcode_2503); // set_audio_stream_speed
-        CLEO_RegisterOpcode(0x2504, opcode_2504); // set_audio_stream_volume_with_transition
-        CLEO_RegisterOpcode(0x2505, opcode_2505); // set_audio_stream_speed_with_transition
-        CLEO_RegisterOpcode(0x2506, opcode_2506); // set_audio_stream_source_size
-        CLEO_RegisterOpcode(0x2507, opcode_2507); // get_audio_stream_progress
-        CLEO_RegisterOpcode(0x2508, opcode_2508); // set_audio_stream_progress
+    CLEO_RegisterOpcode(0x0AC0, opcode_0AC0); // loop_audiostream
+    CLEO_RegisterOpcode(0x0AC1,
+                        opcode_0AC1); // load_audiostream_with_3d_support
+    CLEO_RegisterOpcode(0x0AC2,
+                        opcode_0AC2); // set_play_3d_audio_stream_at_coords
+    CLEO_RegisterOpcode(0x0AC3,
+                        opcode_0AC3); // set_play_3d_audio_stream_at_object
+    CLEO_RegisterOpcode(0x0AC4,
+                        opcode_0AC4); // set_play_3d_audio_stream_at_char
+    CLEO_RegisterOpcode(0x0AC5,
+                        opcode_0AC5); // set_play_3d_audio_stream_at_vehicle
 
-        CLEO_RegisterOpcode(0x2509, opcode_2509); // get_audio_stream_type
-        CLEO_RegisterOpcode(0x250A, opcode_250A); // set_audio_stream_type
+    CLEO_RegisterOpcode(0x2500, opcode_2500); // is_audio_stream_playing
+    CLEO_RegisterOpcode(0x2501, opcode_2501); // get_audiostream_duration
+    CLEO_RegisterOpcode(0x2502, opcode_2502); // get_audio_stream_speed
+    CLEO_RegisterOpcode(0x2503, opcode_2503); // set_audio_stream_speed
+    CLEO_RegisterOpcode(0x2504,
+                        opcode_2504); // set_audio_stream_volume_with_transition
+    CLEO_RegisterOpcode(0x2505,
+                        opcode_2505); // set_audio_stream_speed_with_transition
+    CLEO_RegisterOpcode(0x2506, opcode_2506); // set_audio_stream_source_size
+    CLEO_RegisterOpcode(0x2507, opcode_2507); // get_audio_stream_progress
+    CLEO_RegisterOpcode(0x2508, opcode_2508); // set_audio_stream_progress
 
-        CLEO_RegisterOpcode(0x250B, opcode_250B); // get_audio_stream_progress_seconds
-        CLEO_RegisterOpcode(0x250C, opcode_250C); // set_audio_stream_progress_seconds
+    CLEO_RegisterOpcode(0x2509, opcode_2509); // get_audio_stream_type
+    CLEO_RegisterOpcode(0x250A, opcode_250A); // set_audio_stream_type
 
-        // register event callbacks
-        CLEO_RegisterCallback(eCallbackId::GameBegin, OnGameBegin);
-        CLEO_RegisterCallback(eCallbackId::GameProcessAfter, OnGameProcessAfter);
-        CLEO_RegisterCallback(eCallbackId::GameEnd, OnGameEnd);
-        CLEO_RegisterCallback(eCallbackId::DrawingFinished, OnDrawingFinished);
-        CLEO_RegisterCallback(eCallbackId::MainWindowFocus, OnMainWindowFocus);
+    CLEO_RegisterOpcode(0x250B,
+                        opcode_250B); // get_audio_stream_progress_seconds
+    CLEO_RegisterOpcode(0x250C,
+                        opcode_250C); // set_audio_stream_progress_seconds
+
+    // register event callbacks
+    CLEO_RegisterCallback(eCallbackId::GameBegin, OnGameBegin);
+    CLEO_RegisterCallback(eCallbackId::GameProcessAfter, OnGameProcessAfter);
+    CLEO_RegisterCallback(eCallbackId::GameEnd, OnGameEnd);
+    CLEO_RegisterCallback(eCallbackId::DrawingFinished, OnDrawingFinished);
+    CLEO_RegisterCallback(eCallbackId::MainWindowFocus, OnMainWindowFocus);
+  }
+
+  ~Audio() {
+    CLEO_UnregisterCallback(eCallbackId::GameBegin, OnGameBegin);
+    CLEO_UnregisterCallback(eCallbackId::GameProcessAfter, OnGameProcessAfter);
+    CLEO_UnregisterCallback(eCallbackId::GameEnd, OnGameEnd);
+    CLEO_UnregisterCallback(eCallbackId::DrawingFinished, OnDrawingFinished);
+    CLEO_UnregisterCallback(eCallbackId::MainWindowFocus, OnMainWindowFocus);
+  }
+
+  static void __stdcall OnGameBegin(DWORD saveSlot) { soundSystem.Init(); }
+
+  static void __stdcall OnGameProcessAfter() { soundSystem.Process(); }
+
+  static void __stdcall OnGameEnd() { soundSystem.Clear(); }
+
+  static void __stdcall OnDrawingFinished() {
+    if (CTimer::m_UserPause) // main menu visible
+      soundSystem.Process();
+  }
+
+  static void __stdcall OnMainWindowFocus(bool active) {
+    if (active)
+      soundSystem.Resume();
+    else
+      soundSystem.Pause();
+  }
+
+  // 0AAC=2,  %2d% = load_audiostream %1d%  // IF and SET
+  static OpcodeResult __stdcall opcode_0AAC(CLEO::CRunningScript *thread) {
+    OPCODE_READ_PARAM_STRING_LEN(path, 511);
+
+    if (!isNetworkSource(path))
+      CLEO_ResolvePath(thread, _buff_path, sizeof(_buff_path));
+
+    auto ptr = soundSystem.CreateStream(path);
+
+    if (ptr != nullptr && IsLegacyScript(thread)) {
+      ptr->SetType(CLEO::CSoundSystem::LegacyModeDefaultStreamType);
     }
 
-    ~Audio()
-    {
-        CLEO_UnregisterCallback(eCallbackId::GameBegin, OnGameBegin);
-        CLEO_UnregisterCallback(eCallbackId::GameProcessAfter, OnGameProcessAfter);
-        CLEO_UnregisterCallback(eCallbackId::GameEnd, OnGameEnd);
-        CLEO_UnregisterCallback(eCallbackId::DrawingFinished, OnDrawingFinished);
-        CLEO_UnregisterCallback(eCallbackId::MainWindowFocus, OnMainWindowFocus);
+    OPCODE_WRITE_PARAM_PTR(ptr);
+    OPCODE_CONDITION_RESULT(ptr != nullptr);
+    return OR_CONTINUE;
+  }
+
+  // 0AAD=2,set_audiostream %1d% perform_action %2d%
+  static OpcodeResult __stdcall opcode_0AAD(CLEO::CRunningScript *thread) {
+    auto stream = (CAudioStream *)OPCODE_READ_PARAM_UINT();
+    VALIDATE_STREAM()
+    auto action = OPCODE_READ_PARAM_INT();
+
+    if (stream) {
+      switch (action) {
+      case eStreamAction::Stop:
+        stream->Stop();
+        break;
+      case eStreamAction::Play:
+        stream->Play();
+        break;
+      case eStreamAction::Pause:
+        stream->Pause();
+        break;
+      case eStreamAction::Resume:
+        stream->Resume();
+        break;
+      default:
+        LOG_WARNING(thread, "Unknown AudioStreamAction (%d) in script %s",
+                    action, ScriptInfoStr(thread).c_str());
+      }
     }
 
-    static void __stdcall OnGameBegin(DWORD saveSlot)
-    {
-        soundSystem.Init();
+    return OR_CONTINUE;
+  }
+
+  // 0AAE=1,release_audiostream %1d%
+  static OpcodeResult __stdcall opcode_0AAE(CLEO::CRunningScript *thread) {
+    auto stream = (CAudioStream *)OPCODE_READ_PARAM_UINT();
+    VALIDATE_STREAM();
+
+    if (stream)
+      soundSystem.DestroyStream(stream);
+
+    return OR_CONTINUE;
+  }
+
+  // 0AAF=2,%2d% = get_audiostream_length %1d%
+  static OpcodeResult __stdcall opcode_0AAF(CLEO::CRunningScript *thread) {
+    auto stream = (CAudioStream *)OPCODE_READ_PARAM_UINT();
+    VALIDATE_STREAM();
+
+    auto length = 0.0f;
+    if (stream)
+      length = stream->GetLength();
+
+    OPCODE_WRITE_PARAM_INT((int)length);
+    return OR_CONTINUE;
+  }
+
+  // 0AB9=2,get_audio_stream_state %1d% store_to %2d%
+  static OpcodeResult __stdcall opcode_0AB9(CLEO::CRunningScript *thread) {
+    auto stream = (CAudioStream *)OPCODE_READ_PARAM_UINT();
+    VALIDATE_STREAM();
+
+    auto state = CAudioStream::StreamState::Stopped;
+    if (stream)
+      state = stream->GetState();
+
+    OPCODE_WRITE_PARAM_INT(state);
+    return OR_CONTINUE;
+  }
+
+  // 0ABB=2,%2d% = get_audio_stream_volume %1d%
+  static OpcodeResult __stdcall opcode_0ABB(CLEO::CRunningScript *thread) {
+    auto stream = (CAudioStream *)OPCODE_READ_PARAM_UINT();
+    VALIDATE_STREAM();
+
+    auto volume = 0.0f;
+    if (stream)
+      volume = stream->GetVolume();
+
+    OPCODE_WRITE_PARAM_FLOAT(volume);
+    return OR_CONTINUE;
+  }
+
+  // 0ABC=2,set_audiostream %1d% volume %2d%
+  static OpcodeResult __stdcall opcode_0ABC(CLEO::CRunningScript *thread) {
+    auto stream = (CAudioStream *)OPCODE_READ_PARAM_UINT();
+    VALIDATE_STREAM();
+    auto volume = OPCODE_READ_PARAM_FLOAT();
+
+    if (stream)
+      stream->SetVolume(volume);
+
+    return OR_CONTINUE;
+  }
+
+  // 0AC0=2,loop_audiostream %1d% flag %2d%
+  static OpcodeResult __stdcall opcode_0AC0(CLEO::CRunningScript *thread) {
+    auto stream = (CAudioStream *)OPCODE_READ_PARAM_UINT();
+    VALIDATE_STREAM();
+    auto loop = OPCODE_READ_PARAM_BOOL();
+
+    if (stream)
+      stream->SetLooping(loop);
+
+    return OR_CONTINUE;
+  }
+
+  // 0AC1=2,%2d% = load_audiostream_with_3d_support %1d% //IF and SET
+  static OpcodeResult __stdcall opcode_0AC1(CLEO::CRunningScript *thread) {
+    OPCODE_READ_PARAM_STRING_LEN(path, 511);
+
+    if (!isNetworkSource(path))
+      CLEO_ResolvePath(thread, _buff_path, sizeof(_buff_path));
+
+    auto ptr = soundSystem.CreateStream(path, true);
+
+    if (ptr != nullptr && IsLegacyScript(thread)) {
+      ptr->SetType(CLEO::CSoundSystem::LegacyModeDefaultStreamType);
     }
 
-    static void __stdcall OnGameProcessAfter()
-    {
-        soundSystem.Process();
+    OPCODE_WRITE_PARAM_PTR(ptr);
+    OPCODE_CONDITION_RESULT(ptr != nullptr);
+    return OR_CONTINUE;
+  }
+
+  // 0AC2=4,set_3d_audiostream %1d% position %2d% %3d% %4d%
+  static OpcodeResult __stdcall opcode_0AC2(CLEO::CRunningScript *thread) {
+    auto stream = (CAudioStream *)OPCODE_READ_PARAM_UINT();
+    VALIDATE_STREAM();
+
+    if (stream && !stream->Is3d()) {
+      LOG_WARNING(
+          thread,
+          "3d audio stream command used with non-3d audio stream in script %s",
+          ScriptInfoStr(thread).c_str());
     }
 
-    static void __stdcall OnGameEnd()
-    {
-        soundSystem.Clear();
+    CVector pos;
+    pos.x = OPCODE_READ_PARAM_FLOAT();
+    pos.y = OPCODE_READ_PARAM_FLOAT();
+    pos.z = OPCODE_READ_PARAM_FLOAT();
+
+    if (stream)
+      stream->Set3dPosition(pos);
+
+    return OR_CONTINUE;
+  }
+
+  // 0AC3=2,link_3d_audiostream %1d% to_object %2d%
+  static OpcodeResult __stdcall opcode_0AC3(CLEO::CRunningScript *thread) {
+    auto stream = (CAudioStream *)OPCODE_READ_PARAM_UINT();
+    VALIDATE_STREAM();
+    auto handle = OPCODE_READ_PARAM_OBJECT_HANDLE();
+
+    if (stream && !stream->Is3d()) {
+      LOG_WARNING(
+          thread,
+          "3d audio stream command used with non-3d audio stream in script %s",
+          ScriptInfoStr(thread).c_str());
     }
 
-    static void __stdcall OnDrawingFinished()
-    {
-        if (CTimer::m_UserPause) // main menu visible
-            soundSystem.Process();
+    if (stream) {
+      auto object = CPools::GetObject(handle);
+      stream->SetHost(object, {0.0f, 0.0f, 0.0f});
     }
 
-    static void __stdcall OnMainWindowFocus(bool active)
-    {
-        if (active)
-            soundSystem.Resume();
-        else
-            soundSystem.Pause();
+    return OR_CONTINUE;
+  }
+
+  // 0AC4=2,link_3d_audiostream %1d% to_actor %2d%
+  static OpcodeResult __stdcall opcode_0AC4(CLEO::CRunningScript *thread) {
+    auto stream = (CAudioStream *)OPCODE_READ_PARAM_UINT();
+    VALIDATE_STREAM();
+    auto handle = OPCODE_READ_PARAM_PED_HANDLE();
+
+    if (stream && !stream->Is3d()) {
+      LOG_WARNING(
+          thread,
+          "3d audio stream command used with non-3d audio stream in script %s",
+          ScriptInfoStr(thread).c_str());
     }
 
- 
-    //0AAC=2,  %2d% = load_audiostream %1d%  // IF and SET
-    static OpcodeResult __stdcall opcode_0AAC(CLEO::CRunningScript* thread)
-    {
-        OPCODE_READ_PARAM_STRING_LEN(path, 511);
-
-        if (!isNetworkSource(path))
-            CLEO_ResolvePath(thread, _buff_path, sizeof(_buff_path));
-
-        auto ptr = soundSystem.CreateStream(path);
-
-        if (ptr != nullptr && IsLegacyScript(thread))
-        {
-            ptr->SetType(CLEO::CSoundSystem::LegacyModeDefaultStreamType);
-        }
-
-        OPCODE_WRITE_PARAM_PTR(ptr);
-        OPCODE_CONDITION_RESULT(ptr != nullptr);
-        return OR_CONTINUE;
+    if (stream) {
+      auto ped = CPools::GetPed(handle);
+      stream->SetHost(ped, {0.0f, 0.0f, 0.0f});
     }
 
-    //0AAD=2,set_audiostream %1d% perform_action %2d%
-    static OpcodeResult __stdcall opcode_0AAD(CLEO::CRunningScript* thread)
-    {
-        auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM()
-        auto action = OPCODE_READ_PARAM_INT();
+    return OR_CONTINUE;
+  }
 
-        if (stream)
-        {
-            switch (action)
-            {
-                case eStreamAction::Stop: stream->Stop(); break;
-                case eStreamAction::Play: stream->Play(); break;
-                case eStreamAction::Pause: stream->Pause(); break;
-                case eStreamAction::Resume: stream->Resume(); break;
-                default:
-                    LOG_WARNING(thread, "Unknown AudioStreamAction (%d) in script %s", action, ScriptInfoStr(thread).c_str());
-            }
-        }
+  // 0AC5=2,link_3d_audiostream %1d% to_vehicle %2d%
+  static OpcodeResult __stdcall opcode_0AC5(CLEO::CRunningScript *thread) {
+    auto stream = (CAudioStream *)OPCODE_READ_PARAM_UINT();
+    VALIDATE_STREAM();
+    auto handle = OPCODE_READ_PARAM_VEHICLE_HANDLE();
 
-        return OR_CONTINUE;
+    if (stream && !stream->Is3d()) {
+      LOG_WARNING(
+          thread,
+          "3d audio stream command used with non-3d audio stream in script %s",
+          ScriptInfoStr(thread).c_str());
     }
 
-    //0AAE=1,release_audiostream %1d%
-    static OpcodeResult __stdcall opcode_0AAE(CLEO::CRunningScript* thread)
-    {
-        auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
-
-        if (stream) soundSystem.DestroyStream(stream);
-
-        return OR_CONTINUE;
+    if (stream) {
+      auto vehicle = CPools::GetVehicle(handle);
+      stream->SetHost(vehicle, {0.0f, 0.0f, 0.0f});
     }
 
-    //0AAF=2,%2d% = get_audiostream_length %1d%
-    static OpcodeResult __stdcall opcode_0AAF(CLEO::CRunningScript* thread)
-    {
-        auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
+    return OR_CONTINUE;
+  }
 
-        auto length = 0.0f;
-        if (stream) length = stream->GetLength();
+  // 2500=1,  is_audio_stream_playing %1d%
+  static OpcodeResult __stdcall opcode_2500(CLEO::CRunningScript *thread) {
+    auto stream = (CAudioStream *)OPCODE_READ_PARAM_UINT();
+    VALIDATE_STREAM();
 
-        OPCODE_WRITE_PARAM_INT((int)length);
-        return OR_CONTINUE;
+    auto state = CAudioStream::StreamState::Stopped;
+    if (stream)
+      state = stream->GetState();
+
+    OPCODE_CONDITION_RESULT(state == CAudioStream::StreamState::Playing);
+    return OR_CONTINUE;
+  }
+
+  // 2501=2,%2d% = get_audiostream_duration %1d%
+  static OpcodeResult __stdcall opcode_2501(CLEO::CRunningScript *thread) {
+    auto stream = (CAudioStream *)OPCODE_READ_PARAM_UINT();
+    VALIDATE_STREAM();
+
+    auto length = 0.0f;
+    if (stream) {
+      auto length = stream->GetLength();
+
+      auto speed = stream->GetSpeed();
+      if (speed <= 0.0f)
+        length = FLT_MAX; // it would take forever to play paused
+      else
+        length /= speed; // speed corrected
     }
 
-    //0AB9=2,get_audio_stream_state %1d% store_to %2d%
-    static OpcodeResult __stdcall opcode_0AB9(CLEO::CRunningScript* thread)
-    {
-        auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
+    OPCODE_WRITE_PARAM_FLOAT(length);
+    return OR_CONTINUE;
+  }
 
-        auto state = CAudioStream::StreamState::Stopped;
-        if (stream) state = stream->GetState();
+  // 2502=2,get_audio_stream_speed %1d% store_to %2d%
+  static OpcodeResult __stdcall opcode_2502(CLEO::CRunningScript *thread) {
+    auto stream = (CAudioStream *)OPCODE_READ_PARAM_UINT();
+    VALIDATE_STREAM();
 
-        OPCODE_WRITE_PARAM_INT(state);
-        return OR_CONTINUE;
+    auto speed = 0.0f;
+    if (stream)
+      speed = stream->GetSpeed();
+
+    OPCODE_WRITE_PARAM_FLOAT(speed);
+    return OR_CONTINUE;
+  }
+
+  // 2503=2,set_audio_stream_speed %1d% speed %2d%
+  static OpcodeResult __stdcall opcode_2503(CLEO::CRunningScript *thread) {
+    auto stream = (CAudioStream *)OPCODE_READ_PARAM_UINT();
+    VALIDATE_STREAM();
+    auto speed = OPCODE_READ_PARAM_FLOAT();
+
+    if (stream)
+      stream->SetSpeed(speed);
+
+    return OR_CONTINUE;
+  }
+
+  // 2504=3,set_audio_stream_volume_with_transition %1d% volume %2d% time_ms
+  // %2d%
+  static OpcodeResult __stdcall opcode_2504(CLEO::CRunningScript *thread) {
+    auto stream = (CAudioStream *)OPCODE_READ_PARAM_UINT();
+    VALIDATE_STREAM();
+    auto volume = OPCODE_READ_PARAM_FLOAT();
+    auto time = OPCODE_READ_PARAM_INT();
+
+    if (stream)
+      stream->SetVolume(volume, 0.001f * time);
+
+    return OR_CONTINUE;
+  }
+
+  // 2505=3,set_audio_stream_speed_with_transition %1d% speed %2d% time_ms %2d%
+  static OpcodeResult __stdcall opcode_2505(CLEO::CRunningScript *thread) {
+    auto stream = (CAudioStream *)OPCODE_READ_PARAM_UINT();
+    VALIDATE_STREAM();
+    auto speed = OPCODE_READ_PARAM_FLOAT();
+    auto time = OPCODE_READ_PARAM_INT();
+
+    if (stream)
+      stream->SetSpeed(speed, 0.001f * time);
+
+    return OR_CONTINUE;
+  }
+
+  // 2506=2,set_audio_stream_source_size %1d% radius %2d%
+  static OpcodeResult __stdcall opcode_2506(CLEO::CRunningScript *thread) {
+    auto stream = (CAudioStream *)OPCODE_READ_PARAM_UINT();
+    VALIDATE_STREAM();
+    auto radius = OPCODE_READ_PARAM_FLOAT();
+
+    if (stream)
+      stream->Set3dSourceSize(radius);
+
+    return OR_CONTINUE;
+  }
+
+  // 2507=2,get_audio_stream_progress %1d% store_to %2d%
+  static OpcodeResult __stdcall opcode_2507(CLEO::CRunningScript *thread) {
+    auto stream = (CAudioStream *)OPCODE_READ_PARAM_UINT();
+    VALIDATE_STREAM();
+
+    auto progress = 0.0f;
+    if (stream)
+      progress = stream->GetProgress();
+
+    OPCODE_WRITE_PARAM_FLOAT(progress);
+    return OR_CONTINUE;
+  }
+
+  // 2508=2,set_audio_stream_progress %1d% speed %2d%
+  static OpcodeResult __stdcall opcode_2508(CLEO::CRunningScript *thread) {
+    auto stream = (CAudioStream *)OPCODE_READ_PARAM_UINT();
+    VALIDATE_STREAM();
+    auto speed = OPCODE_READ_PARAM_FLOAT();
+
+    if (stream)
+      stream->SetProgress(speed);
+
+    return OR_CONTINUE;
+  }
+
+  // 2509=2,get_audio_stream_type %1d% store_to %2d%
+  static OpcodeResult __stdcall opcode_2509(CLEO::CRunningScript *thread) {
+    auto stream = (CAudioStream *)OPCODE_READ_PARAM_UINT();
+    VALIDATE_STREAM();
+
+    auto type = eStreamType::None;
+    if (stream)
+      type = stream->GetType();
+
+    OPCODE_WRITE_PARAM_INT(type);
+    return OR_CONTINUE;
+  }
+
+  // 250A=2,set_audio_stream_type %1d% type %2d%
+  static OpcodeResult __stdcall opcode_250A(CLEO::CRunningScript *thread) {
+    auto stream = (CAudioStream *)OPCODE_READ_PARAM_UINT();
+    VALIDATE_STREAM();
+    auto type = OPCODE_READ_PARAM_INT();
+
+    if (stream)
+      stream->SetType((eStreamType)type);
+
+    return OR_CONTINUE;
+  }
+
+  // 250B=2,get_audio_stream_progress_seconds %1d% store_to %2d%
+  static OpcodeResult __stdcall opcode_250B(CLEO::CRunningScript *thread) {
+    auto stream = (CAudioStream *)OPCODE_READ_PARAM_UINT();
+    VALIDATE_STREAM();
+
+    auto progress = 0.0f;
+    if (stream) {
+      progress = stream->GetProgress(); // 0.0 - 1.0
+      progress *= stream->GetLength();
     }
 
-    //0ABB=2,%2d% = get_audio_stream_volume %1d%
-    static OpcodeResult __stdcall opcode_0ABB(CLEO::CRunningScript* thread)
-    {
-        auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
+    OPCODE_WRITE_PARAM_FLOAT(progress);
+    return OR_CONTINUE;
+  }
 
-        auto volume = 0.0f;
-        if (stream) volume = stream->GetVolume();
+  // 250C=2,set_audio_stream_progress_seconds %1d% value %2d%
+  static OpcodeResult __stdcall opcode_250C(CLEO::CRunningScript *thread) {
+    auto stream = (CAudioStream *)OPCODE_READ_PARAM_UINT();
+    VALIDATE_STREAM();
+    auto progress = OPCODE_READ_PARAM_FLOAT();
 
-        OPCODE_WRITE_PARAM_FLOAT(volume);
-        return OR_CONTINUE;
+    if (stream) {
+      float len = stream->GetLength();
+      if (len > 0.0f) {
+        progress /= len;
+      } else {
+        progress = 0.0f; // invalid total size
+      }
+
+      stream->SetProgress(progress);
     }
 
-    //0ABC=2,set_audiostream %1d% volume %2d%
-    static OpcodeResult __stdcall opcode_0ABC(CLEO::CRunningScript* thread)
-    {
-        auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
-        auto volume = OPCODE_READ_PARAM_FLOAT();
-
-        if (stream) stream->SetVolume(volume);
-
-        return OR_CONTINUE;
-    }
-
-    //0AC0=2,loop_audiostream %1d% flag %2d%
-    static OpcodeResult __stdcall opcode_0AC0(CLEO::CRunningScript* thread)
-    {
-        auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
-        auto loop = OPCODE_READ_PARAM_BOOL();
-
-        if (stream) stream->SetLooping(loop);
-
-        return OR_CONTINUE;
-    }
-
-    //0AC1=2,%2d% = load_audiostream_with_3d_support %1d% //IF and SET
-    static OpcodeResult __stdcall opcode_0AC1(CLEO::CRunningScript* thread)
-    {
-        OPCODE_READ_PARAM_STRING_LEN(path, 511);
-
-        if (!isNetworkSource(path))
-            CLEO_ResolvePath(thread, _buff_path, sizeof(_buff_path));
-
-        auto ptr = soundSystem.CreateStream(path, true);
-
-        if (ptr != nullptr && IsLegacyScript(thread))
-        {
-            ptr->SetType(CLEO::CSoundSystem::LegacyModeDefaultStreamType);
-        }
-
-        OPCODE_WRITE_PARAM_PTR(ptr);
-        OPCODE_CONDITION_RESULT(ptr != nullptr);
-        return OR_CONTINUE;
-    }
-
-    //0AC2=4,set_3d_audiostream %1d% position %2d% %3d% %4d%
-    static OpcodeResult __stdcall opcode_0AC2(CLEO::CRunningScript* thread)
-    {
-        auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
-
-        if (stream && !stream->Is3d())
-        {
-            LOG_WARNING(thread, "3d audio stream command used with non-3d audio stream in script %s", ScriptInfoStr(thread).c_str());
-        }
-
-        CVector pos;
-        pos.x = OPCODE_READ_PARAM_FLOAT();
-        pos.y = OPCODE_READ_PARAM_FLOAT();
-        pos.z = OPCODE_READ_PARAM_FLOAT();
-
-        if (stream) stream->Set3dPosition(pos);
-
-        return OR_CONTINUE;
-    }
-
-    //0AC3=2,link_3d_audiostream %1d% to_object %2d%
-    static OpcodeResult __stdcall opcode_0AC3(CLEO::CRunningScript* thread)
-    {
-        auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
-        auto handle = OPCODE_READ_PARAM_OBJECT_HANDLE();
-
-        if (stream && !stream->Is3d())
-        {
-            LOG_WARNING(thread, "3d audio stream command used with non-3d audio stream in script %s", ScriptInfoStr(thread).c_str());
-        }
-
-        if (stream)
-        {
-            auto object = CPools::GetObject(handle);
-            stream->SetHost(object, { 0.0f, 0.0f, 0.0f });
-        }
-
-        return OR_CONTINUE;
-    }
-
-    //0AC4=2,link_3d_audiostream %1d% to_actor %2d%
-    static OpcodeResult __stdcall opcode_0AC4(CLEO::CRunningScript* thread)
-    {
-        auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
-        auto handle = OPCODE_READ_PARAM_PED_HANDLE();
-
-        if (stream && !stream->Is3d())
-        {
-            LOG_WARNING(thread, "3d audio stream command used with non-3d audio stream in script %s", ScriptInfoStr(thread).c_str());
-        }
-
-        if (stream)
-        {
-            auto ped = CPools::GetPed(handle);
-            stream->SetHost(ped, { 0.0f, 0.0f, 0.0f });
-        }
-
-        return OR_CONTINUE;
-    }
-
-    //0AC5=2,link_3d_audiostream %1d% to_vehicle %2d%
-    static OpcodeResult __stdcall opcode_0AC5(CLEO::CRunningScript* thread)
-    {
-        auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
-        auto handle = OPCODE_READ_PARAM_VEHICLE_HANDLE();
-
-        if (stream && !stream->Is3d())
-        {
-            LOG_WARNING(thread, "3d audio stream command used with non-3d audio stream in script %s", ScriptInfoStr(thread).c_str());
-        }
-
-        if (stream)
-        {
-            auto vehicle = CPools::GetVehicle(handle);
-            stream->SetHost(vehicle, { 0.0f, 0.0f, 0.0f });
-         }
-
-        return OR_CONTINUE;
-    }
-
-    //2500=1,  is_audio_stream_playing %1d%
-    static OpcodeResult __stdcall opcode_2500(CLEO::CRunningScript* thread)
-    {
-        auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
-
-        auto state = CAudioStream::StreamState::Stopped;
-        if (stream) state = stream->GetState();
-
-        OPCODE_CONDITION_RESULT(state == CAudioStream::StreamState::Playing);
-        return OR_CONTINUE;
-    }
-
-    //2501=2,%2d% = get_audiostream_duration %1d%
-    static OpcodeResult __stdcall opcode_2501(CLEO::CRunningScript* thread)
-    {
-        auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
-
-        auto length = 0.0f;
-        if (stream)
-        {
-            auto length = stream->GetLength();
-
-            auto speed = stream->GetSpeed();
-            if (speed <= 0.0f)
-                length = FLT_MAX; // it would take forever to play paused
-            else
-                length /= speed; // speed corrected
-        }
-
-        OPCODE_WRITE_PARAM_FLOAT(length);
-        return OR_CONTINUE;
-    }
-
-    //2502=2,get_audio_stream_speed %1d% store_to %2d%
-    static OpcodeResult __stdcall opcode_2502(CLEO::CRunningScript* thread)
-    {
-        auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
-
-        auto speed = 0.0f;
-        if (stream) speed = stream->GetSpeed();
-
-        OPCODE_WRITE_PARAM_FLOAT(speed);
-        return OR_CONTINUE;
-    }
-
-    //2503=2,set_audio_stream_speed %1d% speed %2d%
-    static OpcodeResult __stdcall opcode_2503(CLEO::CRunningScript* thread)
-    {
-        auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
-        auto speed = OPCODE_READ_PARAM_FLOAT();
-
-        if (stream) stream->SetSpeed(speed);
-
-        return OR_CONTINUE;
-    }
-
-    //2504=3,set_audio_stream_volume_with_transition %1d% volume %2d% time_ms %2d%
-    static OpcodeResult __stdcall opcode_2504(CLEO::CRunningScript* thread)
-    {
-        auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
-        auto volume = OPCODE_READ_PARAM_FLOAT();
-        auto time = OPCODE_READ_PARAM_INT();
-
-        if (stream) stream->SetVolume(volume, 0.001f * time);
-
-        return OR_CONTINUE;
-    }
-
-    //2505=3,set_audio_stream_speed_with_transition %1d% speed %2d% time_ms %2d%
-    static OpcodeResult __stdcall opcode_2505(CLEO::CRunningScript* thread)
-    {
-        auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
-        auto speed = OPCODE_READ_PARAM_FLOAT();
-        auto time = OPCODE_READ_PARAM_INT();
-
-        if (stream) stream->SetSpeed(speed, 0.001f * time);
-
-        return OR_CONTINUE;
-    }
-
-    //2506=2,set_audio_stream_source_size %1d% radius %2d%
-    static OpcodeResult __stdcall opcode_2506(CLEO::CRunningScript* thread)
-    {
-        auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
-        auto radius = OPCODE_READ_PARAM_FLOAT();
-
-        if (stream) stream->Set3dSourceSize(radius);
-
-        return OR_CONTINUE;
-    }
-
-    //2507=2,get_audio_stream_progress %1d% store_to %2d%
-    static OpcodeResult __stdcall opcode_2507(CLEO::CRunningScript* thread)
-    {
-        auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
-
-        auto progress = 0.0f;
-        if (stream) progress = stream->GetProgress();
-
-        OPCODE_WRITE_PARAM_FLOAT(progress);
-        return OR_CONTINUE;
-    }
-
-    //2508=2,set_audio_stream_progress %1d% speed %2d%
-    static OpcodeResult __stdcall opcode_2508(CLEO::CRunningScript* thread)
-    {
-        auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
-        auto speed = OPCODE_READ_PARAM_FLOAT();
-
-        if (stream) stream->SetProgress(speed);
-
-        return OR_CONTINUE;
-    }
-
-    //2509=2,get_audio_stream_type %1d% store_to %2d%
-    static OpcodeResult __stdcall opcode_2509(CLEO::CRunningScript* thread)
-    {
-        auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
-
-        auto type = eStreamType::None;
-        if (stream) type = stream->GetType();
-
-        OPCODE_WRITE_PARAM_INT(type);
-        return OR_CONTINUE;
-    }
-
-    //250A=2,set_audio_stream_type %1d% type %2d%
-    static OpcodeResult __stdcall opcode_250A(CLEO::CRunningScript* thread)
-    {
-        auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
-        auto type = OPCODE_READ_PARAM_INT();
-
-        if (stream) stream->SetType((eStreamType)type);
-
-        return OR_CONTINUE;
-    }
-
-    //250B=2,get_audio_stream_progress_seconds %1d% store_to %2d%
-    static OpcodeResult __stdcall opcode_250B(CLEO::CRunningScript* thread)
-    {
-        auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
-
-        auto progress = 0.0f;
-        if (stream)
-        {
-            progress = stream->GetProgress(); // 0.0 - 1.0
-            progress *= stream->GetLength();
-        }
-
-        OPCODE_WRITE_PARAM_FLOAT(progress);
-        return OR_CONTINUE;
-    }
-
-    //250C=2,set_audio_stream_progress_seconds %1d% value %2d%
-    static OpcodeResult __stdcall opcode_250C(CLEO::CRunningScript* thread)
-    {
-        auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT(); VALIDATE_STREAM();
-        auto progress = OPCODE_READ_PARAM_FLOAT();
-
-        if (stream)
-        {
-            float len = stream->GetLength();
-            if(len > 0.0f)
-            {
-                progress /= len;
-            }
-            else
-            {
-                progress = 0.0f; // invalid total size
-            }
-
-            stream->SetProgress(progress);
-        }
-
-        return OR_CONTINUE;
-    }
+    return OR_CONTINUE;
+  }
 } audioInstance;
 
 CSoundSystem Audio::soundSystem;

--- a/cleo_plugins/Audio/C3DAudioStream.cpp
+++ b/cleo_plugins/Audio/C3DAudioStream.cpp
@@ -1,210 +1,223 @@
 #include "C3DAudioStream.h"
-#include "CSoundSystem.h"
-#include "CLEO_Utils.h"
 #include "CCamera.h"
+#include "CLEO_Utils.h"
+#include "CSoundSystem.h"
 
 using namespace CLEO;
 
-C3DAudioStream::C3DAudioStream(const char* filepath) : CAudioStream()
-{
-    // see https://github.com/cleolibrary/CLEO5/pull/230
-    static_assert(offsetof(C3DAudioStream, streamInternal) == 4 && alignof(C3DAudioStream) == 4, "C3DAudioStream compatibility with CLEO4 broken!");
+C3DAudioStream::C3DAudioStream(const char *filepath) : CAudioStream() {
+  // see https://github.com/cleolibrary/CLEO5/pull/230
+  static_assert(offsetof(C3DAudioStream, streamInternal) == 4 &&
+                    alignof(C3DAudioStream) == 4,
+                "C3DAudioStream compatibility with CLEO4 broken!");
 
-    if (isNetworkSource(filepath) && !CSoundSystem::allowNetworkSources)
-    {
-        TRACE("Loading of 3d-audiostream '%s' failed. Support of network sources was disabled in SA.Audio.ini", filepath);
-        return;
-    }
+  if (isNetworkSource(filepath) && !CSoundSystem::allowNetworkSources) {
+    TRACE("Loading of 3d-audiostream '%s' failed. Support of network sources "
+          "was disabled in SA.Audio.ini",
+          filepath);
+    return;
+  }
 
-    unsigned flags = BASS_SAMPLE_3D | BASS_SAMPLE_MONO | BASS_SAMPLE_SOFTWARE | BASS_STREAM_PRESCAN;
-    if (CSoundSystem::useFloatAudio) flags |= BASS_SAMPLE_FLOAT;
+  unsigned flags = BASS_SAMPLE_3D | BASS_SAMPLE_MONO | BASS_SAMPLE_SOFTWARE |
+                   BASS_STREAM_PRESCAN;
+  if (CSoundSystem::useFloatAudio)
+    flags |= BASS_SAMPLE_FLOAT;
 
-    if (!(streamInternal = BASS_StreamCreateFile(FALSE, filepath, 0, 0, flags)) &&
-        !(streamInternal = BASS_StreamCreateURL(filepath, 0, flags, nullptr, nullptr)))
-    {
-        LOG_WARNING(0, "Loading of 3d-audiostream '%s' failed. Error code: %d", filepath, BASS_ErrorGetCode());
-        return;
-    }
+  if (!(streamInternal = BASS_StreamCreateFile(FALSE, filepath, 0, 0, flags)) &&
+      !(streamInternal =
+            BASS_StreamCreateURL(filepath, 0, flags, nullptr, nullptr))) {
+    LOG_WARNING(0, "Loading of 3d-audiostream '%s' failed. Error code: %d",
+                filepath, BASS_ErrorGetCode());
+    return;
+  }
 
-    BASS_ChannelGetAttribute(streamInternal, BASS_ATTRIB_FREQ, &rate);
-    BASS_ChannelSet3DAttributes(streamInternal, BASS_3DMODE_NORMAL, -1.0f, -1.0f, -1, -1, -1.0f);
-    BASS_ChannelSetAttribute(streamInternal, BASS_ATTRIB_VOL, 0.0f); // muted until processed
-    ok = true;
+  BASS_ChannelGetAttribute(streamInternal, BASS_ATTRIB_FREQ, &rate);
+  BASS_ChannelSet3DAttributes(streamInternal, BASS_3DMODE_NORMAL, -1.0f, -1.0f,
+                              -1, -1, -1.0f);
+  BASS_ChannelSetAttribute(streamInternal, BASS_ATTRIB_VOL,
+                           0.0f); // muted until processed
+  ok = true;
 }
 
-void C3DAudioStream::Set3dPosition(const CVector& pos)
-{
-    host = nullptr;
+void C3DAudioStream::Set3dPosition(const CVector &pos) {
+  host = nullptr;
+  hostType = ENTITY_TYPE_NOTHING;
+  offset = pos;
+}
+
+void C3DAudioStream::Set3dSourceSize(float radius) {
+  this->radius = std::max<float>(radius, 0.01f);
+}
+
+void C3DAudioStream::SetHost(CEntity *host, const CVector &offset) {
+  if (host != nullptr) {
+    this->host = host;
+    hostType = (eEntityType)host->m_nType;
+  } else {
+    this->host = nullptr;
     hostType = ENTITY_TYPE_NOTHING;
-    offset = pos;
+  }
+
+  this->offset = offset;
 }
 
-void C3DAudioStream::Set3dSourceSize(float radius)
-{
-    this->radius = std::max<float>(radius, 0.01f);
+void C3DAudioStream::Process() {
+  UpdatePosition();
+  CAudioStream::Process();
+
+  // position and velocity
+  CVector relPos = position - CSoundSystem::position;
+  float distance = relPos.NormaliseAndMag();
+  float inFactor = (float)CalculateDistanceDecay(
+      radius * 5.0f,
+      distance *
+          5.0f); // use decay curve for blending inside-outside source effects
+
+  // stereo panning
+  float sign = dot(CSoundSystem::direction, relPos) > 0.0f ? 1.0f : -1.0f;
+  CVector centerPos =
+      CSoundSystem::position + CSoundSystem::direction * distance * sign;
+  CVector percPos = lerp(position, centerPos, inFactor);
+
+  CVector percVel = lerp(velocity, CSoundSystem::velocity, inFactor);
+
+  BASS_ChannelSet3DPosition(streamInternal, &toBass(percPos), nullptr,
+                            &toBass(percVel));
 }
 
-void C3DAudioStream::SetHost(CEntity* host, const CVector& offset)
-{
-    if (host != nullptr)
-    {
-        this->host = host;
-        hostType = (eEntityType)host->m_nType;
-    }
-    else
-    {
-        this->host = nullptr;
-        hostType = ENTITY_TYPE_NOTHING;
-    }
+float C3DAudioStream::CalculateVolume() {
+  if (!placed) {
+    return 0.0f; // mute until processed
+  }
 
-    this->offset = offset;
+  CVector relPos = position - CSoundSystem::position;
+  float distance = relPos.NormaliseAndMag();
+  float inFactor = (float)CalculateDistanceDecay(
+      radius * 5.0f,
+      distance *
+          5.0f); // use decay curve for blending inside-outside source effects
+
+  double vol = Volume_3D_Adjust;
+
+  switch (type) {
+  case SoundEffect:
+    vol *= CSoundSystem::masterVolumeSfx;
+    break;
+  case Music:
+    vol *= CSoundSystem::masterVolumeMusic;
+    break;
+  case UserInterface:
+    vol *= CSoundSystem::masterVolumeSfx;
+    break;
+  default:
+    vol *= 1.0f;
+    break;
+  }
+
+  // distance decay
+  vol *= CalculateDistanceDecay(radius, distance);
+
+  // "look" direction decay
+  vol *= lerp(CalculateDirectionDecay(CSoundSystem::direction, relPos), 1.0f,
+              inFactor);
+
+  // screen black fade
+  if (type != UserInterface && !TheCamera.m_bIgnoreFadingStuffForMusic) {
+    vol *= 1.0f - TheCamera.m_fFadeAlpha / 255.0f;
+  }
+
+  // music volume lowering in cutscenes, when characters talk, mission sounds
+  // are played etc.
+  if (type == Music) {
+    if (TheCamera.m_bWideScreenOn)
+      vol *= 0.25f;
+  }
+
+  // stream's volume
+  vol *= volume.value();
+
+  return (float)vol;
 }
 
-void C3DAudioStream::Process()
-{
-    UpdatePosition();
-    CAudioStream::Process();
+float C3DAudioStream::CalculateSpeed() {
+  float masterSpeed;
+  switch (type) {
+  case SoundEffect:
+    masterSpeed = CSoundSystem::masterSpeed;
+    break;
+  case Music:
+    masterSpeed = CSoundSystem::masterSpeed;
+    break;
+  case UserInterface:
+    masterSpeed = 1.0f;
+    break;
+  default:
+    masterSpeed = 1.0f;
+  }
 
-    // position and velocity
-    CVector relPos = position - CSoundSystem::position;
-    float distance = relPos.NormaliseAndMag();
-    float inFactor = (float)CalculateDistanceDecay(radius * 5.0f, distance * 5.0f); // use decay curve for blending inside-outside source effects
-
-    // stereo panning
-    float sign = dot(CSoundSystem::direction, relPos) > 0.0f ? 1.0f : -1.0f;
-    CVector centerPos = CSoundSystem::position + CSoundSystem::direction * distance * sign;
-    CVector percPos = lerp(position, centerPos, inFactor);
-
-    CVector percVel = lerp(velocity, CSoundSystem::velocity, inFactor);
-
-    BASS_ChannelSet3DPosition(streamInternal, &toBass(percPos), nullptr, &toBass(percVel));
+  return masterSpeed * speed.value();
 }
 
-float C3DAudioStream::CalculateVolume()
-{
-    if (!placed)
-    {
-        return 0.0f; // mute until processed
-    }
+double C3DAudioStream::CalculateDistanceDecay(float radius, float distance) {
+  distance = std::max<float>(distance - radius, 0.0f);
 
-    CVector relPos = position - CSoundSystem::position;
-    float distance = relPos.NormaliseAndMag();
-    float inFactor = (float)CalculateDistanceDecay(radius * 5.0f, distance * 5.0f); // use decay curve for blending inside-outside source effects
+  // exact match to ingame sounds
+  /*float factor = 1.0f / powf(1.0f + distance, 2); // inverse square
+  factor -= 0.00006f;
+  factor = std::clamp(factor, 0.0f, 1.0f);*/
 
-    double vol = Volume_3D_Adjust;
-
-    switch (type)
-    {
-        case SoundEffect: vol *= CSoundSystem::masterVolumeSfx; break;
-        case Music: vol *= CSoundSystem::masterVolumeMusic; break;
-        case UserInterface: vol *= CSoundSystem::masterVolumeSfx; break;
-        default: vol *= 1.0f; break;
-    }
-
-    // distance decay
-    vol *= CalculateDistanceDecay(radius, distance);
-
-    // "look" direction decay
-    vol *= lerp(CalculateDirectionDecay(CSoundSystem::direction, relPos), 1.0f, inFactor);
-
-    // screen black fade
-    if (type != UserInterface && !TheCamera.m_bIgnoreFadingStuffForMusic)
-    {
-        vol *= 1.0f - TheCamera.m_fFadeAlpha / 255.0f;
-    }
-
-    // music volume lowering in cutscenes, when characters talk, mission sounds are played etc.
-    if (type == Music) 
-    {
-        if (TheCamera.m_bWideScreenOn) vol *= 0.25f;
-    }
-
-    // stream's volume
-    vol *= volume.value();
-
-    return (float)vol;
+  return exp(-0.013 * pow(distance, 1.4)); // more natural feeling
 }
 
-float C3DAudioStream::CalculateSpeed()
-{
-    float masterSpeed;
-    switch (type)
-    {
-        case SoundEffect: masterSpeed = CSoundSystem::masterSpeed; break;
-        case Music: masterSpeed = CSoundSystem::masterSpeed; break;
-        case UserInterface: masterSpeed = 1.0f; break;
-        default: masterSpeed = 1.0f;
-    }
-
-    return masterSpeed * speed.value();
+float C3DAudioStream::CalculateDirectionDecay(const CVector &listenerDir,
+                                              const CVector &relativePos) {
+  float factor = dot(listenerDir, relativePos);
+  factor = 0.6f + 0.4f * factor; // 0.2 to 1.0
+  return factor;
 }
 
-double C3DAudioStream::CalculateDistanceDecay(float radius, float distance)
-{
-    distance = std::max<float>(distance - radius, 0.0f);
+void C3DAudioStream::UpdatePosition() {
+  auto prevPos = position;
 
-    // exact match to ingame sounds
-    /*float factor = 1.0f / powf(1.0f + distance, 2); // inverse square
-    factor -= 0.00006f;
-    factor = std::clamp(factor, 0.0f, 1.0f);*/
+  if (host != nullptr) {
+    if (hostType == ENTITY_TYPE_NOTHING)
+      return;
 
-    return exp(-0.013 * pow(distance, 1.4)); // more natural feeling
-}
+    // host despawned?
+    bool hostValid = false;
+    switch (hostType) {
+    case ENTITY_TYPE_OBJECT:
+      hostValid = CPools::ms_pObjectPool->IsObjectValid((CObject *)host);
+      break;
 
-float C3DAudioStream::CalculateDirectionDecay(const CVector& listenerDir, const CVector& relativePos)
-{
-    float factor = dot(listenerDir, relativePos);
-    factor = 0.6f + 0.4f * factor; // 0.2 to 1.0
-    return factor;
-}
+    case ENTITY_TYPE_PED:
+      hostValid = CPools::ms_pPedPool->IsObjectValid((CPed *)host);
+      break;
 
-void C3DAudioStream::UpdatePosition()
-{
-    auto prevPos = position;
-
-    if (host != nullptr)
-    {
-        if (hostType == ENTITY_TYPE_NOTHING) return;
-
-        // host despawned?
-        bool hostValid = false;
-        switch (hostType)
-        {
-            case ENTITY_TYPE_OBJECT:
-                hostValid = CPools::ms_pObjectPool->IsObjectValid((CObject*)host);
-                break;
-
-            case ENTITY_TYPE_PED:
-                hostValid = CPools::ms_pPedPool->IsObjectValid((CPed*)host);
-                break;
-
-            case ENTITY_TYPE_VEHICLE:
-                hostValid = CPools::ms_pVehiclePool->IsObjectValid((CVehicle*)host);
-                break;
-        }
-        if (!hostValid)
-        {
-            hostType = ENTITY_TYPE_NOTHING;
-            placed = false;
-            Stop();
-            return;
-        }
-
-        RwV3dTransformPoint((RwV3d*)&position, (RwV3d*)&offset, (RwMatrix*)host->GetMatrix());
+    case ENTITY_TYPE_VEHICLE:
+      hostValid = CPools::ms_pVehiclePool->IsObjectValid((CVehicle *)host);
+      break;
     }
-    else // world offset
-    {
-        position = offset;
+    if (!hostValid) {
+      hostType = ENTITY_TYPE_NOTHING;
+      placed = false;
+      Stop();
+      return;
     }
 
-    if (prevPos.Magnitude() > 0.0f) // not equal to 0,0,0
-    {
-        velocity = position - prevPos;
-        velocity /= CSoundSystem::timeStep;
-        placed = true;
-    }
-    else
-    {
-        placed = false;
-    }
+    RwV3dTransformPoint((RwV3d *)&position, (RwV3d *)&offset,
+                        (RwMatrix *)host->GetMatrix());
+  } else // world offset
+  {
+    position = offset;
+  }
+
+  if (prevPos.Magnitude() > 0.0f) // not equal to 0,0,0
+  {
+    velocity = position - prevPos;
+    velocity /= CSoundSystem::timeStep;
+    placed = true;
+  } else {
+    placed = false;
+  }
 }

--- a/cleo_plugins/Audio/C3DAudioStream.h
+++ b/cleo_plugins/Audio/C3DAudioStream.h
@@ -1,38 +1,36 @@
 #pragma once
 #include "CAudioStream.h"
 
-namespace CLEO
-{
-    class C3DAudioStream : public CAudioStream
-    {
-    public:
-        C3DAudioStream(const char* filepath);
+namespace CLEO {
+class C3DAudioStream : public CAudioStream {
+public:
+  C3DAudioStream(const char *filepath);
 
-        // overloaded actions
-        virtual bool Is3d() const { return true; }
-        virtual void Set3dPosition(const CVector& pos);
-        virtual void Set3dSourceSize(float radius);
-        virtual void SetHost(CEntity* host, const CVector& offset);
-        virtual void Process();
-        virtual float CalculateVolume();
-        virtual float CalculateSpeed();
+  // overloaded actions
+  virtual bool Is3d() const { return true; }
+  virtual void Set3dPosition(const CVector &pos);
+  virtual void Set3dSourceSize(float radius);
+  virtual void SetHost(CEntity *host, const CVector &offset);
+  virtual void Process();
+  virtual float CalculateVolume();
+  virtual float CalculateSpeed();
 
-    protected:
-        const float Volume_3D_Adjust = 0.5f; // match other ingame sound sources
-        static double CalculateDistanceDecay(float radius, float distance);
-        static float CalculateDirectionDecay(const CVector& listenerDir, const CVector& relativePos);
+protected:
+  const float Volume_3D_Adjust = 0.5f; // match other ingame sound sources
+  static double CalculateDistanceDecay(float radius, float distance);
+  static float CalculateDirectionDecay(const CVector &listenerDir,
+                                       const CVector &relativePos);
 
-        CEntity* host = nullptr;
-        eEntityType hostType = ENTITY_TYPE_NOTHING;
-        CVector offset = { 0.0f, 0.0f, 0.0f }; // offset in relation to host
-        float radius = 0.5f; // size of sound source
+  CEntity *host = nullptr;
+  eEntityType hostType = ENTITY_TYPE_NOTHING;
+  CVector offset = {0.0f, 0.0f, 0.0f}; // offset in relation to host
+  float radius = 0.5f;                 // size of sound source
 
-        bool placed = false;
-        CVector position = { 0.0f, 0.0f, 0.0f }; // last world position
-        CVector velocity = { 0.0f, 0.0f, 0.0f };
+  bool placed = false;
+  CVector position = {0.0f, 0.0f, 0.0f}; // last world position
+  CVector velocity = {0.0f, 0.0f, 0.0f};
 
-        C3DAudioStream(const C3DAudioStream&) = delete; // no copying!
-        void UpdatePosition();
-    };
-}
-
+  C3DAudioStream(const C3DAudioStream &) = delete; // no copying!
+  void UpdatePosition();
+};
+} // namespace CLEO

--- a/cleo_plugins/Audio/CAudioStream.cpp
+++ b/cleo_plugins/Audio/CAudioStream.cpp
@@ -1,261 +1,243 @@
 #include "CAudioStream.h"
-#include "CSoundSystem.h"
 #include "CLEO_Utils.h"
+#include "CSoundSystem.h"
 #include <CAEAudioHardware.h>
 #include <CCamera.h>
 
 using namespace CLEO;
 
-CAudioStream::CAudioStream(const char* filepath)
-{
-    // see https://github.com/cleolibrary/CLEO5/pull/230
-    static_assert(offsetof(CAudioStream, streamInternal) == 4 && alignof(CAudioStream) == 4, "CAudioStream compatibility with CLEO4 broken!");
+CAudioStream::CAudioStream(const char *filepath) {
+  // see https://github.com/cleolibrary/CLEO5/pull/230
+  static_assert(offsetof(CAudioStream, streamInternal) == 4 &&
+                    alignof(CAudioStream) == 4,
+                "CAudioStream compatibility with CLEO4 broken!");
 
-    if (isNetworkSource(filepath) && !CSoundSystem::allowNetworkSources)
-    {
-        TRACE("Loading of audiostream '%s' failed. Support of network sources was disabled in SA.Audio.ini", filepath);
-        return;
-    }
+  if (isNetworkSource(filepath) && !CSoundSystem::allowNetworkSources) {
+    TRACE("Loading of audiostream '%s' failed. Support of network sources was "
+          "disabled in SA.Audio.ini",
+          filepath);
+    return;
+  }
 
-    unsigned flags = BASS_SAMPLE_SOFTWARE | BASS_STREAM_PRESCAN;
-    if (CSoundSystem::useFloatAudio) flags |= BASS_SAMPLE_FLOAT;
+  unsigned flags = BASS_SAMPLE_SOFTWARE | BASS_STREAM_PRESCAN;
+  if (CSoundSystem::useFloatAudio)
+    flags |= BASS_SAMPLE_FLOAT;
 
-    if (!(streamInternal = BASS_StreamCreateFile(FALSE, filepath, 0, 0, flags)) &&
-        !(streamInternal = BASS_StreamCreateURL(filepath, 0, flags, 0, nullptr)))
-    {
-        LOG_WARNING(0, "Loading of audiostream '%s' failed. Error code: %d", filepath, BASS_ErrorGetCode());
-        return;
-    }
+  if (!(streamInternal = BASS_StreamCreateFile(FALSE, filepath, 0, 0, flags)) &&
+      !(streamInternal =
+            BASS_StreamCreateURL(filepath, 0, flags, 0, nullptr))) {
+    LOG_WARNING(0, "Loading of audiostream '%s' failed. Error code: %d",
+                filepath, BASS_ErrorGetCode());
+    return;
+  }
 
-    BASS_ChannelGetAttribute(streamInternal, BASS_ATTRIB_FREQ, &rate);
-    ok = true;
+  BASS_ChannelGetAttribute(streamInternal, BASS_ATTRIB_FREQ, &rate);
+  ok = true;
 }
 
-CAudioStream::~CAudioStream()
-{
-    if (streamInternal) BASS_StreamFree(streamInternal);
+CAudioStream::~CAudioStream() {
+  if (streamInternal)
+    BASS_StreamFree(streamInternal);
 }
 
-void CAudioStream::Play()
-{
-    if (state == Stopped) BASS_ChannelSetPosition(streamInternal, 0, BASS_POS_BYTE); // rewind
-    state = PlayingInactive; // needs to be processed
+void CAudioStream::Play() {
+  if (state == Stopped)
+    BASS_ChannelSetPosition(streamInternal, 0, BASS_POS_BYTE); // rewind
+  state = PlayingInactive; // needs to be processed
 }
 
-void CAudioStream::Pause(bool changeState)
-{
-    if (GetState() == Playing)
-    {
-        BASS_ChannelPause(streamInternal);
-        state = changeState ? Paused : PlayingInactive;
-    }
-}
-
-void CAudioStream::Stop()
-{
+void CAudioStream::Pause(bool changeState) {
+  if (GetState() == Playing) {
     BASS_ChannelPause(streamInternal);
-    state = Stopped;
-
-    // cancel ongoing transitions
-    speed.finish();
-    volume.finish();
+    state = changeState ? Paused : PlayingInactive;
+  }
 }
 
-void CAudioStream::Resume()
-{
-    Play();
+void CAudioStream::Stop() {
+  BASS_ChannelPause(streamInternal);
+  state = Stopped;
+
+  // cancel ongoing transitions
+  speed.finish();
+  volume.finish();
 }
 
-float CAudioStream::GetLength() const
-{
-    return (float)BASS_ChannelBytes2Seconds(streamInternal, BASS_ChannelGetLength(streamInternal, BASS_POS_BYTE));
+void CAudioStream::Resume() { Play(); }
+
+float CAudioStream::GetLength() const {
+  return (float)BASS_ChannelBytes2Seconds(
+      streamInternal, BASS_ChannelGetLength(streamInternal, BASS_POS_BYTE));
 }
 
-void CAudioStream::SetProgress(float value)
-{
-    if (GetState() == Stopped)
-    {
-        state = Paused; // resume from set progress
+void CAudioStream::SetProgress(float value) {
+  if (GetState() == Stopped) {
+    state = Paused; // resume from set progress
+  }
+
+  value = std::clamp(value, 0.0f, 1.0f);
+  auto bytePos = BASS_ChannelSeconds2Bytes(streamInternal, GetLength() * value);
+
+  BASS_ChannelSetPosition(streamInternal, bytePos, BASS_POS_BYTE);
+}
+
+float CAudioStream::GetProgress() const {
+  auto bytePos = BASS_ChannelGetPosition(streamInternal, BASS_POS_BYTE);
+  if (bytePos == -1)
+    bytePos = 0; // error or not available yet
+  auto pos = BASS_ChannelBytes2Seconds(streamInternal, bytePos);
+
+  auto byteTotal = BASS_ChannelGetLength(streamInternal, BASS_POS_BYTE);
+  auto total = BASS_ChannelBytes2Seconds(streamInternal, byteTotal);
+
+  return (float)(pos / total);
+}
+
+CAudioStream::StreamState CAudioStream::GetState() const {
+  return (state == PlayingInactive) ? Playing : state;
+}
+
+void CAudioStream::SetLooping(bool enable) {
+  BASS_ChannelFlags(streamInternal, enable ? BASS_SAMPLE_LOOP : 0,
+                    BASS_SAMPLE_LOOP);
+}
+
+bool CLEO::CAudioStream::GetLooping() const {
+  return (BASS_ChannelFlags(streamInternal, 0, 0) & BASS_SAMPLE_LOOP) != 0;
+}
+
+void CAudioStream::SetVolume(float value, float transitionTime) {
+  volume.setValue(std::max(value, 0.0f), transitionTime);
+}
+
+float CAudioStream::GetVolume() const { return volume.value(); }
+
+void CAudioStream::SetSpeed(float value, float transitionTime) {
+  if (value > 0.0f && transitionTime > 0.0f)
+    Resume();
+  speed.setValue(std::max(value, 0.0f), transitionTime);
+}
+
+float CAudioStream::GetSpeed() const { return speed.value(); }
+
+void CLEO::CAudioStream::SetType(eStreamType value) {
+  switch (value) {
+  case eStreamType::SoundEffect:
+  case eStreamType::Music:
+  case eStreamType::UserInterface:
+    type = value;
+    break;
+
+  default:
+    type = None;
+  }
+}
+
+eStreamType CLEO::CAudioStream::GetType() const { return type; }
+
+float CAudioStream::CalculateVolume() {
+  float vol = 1.0f;
+
+  switch (type) {
+  case SoundEffect:
+    vol *= CSoundSystem::masterVolumeSfx;
+    break;
+  case Music:
+    vol *= CSoundSystem::masterVolumeMusic;
+    break;
+  case UserInterface:
+    vol *= CSoundSystem::masterVolumeSfx;
+    break;
+  }
+
+  // screen black fade
+  switch (type) {
+  case SoundEffect:
+    vol *= AEAudioHardware.m_fEffectsFaderScalingFactor;
+    break;
+  case Music:
+    vol *= AEAudioHardware.m_fMusicFaderScalingFactor;
+    break;
+  }
+
+  // music volume lowering in cutscenes, when characters talk, mission sounds
+  // are played etc.
+  if (type == Music) {
+    if (TheCamera.m_bWideScreenOn)
+      vol *= 0.25f;
+  }
+
+  // stream's volume
+  vol *= volume.value();
+
+  return vol;
+}
+
+float CAudioStream::CalculateSpeed() {
+  float masterSpeed;
+  switch (type) {
+  case SoundEffect:
+    masterSpeed = CSoundSystem::masterSpeed;
+    break;
+  case Music:
+    masterSpeed = TheCamera.m_bWideScreenOn ? 1.0f : CSoundSystem::masterSpeed;
+    break;
+  case UserInterface:
+    masterSpeed = 1.0f;
+    break;
+  default:
+    masterSpeed = 1.0f;
+  }
+
+  return speed.value() * masterSpeed;
+}
+
+bool CAudioStream::IsOk() const { return ok; }
+
+HSTREAM CAudioStream::GetInternal() { return streamInternal; }
+
+void CAudioStream::Process() {
+  if (state == PlayingInactive) {
+    if (BASS_ChannelPlay(streamInternal, FALSE)) {
+      state = Playing;
     }
-
-    value = std::clamp(value, 0.0f, 1.0f);
-    auto bytePos = BASS_ChannelSeconds2Bytes(streamInternal, GetLength() * value);
-
-    BASS_ChannelSetPosition(streamInternal, bytePos, BASS_POS_BYTE);
-}
-
-float CAudioStream::GetProgress() const
-{
-    auto bytePos = BASS_ChannelGetPosition(streamInternal, BASS_POS_BYTE);
-    if (bytePos == -1) bytePos = 0; // error or not available yet
-    auto pos = BASS_ChannelBytes2Seconds(streamInternal, bytePos);
-
-    auto byteTotal = BASS_ChannelGetLength(streamInternal, BASS_POS_BYTE);
-    auto total = BASS_ChannelBytes2Seconds(streamInternal, byteTotal);
-
-    return (float)(pos / total);
-}
-
-CAudioStream::StreamState CAudioStream::GetState() const
-{
-    return (state == PlayingInactive) ? Playing : state;
-}
-
-void CAudioStream::SetLooping(bool enable)
-{
-    BASS_ChannelFlags(streamInternal, enable ? BASS_SAMPLE_LOOP : 0, BASS_SAMPLE_LOOP);
-}
-
-bool CLEO::CAudioStream::GetLooping() const
-{
-    return (BASS_ChannelFlags(streamInternal, 0, 0) & BASS_SAMPLE_LOOP) != 0;
-}
-
-void CAudioStream::SetVolume(float value, float transitionTime)
-{
-    volume.setValue(std::max(value, 0.0f), transitionTime);
-}
-
-float CAudioStream::GetVolume() const
-{
-    return volume.value();
-}
-
-void CAudioStream::SetSpeed(float value, float transitionTime)
-{
-    if (value > 0.0f && transitionTime > 0.0f) Resume();
-    speed.setValue(std::max(value, 0.0f), transitionTime);
-}
-
-float CAudioStream::GetSpeed() const
-{
-    return speed.value();
-}
-
-void CLEO::CAudioStream::SetType(eStreamType value)
-{
-    switch(value)
+  } else {
+    if (state == Playing && BASS_ChannelIsActive(streamInternal) ==
+                                BASS_ACTIVE_STOPPED) // end reached
     {
-        case eStreamType::SoundEffect:
-        case eStreamType::Music:
-        case eStreamType::UserInterface:
-            type = value;
-            break;
-
-        default:
-            type = None;
+      state = Stopped;
     }
+  }
+
+  float prevSpeed = speed.value();
+
+  // update animated params
+  speed.update(CSoundSystem::timeStep);
+  volume.update(CSoundSystem::timeStep);
+
+  // transitioning speed to 0 pauses playback
+  if (prevSpeed > 0.0f && speed.value() <= 0.0f) {
+    Pause();
+  }
+
+  if (state != Playing)
+    return; // done
+
+  float volume = CalculateVolume();
+  BASS_ChannelSetAttribute(streamInternal, BASS_ATTRIB_VOL, volume);
+
+  float freq = rate * CalculateSpeed();
+  freq = std::max(freq, 0.000001f); // 0 results in original speed
+  BASS_ChannelSetAttribute(streamInternal, BASS_ATTRIB_FREQ, freq);
 }
 
-eStreamType CLEO::CAudioStream::GetType() const
-{
-    return type;
+void CAudioStream::Set3dPosition(const CVector &pos) {
+  // not applicable for 2d audio
 }
 
-float CAudioStream::CalculateVolume()
-{
-    float vol = 1.0f;
-
-    switch(type)
-    {
-        case SoundEffect: vol *= CSoundSystem::masterVolumeSfx; break;
-        case Music: vol *= CSoundSystem::masterVolumeMusic; break;
-        case UserInterface: vol *= CSoundSystem::masterVolumeSfx; break;
-    }
-
-    // screen black fade
-    switch (type)
-    {
-        case SoundEffect: vol *= AEAudioHardware.m_fEffectsFaderScalingFactor; break;
-        case Music: vol *= AEAudioHardware.m_fMusicFaderScalingFactor; break;
-    }
-
-    // music volume lowering in cutscenes, when characters talk, mission sounds are played etc.
-    if (type == Music)
-    {
-        if (TheCamera.m_bWideScreenOn) vol *= 0.25f;
-    }
-
-    // stream's volume
-    vol *= volume.value();
-
-    return vol;
+void CAudioStream::Set3dSourceSize(float radius) {
+  // not applicable for 2d audio
 }
 
-float CAudioStream::CalculateSpeed()
-{
-    float masterSpeed;
-    switch (type)
-    {
-        case SoundEffect: masterSpeed = CSoundSystem::masterSpeed; break;
-        case Music: masterSpeed = TheCamera.m_bWideScreenOn ? 1.0f : CSoundSystem::masterSpeed; break;
-        case UserInterface: masterSpeed = 1.0f; break;
-        default: masterSpeed = 1.0f;
-    }
-
-    return speed.value() * masterSpeed;
-}
-
-bool CAudioStream::IsOk() const
-{
-    return ok;
-}
-
-HSTREAM CAudioStream::GetInternal()
-{
-    return streamInternal;
-}
-
-void CAudioStream::Process()
-{
-    if (state == PlayingInactive)
-    {
-        if (BASS_ChannelPlay(streamInternal, FALSE))
-        {
-            state = Playing;
-        }
-    }
-    else
-    {
-        if (state == Playing && BASS_ChannelIsActive(streamInternal) == BASS_ACTIVE_STOPPED) // end reached
-        {
-            state = Stopped;
-        }
-    }
-
-    float prevSpeed = speed.value();
-
-    // update animated params
-    speed.update(CSoundSystem::timeStep);
-    volume.update(CSoundSystem::timeStep);
-
-    // transitioning speed to 0 pauses playback
-    if (prevSpeed > 0.0f && speed.value() <= 0.0f)
-    {
-        Pause();
-    }
-
-    if (state != Playing) return; // done
-
-    float volume = CalculateVolume();
-    BASS_ChannelSetAttribute(streamInternal, BASS_ATTRIB_VOL, volume);
-
-    float freq = rate * CalculateSpeed();
-    freq = std::max(freq, 0.000001f); // 0 results in original speed
-    BASS_ChannelSetAttribute(streamInternal, BASS_ATTRIB_FREQ, freq);
-}
-
-void CAudioStream::Set3dPosition(const CVector& pos)
-{
-    // not applicable for 2d audio
-}
-
-void CAudioStream::Set3dSourceSize(float radius)
-{
-    // not applicable for 2d audio
-}
-
-void CAudioStream::SetHost(CEntity* placable, const CVector& offset)
-{
-    // not applicable for 2d audio
+void CAudioStream::SetHost(CEntity *placable, const CVector &offset) {
+  // not applicable for 2d audio
 }

--- a/cleo_plugins/Audio/CAudioStream.h
+++ b/cleo_plugins/Audio/CAudioStream.h
@@ -1,73 +1,71 @@
 #pragma once
-#include "CSoundSystem.h"
 #include "CInterpolatedValue.h"
-#include "plugin.h"
+#include "CSoundSystem.h"
 #include "bass.h"
+#include "plugin.h"
 
-namespace CLEO
-{
-#pragma pack(push,4)
-    class CAudioStream
-    {
-    public:
-        enum StreamState
-        {
-            Stopped = -1,
-            PlayingInactive, // internal: playing, but not processed yet or the sound system is silenced right now
-            Playing,
-            Paused,
-        };
+namespace CLEO {
+#pragma pack(push, 4)
+class CAudioStream {
+public:
+  enum StreamState {
+    Stopped = -1,
+    PlayingInactive, // internal: playing, but not processed yet or the sound
+                     // system is silenced right now
+    Playing,
+    Paused,
+  };
 
-        CAudioStream(const char* filepath); // filesystem or URL
-        virtual ~CAudioStream();
+  CAudioStream(const char *filepath); // filesystem or URL
+  virtual ~CAudioStream();
 
-        bool IsOk() const;
-        HSTREAM GetInternal(); // get BASS stream
+  bool IsOk() const;
+  HSTREAM GetInternal(); // get BASS stream
 
-        StreamState GetState() const;
-        void Play();
-        void Pause(bool changeState = true);
-        void Stop();
-        void Resume();
+  StreamState GetState() const;
+  void Play();
+  void Pause(bool changeState = true);
+  void Stop();
+  void Resume();
 
-        void SetLooping(bool enable);
-        bool GetLooping() const;
+  void SetLooping(bool enable);
+  bool GetLooping() const;
 
-        float GetLength() const;
+  float GetLength() const;
 
-        void SetProgress(float value);
-        float GetProgress() const;
+  void SetProgress(float value);
+  float GetProgress() const;
 
-        void SetSpeed(float value, float transitionTime = 0.0f);
-        float GetSpeed() const;
+  void SetSpeed(float value, float transitionTime = 0.0f);
+  float GetSpeed() const;
 
-        void SetType(eStreamType value);
-        eStreamType GetType() const;
+  void SetType(eStreamType value);
+  eStreamType GetType() const;
 
-        void SetVolume(float value, float transitionTime = 0.0f);
-        float GetVolume() const;
+  void SetVolume(float value, float transitionTime = 0.0f);
+  float GetVolume() const;
 
-        // 3d
-        virtual bool Is3d() const { return false; }
-        virtual void Set3dPosition(const CVector& pos);
-        virtual void Set3dSourceSize(float radius);
-        virtual void SetHost(CEntity* placable, const CVector& offset);
+  // 3d
+  virtual bool Is3d() const { return false; }
+  virtual void Set3dPosition(const CVector &pos);
+  virtual void Set3dSourceSize(float radius);
+  virtual void SetHost(CEntity *placable, const CVector &offset);
 
-        virtual void Process();
-        virtual float CalculateVolume();
-        virtual float CalculateSpeed();
+  virtual void Process();
+  virtual float CalculateVolume();
+  virtual float CalculateSpeed();
 
-    protected:
-        HSTREAM streamInternal = 0;
-        StreamState state = Paused;
-        eStreamType type = eStreamType::SoundEffect;
-        bool ok = false;
-        float rate = 44100.0f; // file's sampling rate
-        CInterpolatedValue speed = { 1.0f };
-        CInterpolatedValue volume = { 1.0f };
+protected:
+  HSTREAM streamInternal = 0;
+  StreamState state = Paused;
+  eStreamType type = eStreamType::SoundEffect;
+  bool ok = false;
+  float rate = 44100.0f; // file's sampling rate
+  CInterpolatedValue speed = {1.0f};
+  CInterpolatedValue volume = {1.0f};
 
-        CAudioStream() = default;
-        CAudioStream(const CAudioStream&) = delete; // no copying!
-    };
+  CAudioStream() = default;
+  CAudioStream(const CAudioStream &) = delete; // no copying!
+};
 #pragma pack(pop)
-}
+} // namespace CLEO

--- a/cleo_plugins/Audio/CInterpolatedValue.h
+++ b/cleo_plugins/Audio/CInterpolatedValue.h
@@ -1,55 +1,46 @@
 #pragma once
 
-class CInterpolatedValue
-{
+class CInterpolatedValue {
 public:
-    CInterpolatedValue(float value)
-    {
-        currValue = value;
-        targetValue = value;
-        step = 0.0f;
+  CInterpolatedValue(float value) {
+    currValue = value;
+    targetValue = value;
+    step = 0.0f;
+  }
+
+  float value() const { return currValue; }
+
+  void setValue(float target, float transitionTime) {
+    targetValue = target;
+
+    if (transitionTime <= 0.0f) {
+      currValue = target;
+      return;
     }
 
-    float value() const { return currValue; }
+    step = (targetValue - currValue) / transitionTime;
+  }
 
-    void setValue(float target, float transitionTime)
-    {
-        targetValue = target;
-
-        if (transitionTime <= 0.0f)
-        {
-            currValue = target;
-            return;
-        }
-
-        step = (targetValue - currValue) / transitionTime;
+  void update(float elapsedTime) {
+    if (currValue == targetValue) {
+      return; // done
     }
 
-    void update(float elapsedTime)
+    currValue += step * elapsedTime;
+
+    // check progress
+    auto remaining = targetValue - currValue;
+    remaining *= (step > 0.0f) ? 1.0f : -1.0f;
+    if (remaining <= 0.0f) // overshoot
     {
-        if (currValue == targetValue)
-        {
-            return; // done
-        }
-
-        currValue += step * elapsedTime;
-
-        // check progress
-        auto remaining = targetValue - currValue;
-        remaining *= (step > 0.0f) ? 1.0f : -1.0f;
-        if (remaining <= 0.0f) // overshoot
-        {
-            currValue = targetValue;
-        }
+      currValue = targetValue;
     }
+  }
 
-    void finish()
-    {
-        currValue = targetValue;
-    }
+  void finish() { currValue = targetValue; }
 
 private:
-    float currValue = 0.0f;
-    float targetValue = 0.0f;
-    float step = 0.0f;
+  float currValue = 0.0f;
+  float targetValue = 0.0f;
+  float step = 0.0f;
 };

--- a/cleo_plugins/Audio/CSoundSystem.cpp
+++ b/cleo_plugins/Audio/CSoundSystem.cpp
@@ -1,248 +1,237 @@
 #include "CSoundSystem.h"
-#include "CAudioStream.h"
 #include "C3dAudioStream.h"
-#include "CLEO_Utils.h"
 #include "CAEAudioHardware.h"
+#include "CAudioStream.h"
 #include "CCamera.h"
+#include "CLEO_Utils.h"
 #include "CPad.h"
 #include "CVector.h"
 
-namespace CLEO
-{
-    bool CSoundSystem::useFloatAudio = false;
-    bool CSoundSystem::allowNetworkSources = true;
-    eStreamType CSoundSystem::LegacyModeDefaultStreamType = eStreamType::None;
-    CVector CSoundSystem::position(0.0f, 0.0f, 0.0f);
-    CVector CSoundSystem::direction(0.0f, 1.0f, 0.0f);
-    CVector CSoundSystem::velocity(0.0f, 0.0f, 0.0f);
-    bool CSoundSystem::skipFrame = true;
-    float CSoundSystem::timeStep = 0.02f;
-    float CSoundSystem::masterSpeed = 1.0f;
-    float CSoundSystem::masterVolumeSfx = 1.0f;
-    float CSoundSystem::masterVolumeMusic = 1.0f;
+namespace CLEO {
+bool CSoundSystem::useFloatAudio = false;
+bool CSoundSystem::allowNetworkSources = true;
+eStreamType CSoundSystem::LegacyModeDefaultStreamType = eStreamType::None;
+CVector CSoundSystem::position(0.0f, 0.0f, 0.0f);
+CVector CSoundSystem::direction(0.0f, 1.0f, 0.0f);
+CVector CSoundSystem::velocity(0.0f, 0.0f, 0.0f);
+bool CSoundSystem::skipFrame = true;
+float CSoundSystem::timeStep = 0.02f;
+float CSoundSystem::masterSpeed = 1.0f;
+float CSoundSystem::masterVolumeSfx = 1.0f;
+float CSoundSystem::masterVolumeMusic = 1.0f;
 
-    void EnumerateBassDevices(int& total, int& enabled, int& default_device)
-    {
-        TRACE("Listing audio devices:");
+void EnumerateBassDevices(int &total, int &enabled, int &default_device) {
+  TRACE("Listing audio devices:");
 
-        BASS_DEVICEINFO info;
-        enabled = 0;
-        default_device = -1;
-        for (total = 0; BASS_GetDeviceInfo(total, &info); ++total)
-        {
-            if (info.flags & BASS_DEVICE_DEFAULT) default_device = total;
+  BASS_DEVICEINFO info;
+  enabled = 0;
+  default_device = -1;
+  for (total = 0; BASS_GetDeviceInfo(total, &info); ++total) {
+    if (info.flags & BASS_DEVICE_DEFAULT)
+      default_device = total;
 
-            bool isEnabled = info.flags & BASS_DEVICE_ENABLED;
-            if (isEnabled) ++enabled;
+    bool isEnabled = info.flags & BASS_DEVICE_ENABLED;
+    if (isEnabled)
+      ++enabled;
 
-            TRACE(" %d: %s%s", total, info.name, isEnabled ? "" : " (disabled)");
-        }
-        TRACE(" Default device index: %d", default_device);
-    }
-
-    CSoundSystem::~CSoundSystem()
-    {
-        TRACE(""); // seaprator
-        TRACE("Finalizing SoundSystem...");
-        Clear();
-
-        if (initialized)
-        {
-            //TRACE("Freeing BASS library");
-            //std::thread(BASS_Free); // causes deadlock with ModLoader
-            initialized = false;
-        }
-        TRACE("SoundSystem finalized");
-    }
-
-    bool CSoundSystem::Init()
-    {
-        if (initialized) return true; // already done
-
-        TRACE(""); // separator
-        TRACE("Initializing SoundSystem...");
-
-        auto ver = HIWORD(BASS_GetVersion());
-        TRACE("BASS library version is %d (required %d or newer)", ver, BASSVERSION);
-        if (ver < BASSVERSION)
-        {
-            SHOW_ERROR("Invalid BASS library version! Expected at least %d, found %d.", BASSVERSION, ver);
-        }
-
-        auto config = GetConfigFilename();
-        LegacyModeDefaultStreamType = (eStreamType)GetPrivateProfileInt("General", "LegacyModeDefaultStreamType", 0, config.c_str());
-        allowNetworkSources = GetPrivateProfileInt("General", "AllowNetworkSources", 1, config.c_str()) != 0;
-
-        int deviceIndex, total_devices, enabled_devices;
-        EnumerateBassDevices(total_devices, enabled_devices, deviceIndex);
-
-        BASS_DEVICEINFO info = { "Unknown device", nullptr, 0 };
-        BASS_GetDeviceInfo(deviceIndex, &info);
-
-        int forceIndex = GetPrivateProfileInt("General", "AudioDevice", -1, config.c_str());
-        if (forceIndex != -1)
-        {
-            BASS_DEVICEINFO forceInfo = { "Unknown device", nullptr, 0 };
-            if (BASS_GetDeviceInfo(forceIndex, &forceInfo) && forceInfo.flags & BASS_DEVICE_ENABLED)
-            {
-                TRACE("Force selecting audio device #%d: %s", forceIndex, forceInfo.name);
-                deviceIndex = forceIndex;
-            }
-            else
-            {
-                LOG_WARNING(0, "Failed to force select device #%d! Selecting default audio device #%d: %s", forceIndex, deviceIndex, info.name);
-            }
-        }
-        else
-        {
-            TRACE("Selecting default audio device #%d: %s", deviceIndex, info.name);
-        }
-
-        BASS_SetConfig(BASS_CONFIG_FLOATDSP, TRUE);
-
-        if (BASS_Init(deviceIndex, 44100, BASS_DEVICE_3D, RsGlobal.ps->window, nullptr) &&
-            BASS_Set3DFactors(1.0f, 0.0f, 1.0f))
-        {
-            TRACE("SoundSystem initialized");
-
-            // Can we use floating-point (HQ) audio streams?
-            DWORD floatable = BASS_StreamCreate(44100, 1, BASS_SAMPLE_FLOAT, NULL, NULL); // floating-point channel support? 0 = no, else yes
-            if (floatable)
-            {
-                TRACE("Floating-point audio supported!");
-                useFloatAudio = true;
-                BASS_StreamFree(floatable);
-            }
-            else TRACE("Floating-point audio not supported!");
-
-            if (BASS_GetInfo(&SoundDevice))
-            {
-                if (SoundDevice.flags & DSCAPS_EMULDRIVER)
-                    TRACE("Audio drivers not installed - using DirectSound emulation");
-                if (!SoundDevice.eax)
-                    TRACE("Audio hardware acceleration disabled (no EAX)");
-            }
-
-            initialized = true;
-            return true;
-        }
-
-        LOG_WARNING(0, "Could not initialize BASS sound system. Error code: %d", BASS_ErrorGetCode());
-        return false;
-    }
-
-    bool CSoundSystem::Initialized()
-    {
-        return initialized;
-    }
-
-    CAudioStream* CSoundSystem::CreateStream(const char *filename, bool in3d)
-    {
-        CAudioStream* result = in3d ? new C3DAudioStream(filename) : new CAudioStream(filename);
-        if (!result->IsOk())
-        {
-            delete result;
-            return nullptr;
-        }
-
-        streams.insert(result);
-        return result;
-    }
-
-    void CSoundSystem::DestroyStream(CAudioStream *stream)
-    {
-        if (streams.erase(stream))
-            delete stream;
-        else
-            TRACE("Unloading of stream that is not in list of loaded streams");
-    }
-
-    bool CSoundSystem::HasStream(CAudioStream* stream)
-    {
-        return streams.find(stream) != streams.end();
-    }
-
-    void CSoundSystem::Clear()
-    {
-        for (auto stream : streams)
-        {
-            delete stream;
-        };
-        streams.clear();
-    }
-
-    void CSoundSystem::Resume()
-    {
-        paused = false;
-        for (auto stream : streams)
-        {
-            if(stream->GetState() == CAudioStream::Playing) stream->Resume();
-        }
-    }
-
-    void CSoundSystem::Pause()
-    {
-        paused = true;
-        for (auto stream : streams)
-        {
-            stream->Pause(false);
-        };
-    }
-
-    void CSoundSystem::Process()
-    {
-        if (CTimer::m_UserPause || CTimer::m_CodePause) // covers menu pausing, no disc in drive pausing, etc.
-        {
-            if (!paused) Pause();
-        }
-        else // not in menu
-        {
-            if (paused) Resume();
-
-            // update globals
-            timeStep = 0.001f * (CTimer::m_snTimeInMillisecondsNonClipped - CTimer::m_snPreviousTimeInMillisecondsNonClipped); // delta in seconds
-            masterSpeed = CTimer::ms_fTimeScale;
-            masterVolumeSfx = AEAudioHardware.m_fEffectMasterScalingFactor * 0.5f; // fit to game's sfx volume
-            masterVolumeMusic = AEAudioHardware.m_fMusicMasterScalingFactor * 0.5f;
-
-            // prevent camera jump-cut glitches
-            int skipFramePrev = skipFrame;
-            skipFrame = TheCamera.m_bJust_Switched || TheCamera.m_bCameraJustRestored || CPad::GetPad(0)->JustOutOfFrontEnd;
-
-            CVector prevPos = position;
-            position = TheCamera.GetPosition();
-            direction = TheCamera.GetForward();
-
-            // new camera velocity
-            if (!skipFrame)
-            {
-                CVector vel = position - prevPos;
-                vel /= timeStep; // meters per second
-
-                if (!skipFramePrev)
-                {
-                    // averaging to smooth artifacts caused by GTA's janky mouse camera control
-                    velocity = (velocity * 2.0f) + vel;
-                    velocity /= 3.0f;
-                }
-                else
-                {
-                    velocity = vel;
-                }
-
-                BASS_Set3DPosition(
-                    &toBass(position),
-                    &toBass(velocity),
-                    &toBass(direction),
-                    &toBass(TheCamera.GetUp())
-                );
-            }
-
-            // process streams
-            for (auto stream : streams) stream->Process();
-
-            // apply changes
-            if (!skipFrame) BASS_Apply3D();
-        }
-    }
+    TRACE(" %d: %s%s", total, info.name, isEnabled ? "" : " (disabled)");
+  }
+  TRACE(" Default device index: %d", default_device);
 }
+
+CSoundSystem::~CSoundSystem() {
+  TRACE(""); // seaprator
+  TRACE("Finalizing SoundSystem...");
+  Clear();
+
+  if (initialized) {
+    // TRACE("Freeing BASS library");
+    // std::thread(BASS_Free); // causes deadlock with ModLoader
+    initialized = false;
+  }
+  TRACE("SoundSystem finalized");
+}
+
+bool CSoundSystem::Init() {
+  if (initialized)
+    return true; // already done
+
+  TRACE(""); // separator
+  TRACE("Initializing SoundSystem...");
+
+  auto ver = HIWORD(BASS_GetVersion());
+  TRACE("BASS library version is %d (required %d or newer)", ver, BASSVERSION);
+  if (ver < BASSVERSION) {
+    SHOW_ERROR("Invalid BASS library version! Expected at least %d, found %d.",
+               BASSVERSION, ver);
+  }
+
+  auto config = GetConfigFilename();
+  LegacyModeDefaultStreamType = (eStreamType)GetPrivateProfileInt(
+      "General", "LegacyModeDefaultStreamType", 0, config.c_str());
+  allowNetworkSources = GetPrivateProfileInt("General", "AllowNetworkSources",
+                                             1, config.c_str()) != 0;
+
+  int deviceIndex, total_devices, enabled_devices;
+  EnumerateBassDevices(total_devices, enabled_devices, deviceIndex);
+
+  BASS_DEVICEINFO info = {"Unknown device", nullptr, 0};
+  BASS_GetDeviceInfo(deviceIndex, &info);
+
+  int forceIndex =
+      GetPrivateProfileInt("General", "AudioDevice", -1, config.c_str());
+  if (forceIndex != -1) {
+    BASS_DEVICEINFO forceInfo = {"Unknown device", nullptr, 0};
+    if (BASS_GetDeviceInfo(forceIndex, &forceInfo) &&
+        forceInfo.flags & BASS_DEVICE_ENABLED) {
+      TRACE("Force selecting audio device #%d: %s", forceIndex, forceInfo.name);
+      deviceIndex = forceIndex;
+    } else {
+      LOG_WARNING(0,
+                  "Failed to force select device #%d! Selecting default audio "
+                  "device #%d: %s",
+                  forceIndex, deviceIndex, info.name);
+    }
+  } else {
+    TRACE("Selecting default audio device #%d: %s", deviceIndex, info.name);
+  }
+
+  BASS_SetConfig(BASS_CONFIG_FLOATDSP, TRUE);
+
+  if (BASS_Init(deviceIndex, 44100, BASS_DEVICE_3D, RsGlobal.ps->window,
+                nullptr) &&
+      BASS_Set3DFactors(1.0f, 0.0f, 1.0f)) {
+    TRACE("SoundSystem initialized");
+
+    // Can we use floating-point (HQ) audio streams?
+    DWORD floatable = BASS_StreamCreate(
+        44100, 1, BASS_SAMPLE_FLOAT, NULL,
+        NULL); // floating-point channel support? 0 = no, else yes
+    if (floatable) {
+      TRACE("Floating-point audio supported!");
+      useFloatAudio = true;
+      BASS_StreamFree(floatable);
+    } else
+      TRACE("Floating-point audio not supported!");
+
+    if (BASS_GetInfo(&SoundDevice)) {
+      if (SoundDevice.flags & DSCAPS_EMULDRIVER)
+        TRACE("Audio drivers not installed - using DirectSound emulation");
+      if (!SoundDevice.eax)
+        TRACE("Audio hardware acceleration disabled (no EAX)");
+    }
+
+    initialized = true;
+    return true;
+  }
+
+  LOG_WARNING(0, "Could not initialize BASS sound system. Error code: %d",
+              BASS_ErrorGetCode());
+  return false;
+}
+
+bool CSoundSystem::Initialized() { return initialized; }
+
+CAudioStream *CSoundSystem::CreateStream(const char *filename, bool in3d) {
+  CAudioStream *result =
+      in3d ? new C3DAudioStream(filename) : new CAudioStream(filename);
+  if (!result->IsOk()) {
+    delete result;
+    return nullptr;
+  }
+
+  streams.insert(result);
+  return result;
+}
+
+void CSoundSystem::DestroyStream(CAudioStream *stream) {
+  if (streams.erase(stream))
+    delete stream;
+  else
+    TRACE("Unloading of stream that is not in list of loaded streams");
+}
+
+bool CSoundSystem::HasStream(CAudioStream *stream) {
+  return streams.find(stream) != streams.end();
+}
+
+void CSoundSystem::Clear() {
+  for (auto stream : streams) {
+    delete stream;
+  };
+  streams.clear();
+}
+
+void CSoundSystem::Resume() {
+  paused = false;
+  for (auto stream : streams) {
+    if (stream->GetState() == CAudioStream::Playing)
+      stream->Resume();
+  }
+}
+
+void CSoundSystem::Pause() {
+  paused = true;
+  for (auto stream : streams) {
+    stream->Pause(false);
+  };
+}
+
+void CSoundSystem::Process() {
+  if (CTimer::m_UserPause || CTimer::m_CodePause) // covers menu pausing, no
+                                                  // disc in drive pausing, etc.
+  {
+    if (!paused)
+      Pause();
+  } else // not in menu
+  {
+    if (paused)
+      Resume();
+
+    // update globals
+    timeStep =
+        0.001f *
+        (CTimer::m_snTimeInMillisecondsNonClipped -
+         CTimer::m_snPreviousTimeInMillisecondsNonClipped); // delta in seconds
+    masterSpeed = CTimer::ms_fTimeScale;
+    masterVolumeSfx = AEAudioHardware.m_fEffectMasterScalingFactor *
+                      0.5f; // fit to game's sfx volume
+    masterVolumeMusic = AEAudioHardware.m_fMusicMasterScalingFactor * 0.5f;
+
+    // prevent camera jump-cut glitches
+    int skipFramePrev = skipFrame;
+    skipFrame = TheCamera.m_bJust_Switched || TheCamera.m_bCameraJustRestored ||
+                CPad::GetPad(0)->JustOutOfFrontEnd;
+
+    CVector prevPos = position;
+    position = TheCamera.GetPosition();
+    direction = TheCamera.GetForward();
+
+    // new camera velocity
+    if (!skipFrame) {
+      CVector vel = position - prevPos;
+      vel /= timeStep; // meters per second
+
+      if (!skipFramePrev) {
+        // averaging to smooth artifacts caused by GTA's janky mouse camera
+        // control
+        velocity = (velocity * 2.0f) + vel;
+        velocity /= 3.0f;
+      } else {
+        velocity = vel;
+      }
+
+      BASS_Set3DPosition(&toBass(position), &toBass(velocity),
+                         &toBass(direction), &toBass(TheCamera.GetUp()));
+    }
+
+    // process streams
+    for (auto stream : streams)
+      stream->Process();
+
+    // apply changes
+    if (!skipFrame)
+      BASS_Apply3D();
+  }
+}
+} // namespace CLEO

--- a/cleo_plugins/Audio/CSoundSystem.h
+++ b/cleo_plugins/Audio/CSoundSystem.h
@@ -1,66 +1,74 @@
 #pragma once
-#include "bass.h"
 #include "CVector.h"
+#include "bass.h"
 #include <set>
 
-namespace CLEO
-{
-    class CAudioStream;
-    class C3DAudioStream;
+namespace CLEO {
+class CAudioStream;
+class C3DAudioStream;
 
-    enum eStreamType
-    {
-        None = 0, // user controlled
-        SoundEffect, // conforms to global SFX volume and in-game speed
-        Music, // conforms to global music volume, muted if game speed is not 1.0
-        UserInterface // conforms to global SFX volume
-    };
+enum eStreamType {
+  None = 0,    // user controlled
+  SoundEffect, // conforms to global SFX volume and in-game speed
+  Music, // conforms to global music volume, muted if game speed is not 1.0
+  UserInterface // conforms to global SFX volume
+};
 
-    class CSoundSystem
-    {
-        friend class CAudioStream;
-        friend class C3DAudioStream;
+class CSoundSystem {
+  friend class CAudioStream;
+  friend class C3DAudioStream;
 
-        std::set<CAudioStream*> streams;
-        BASS_INFO SoundDevice = { 0 };
-        bool initialized = false;
-        bool paused = false;
+  std::set<CAudioStream *> streams;
+  BASS_INFO SoundDevice = {0};
+  bool initialized = false;
+  bool paused = false;
 
-        static bool useFloatAudio;
-        static bool CSoundSystem::allowNetworkSources;
+  static bool useFloatAudio;
+  static bool CSoundSystem::allowNetworkSources;
 
-        static CVector position;
-        static CVector direction;
-        static CVector velocity;
-        static bool skipFrame; // do not apply changes during this frame
-        static float timeStep; // delta time for current frame
-        static float masterSpeed; // game simulation speed
-        static float masterVolumeSfx;
-        static float masterVolumeMusic;
+  static CVector position;
+  static CVector direction;
+  static CVector velocity;
+  static bool skipFrame;    // do not apply changes during this frame
+  static float timeStep;    // delta time for current frame
+  static float masterSpeed; // game simulation speed
+  static float masterVolumeSfx;
+  static float masterVolumeMusic;
 
-    public:
-        static eStreamType LegacyModeDefaultStreamType;
+public:
+  static eStreamType LegacyModeDefaultStreamType;
 
-        CSoundSystem() = default; // TODO: give to user an ability to force a sound device to use (ini-file or cmd-line?)
-        ~CSoundSystem();
+  CSoundSystem() = default; // TODO: give to user an ability to force a sound
+                            // device to use (ini-file or cmd-line?)
+  ~CSoundSystem();
 
-        bool Init();
-        bool Initialized();
+  bool Init();
+  bool Initialized();
 
-        CAudioStream* CreateStream(const char *filename, bool in3d = false);
-        void DestroyStream(CAudioStream *stream);
+  CAudioStream *CreateStream(const char *filename, bool in3d = false);
+  void DestroyStream(CAudioStream *stream);
 
-        bool HasStream(CAudioStream* stream);
-        void Clear(); // destroy all created streams
+  bool HasStream(CAudioStream *stream);
+  void Clear(); // destroy all created streams
 
-        void Pause();
-        void Resume();
-        void Process();
-    };
+  void Pause();
+  void Resume();
+  void Process();
+};
 
-    static bool isNetworkSource(const char* path) { return _strnicmp("http:", path, 5) == 0 || _strnicmp("https:", path, 6) == 0; }
-    static float dot(CVector a, CVector b) { return a.x * b.x + a.y * b.y + a.z * b.z; }
-    static float lerp(float a, float b, float progress) { return a * (1.0f - progress) + b * progress; }
-    static CVector lerp(CVector a, CVector b, float progress) { return a * (1.0f - progress) + b * progress; }
-    static BASS_3DVECTOR toBass(const CVector& v) { return BASS_3DVECTOR(v.x, v.z, v.y); } // convert GTA to BASS coordinate system
+static bool isNetworkSource(const char *path) {
+  return _strnicmp("http:", path, 5) == 0 || _strnicmp("https:", path, 6) == 0;
 }
+static float dot(CVector a, CVector b) {
+  return a.x * b.x + a.y * b.y + a.z * b.z;
+}
+static float lerp(float a, float b, float progress) {
+  return a * (1.0f - progress) + b * progress;
+}
+static CVector lerp(CVector a, CVector b, float progress) {
+  return a * (1.0f - progress) + b * progress;
+}
+static BASS_3DVECTOR toBass(const CVector &v) {
+  return BASS_3DVECTOR(v.x, v.z, v.y);
+} // convert GTA to BASS coordinate system
+} // namespace CLEO

--- a/cleo_plugins/Audio/bass/bass.h
+++ b/cleo_plugins/Audio/bass/bass.h
@@ -1,8 +1,8 @@
 /*
-	BASS 2.4 C/C++ header file
-	Copyright (c) 1999-2024 Un4seen Developments Ltd.
+        BASS 2.4 C/C++ header file
+        Copyright (c) 1999-2024 Un4seen Developments Ltd.
 
-	See the BASS.CHM file for more detailed documentation
+        See the BASS.CHM file for more detailed documentation
 */
 
 #ifndef BASS_H
@@ -33,19 +33,19 @@ typedef int BOOL;
 #define FALSE 0
 #endif
 #define LOBYTE(a) (BYTE)(a)
-#define HIBYTE(a) (BYTE)((a)>>8)
+#define HIBYTE(a) (BYTE)((a) >> 8)
 #define LOWORD(a) (WORD)(a)
-#define HIWORD(a) (WORD)((a)>>16)
-#define MAKEWORD(a,b) (WORD)(((a)&0xff)|((b)<<8))
-#define MAKELONG(a,b) (DWORD)(((a)&0xffff)|((b)<<16))
+#define HIWORD(a) (WORD)((a) >> 16)
+#define MAKEWORD(a, b) (WORD)(((a) & 0xff) | ((b) << 8))
+#define MAKELONG(a, b) (DWORD)(((a) & 0xffff) | ((b) << 16))
 #endif
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#define BASSVERSION			0x204	// API version
-#define BASSVERSIONTEXT		"2.4"
+#define BASSVERSION 0x204 // API version
+#define BASSVERSIONTEXT "2.4"
 
 #ifndef BASSDEF
 #define BASSDEF(f) WINAPI f
@@ -53,526 +53,545 @@ extern "C" {
 #define NOBASSOVERLOADS
 #endif
 
-typedef DWORD HMUSIC;		// MOD music handle
-typedef DWORD HSAMPLE;		// sample handle
-typedef DWORD HCHANNEL;		// sample playback handle
-typedef DWORD HSTREAM;		// sample stream handle
-typedef DWORD HRECORD;		// recording handle
-typedef DWORD HSYNC;		// synchronizer handle
-typedef DWORD HDSP;			// DSP handle
-typedef DWORD HFX;			// effect handle
-typedef DWORD HPLUGIN;		// plugin handle
+typedef DWORD HMUSIC;   // MOD music handle
+typedef DWORD HSAMPLE;  // sample handle
+typedef DWORD HCHANNEL; // sample playback handle
+typedef DWORD HSTREAM;  // sample stream handle
+typedef DWORD HRECORD;  // recording handle
+typedef DWORD HSYNC;    // synchronizer handle
+typedef DWORD HDSP;     // DSP handle
+typedef DWORD HFX;      // effect handle
+typedef DWORD HPLUGIN;  // plugin handle
 
 // Error codes returned by BASS_ErrorGetCode
-#define BASS_OK				0	// all is OK
-#define BASS_ERROR_MEM		1	// memory error
-#define BASS_ERROR_FILEOPEN	2	// can't open the file
-#define BASS_ERROR_DRIVER	3	// can't find a free/valid driver
-#define BASS_ERROR_BUFLOST	4	// the sample buffer was lost
-#define BASS_ERROR_HANDLE	5	// invalid handle
-#define BASS_ERROR_FORMAT	6	// unsupported sample format
-#define BASS_ERROR_POSITION	7	// invalid position
-#define BASS_ERROR_INIT		8	// BASS_Init has not been successfully called
-#define BASS_ERROR_START	9	// BASS_Start has not been successfully called
-#define BASS_ERROR_SSL		10	// SSL/HTTPS support isn't available
-#define BASS_ERROR_REINIT	11	// device needs to be reinitialized
-#define BASS_ERROR_ALREADY	14	// already initialized/paused/whatever
-#define BASS_ERROR_NOTAUDIO	17	// file does not contain audio
-#define BASS_ERROR_NOCHAN	18	// can't get a free channel
-#define BASS_ERROR_ILLTYPE	19	// an illegal type was specified
-#define BASS_ERROR_ILLPARAM	20	// an illegal parameter was specified
-#define BASS_ERROR_NO3D		21	// no 3D support
-#define BASS_ERROR_NOEAX	22	// no EAX support
-#define BASS_ERROR_DEVICE	23	// illegal device number
-#define BASS_ERROR_NOPLAY	24	// not playing
-#define BASS_ERROR_FREQ		25	// illegal sample rate
-#define BASS_ERROR_NOTFILE	27	// the stream is not a file stream
-#define BASS_ERROR_NOHW		29	// no hardware voices available
-#define BASS_ERROR_EMPTY	31	// the file has no sample data
-#define BASS_ERROR_NONET	32	// no internet connection could be opened
-#define BASS_ERROR_CREATE	33	// couldn't create the file
-#define BASS_ERROR_NOFX		34	// effects are not available
-#define BASS_ERROR_NOTAVAIL	37	// requested data/action is not available
-#define BASS_ERROR_DECODE	38	// the channel is/isn't a "decoding channel"
-#define BASS_ERROR_DX		39	// a sufficient DirectX version is not installed
-#define BASS_ERROR_TIMEOUT	40	// connection timedout
-#define BASS_ERROR_FILEFORM	41	// unsupported file format
-#define BASS_ERROR_SPEAKER	42	// unavailable speaker
-#define BASS_ERROR_VERSION	43	// invalid BASS version (used by add-ons)
-#define BASS_ERROR_CODEC	44	// codec is not available/supported
-#define BASS_ERROR_ENDED	45	// the channel/file has ended
-#define BASS_ERROR_BUSY		46	// the device is busy
-#define BASS_ERROR_UNSTREAMABLE	47	// unstreamable file
-#define BASS_ERROR_PROTOCOL	48	// unsupported protocol
-#define BASS_ERROR_DENIED	49	// access denied
-#define BASS_ERROR_FREEING	50	// being freed
-#define BASS_ERROR_CANCEL	51	// cancelled
-#define BASS_ERROR_UNKNOWN	-1	// some other mystery problem
+#define BASS_OK 0              // all is OK
+#define BASS_ERROR_MEM 1       // memory error
+#define BASS_ERROR_FILEOPEN 2  // can't open the file
+#define BASS_ERROR_DRIVER 3    // can't find a free/valid driver
+#define BASS_ERROR_BUFLOST 4   // the sample buffer was lost
+#define BASS_ERROR_HANDLE 5    // invalid handle
+#define BASS_ERROR_FORMAT 6    // unsupported sample format
+#define BASS_ERROR_POSITION 7  // invalid position
+#define BASS_ERROR_INIT 8      // BASS_Init has not been successfully called
+#define BASS_ERROR_START 9     // BASS_Start has not been successfully called
+#define BASS_ERROR_SSL 10      // SSL/HTTPS support isn't available
+#define BASS_ERROR_REINIT 11   // device needs to be reinitialized
+#define BASS_ERROR_ALREADY 14  // already initialized/paused/whatever
+#define BASS_ERROR_NOTAUDIO 17 // file does not contain audio
+#define BASS_ERROR_NOCHAN 18   // can't get a free channel
+#define BASS_ERROR_ILLTYPE 19  // an illegal type was specified
+#define BASS_ERROR_ILLPARAM 20 // an illegal parameter was specified
+#define BASS_ERROR_NO3D 21     // no 3D support
+#define BASS_ERROR_NOEAX 22    // no EAX support
+#define BASS_ERROR_DEVICE 23   // illegal device number
+#define BASS_ERROR_NOPLAY 24   // not playing
+#define BASS_ERROR_FREQ 25     // illegal sample rate
+#define BASS_ERROR_NOTFILE 27  // the stream is not a file stream
+#define BASS_ERROR_NOHW 29     // no hardware voices available
+#define BASS_ERROR_EMPTY 31    // the file has no sample data
+#define BASS_ERROR_NONET 32    // no internet connection could be opened
+#define BASS_ERROR_CREATE 33   // couldn't create the file
+#define BASS_ERROR_NOFX 34     // effects are not available
+#define BASS_ERROR_NOTAVAIL 37 // requested data/action is not available
+#define BASS_ERROR_DECODE 38   // the channel is/isn't a "decoding channel"
+#define BASS_ERROR_DX 39       // a sufficient DirectX version is not installed
+#define BASS_ERROR_TIMEOUT 40  // connection timedout
+#define BASS_ERROR_FILEFORM 41 // unsupported file format
+#define BASS_ERROR_SPEAKER 42  // unavailable speaker
+#define BASS_ERROR_VERSION 43  // invalid BASS version (used by add-ons)
+#define BASS_ERROR_CODEC 44    // codec is not available/supported
+#define BASS_ERROR_ENDED 45    // the channel/file has ended
+#define BASS_ERROR_BUSY 46     // the device is busy
+#define BASS_ERROR_UNSTREAMABLE 47 // unstreamable file
+#define BASS_ERROR_PROTOCOL 48     // unsupported protocol
+#define BASS_ERROR_DENIED 49       // access denied
+#define BASS_ERROR_FREEING 50      // being freed
+#define BASS_ERROR_CANCEL 51       // cancelled
+#define BASS_ERROR_UNKNOWN -1      // some other mystery problem
 
 // BASS_SetConfig options
-#define BASS_CONFIG_BUFFER			0
-#define BASS_CONFIG_UPDATEPERIOD	1
-#define BASS_CONFIG_GVOL_SAMPLE		4
-#define BASS_CONFIG_GVOL_STREAM		5
-#define BASS_CONFIG_GVOL_MUSIC		6
-#define BASS_CONFIG_CURVE_VOL		7
-#define BASS_CONFIG_CURVE_PAN		8
-#define BASS_CONFIG_FLOATDSP		9
-#define BASS_CONFIG_3DALGORITHM		10
-#define BASS_CONFIG_NET_TIMEOUT		11
-#define BASS_CONFIG_NET_BUFFER		12
-#define BASS_CONFIG_PAUSE_NOPLAY	13
-#define BASS_CONFIG_NET_PREBUF		15
-#define BASS_CONFIG_NET_PASSIVE		18
-#define BASS_CONFIG_REC_BUFFER		19
-#define BASS_CONFIG_NET_PLAYLIST	21
-#define BASS_CONFIG_MUSIC_VIRTUAL	22
-#define BASS_CONFIG_VERIFY			23
-#define BASS_CONFIG_UPDATETHREADS	24
-#define BASS_CONFIG_DEV_BUFFER		27
-#define BASS_CONFIG_REC_LOOPBACK	28
-#define BASS_CONFIG_VISTA_TRUEPOS	30
-#define BASS_CONFIG_IOS_SESSION		34
-#define BASS_CONFIG_IOS_MIXAUDIO	34
-#define BASS_CONFIG_DEV_DEFAULT		36
-#define BASS_CONFIG_NET_READTIMEOUT	37
-#define BASS_CONFIG_VISTA_SPEAKERS	38
-#define BASS_CONFIG_IOS_SPEAKER		39
-#define BASS_CONFIG_MF_DISABLE		40
-#define BASS_CONFIG_HANDLES			41
-#define BASS_CONFIG_UNICODE			42
-#define BASS_CONFIG_SRC				43
-#define BASS_CONFIG_SRC_SAMPLE		44
+#define BASS_CONFIG_BUFFER 0
+#define BASS_CONFIG_UPDATEPERIOD 1
+#define BASS_CONFIG_GVOL_SAMPLE 4
+#define BASS_CONFIG_GVOL_STREAM 5
+#define BASS_CONFIG_GVOL_MUSIC 6
+#define BASS_CONFIG_CURVE_VOL 7
+#define BASS_CONFIG_CURVE_PAN 8
+#define BASS_CONFIG_FLOATDSP 9
+#define BASS_CONFIG_3DALGORITHM 10
+#define BASS_CONFIG_NET_TIMEOUT 11
+#define BASS_CONFIG_NET_BUFFER 12
+#define BASS_CONFIG_PAUSE_NOPLAY 13
+#define BASS_CONFIG_NET_PREBUF 15
+#define BASS_CONFIG_NET_PASSIVE 18
+#define BASS_CONFIG_REC_BUFFER 19
+#define BASS_CONFIG_NET_PLAYLIST 21
+#define BASS_CONFIG_MUSIC_VIRTUAL 22
+#define BASS_CONFIG_VERIFY 23
+#define BASS_CONFIG_UPDATETHREADS 24
+#define BASS_CONFIG_DEV_BUFFER 27
+#define BASS_CONFIG_REC_LOOPBACK 28
+#define BASS_CONFIG_VISTA_TRUEPOS 30
+#define BASS_CONFIG_IOS_SESSION 34
+#define BASS_CONFIG_IOS_MIXAUDIO 34
+#define BASS_CONFIG_DEV_DEFAULT 36
+#define BASS_CONFIG_NET_READTIMEOUT 37
+#define BASS_CONFIG_VISTA_SPEAKERS 38
+#define BASS_CONFIG_IOS_SPEAKER 39
+#define BASS_CONFIG_MF_DISABLE 40
+#define BASS_CONFIG_HANDLES 41
+#define BASS_CONFIG_UNICODE 42
+#define BASS_CONFIG_SRC 43
+#define BASS_CONFIG_SRC_SAMPLE 44
 #define BASS_CONFIG_ASYNCFILE_BUFFER 45
-#define BASS_CONFIG_OGG_PRESCAN		47
-#define BASS_CONFIG_VIDEO			48
-#define BASS_CONFIG_MF_VIDEO		BASS_CONFIG_VIDEO
-#define BASS_CONFIG_AIRPLAY			49
-#define BASS_CONFIG_DEV_NONSTOP		50
-#define BASS_CONFIG_IOS_NOCATEGORY	51
-#define BASS_CONFIG_VERIFY_NET		52
-#define BASS_CONFIG_DEV_PERIOD		53
-#define BASS_CONFIG_FLOAT			54
-#define BASS_CONFIG_NET_SEEK		56
-#define BASS_CONFIG_AM_DISABLE		58
-#define BASS_CONFIG_NET_PLAYLIST_DEPTH	59
-#define BASS_CONFIG_NET_PREBUF_WAIT	60
-#define BASS_CONFIG_ANDROID_SESSIONID	62
-#define BASS_CONFIG_WASAPI_PERSIST	65
-#define BASS_CONFIG_REC_WASAPI		66
-#define BASS_CONFIG_ANDROID_AAUDIO	67
-#define BASS_CONFIG_SAMPLE_ONEHANDLE	69
-#define BASS_CONFIG_NET_META		71
-#define BASS_CONFIG_NET_RESTRATE	72
-#define BASS_CONFIG_REC_DEFAULT		73
-#define BASS_CONFIG_NORAMP			74
-#define BASS_CONFIG_NOSOUND_MAXDELAY	76
-#define BASS_CONFIG_STACKALLOC		79
+#define BASS_CONFIG_OGG_PRESCAN 47
+#define BASS_CONFIG_VIDEO 48
+#define BASS_CONFIG_MF_VIDEO BASS_CONFIG_VIDEO
+#define BASS_CONFIG_AIRPLAY 49
+#define BASS_CONFIG_DEV_NONSTOP 50
+#define BASS_CONFIG_IOS_NOCATEGORY 51
+#define BASS_CONFIG_VERIFY_NET 52
+#define BASS_CONFIG_DEV_PERIOD 53
+#define BASS_CONFIG_FLOAT 54
+#define BASS_CONFIG_NET_SEEK 56
+#define BASS_CONFIG_AM_DISABLE 58
+#define BASS_CONFIG_NET_PLAYLIST_DEPTH 59
+#define BASS_CONFIG_NET_PREBUF_WAIT 60
+#define BASS_CONFIG_ANDROID_SESSIONID 62
+#define BASS_CONFIG_WASAPI_PERSIST 65
+#define BASS_CONFIG_REC_WASAPI 66
+#define BASS_CONFIG_ANDROID_AAUDIO 67
+#define BASS_CONFIG_SAMPLE_ONEHANDLE 69
+#define BASS_CONFIG_NET_META 71
+#define BASS_CONFIG_NET_RESTRATE 72
+#define BASS_CONFIG_REC_DEFAULT 73
+#define BASS_CONFIG_NORAMP 74
+#define BASS_CONFIG_NOSOUND_MAXDELAY 76
+#define BASS_CONFIG_STACKALLOC 79
 
 // BASS_SetConfigPtr options
-#define BASS_CONFIG_NET_AGENT		16
-#define BASS_CONFIG_NET_PROXY		17
-#define BASS_CONFIG_IOS_NOTIFY		46
-#define BASS_CONFIG_ANDROID_JAVAVM	63
-#define BASS_CONFIG_LIBSSL			64
-#define BASS_CONFIG_FILENAME		75
-#define BASS_CONFIG_FILEOPENPROCS	77
+#define BASS_CONFIG_NET_AGENT 16
+#define BASS_CONFIG_NET_PROXY 17
+#define BASS_CONFIG_IOS_NOTIFY 46
+#define BASS_CONFIG_ANDROID_JAVAVM 63
+#define BASS_CONFIG_LIBSSL 64
+#define BASS_CONFIG_FILENAME 75
+#define BASS_CONFIG_FILEOPENPROCS 77
 
-#define BASS_CONFIG_THREAD			0x40000000 // flag: thread-specific setting
+#define BASS_CONFIG_THREAD 0x40000000 // flag: thread-specific setting
 
 // BASS_CONFIG_IOS_SESSION flags
-#define BASS_IOS_SESSION_MIX		1
-#define BASS_IOS_SESSION_DUCK		2
-#define BASS_IOS_SESSION_AMBIENT	4
-#define BASS_IOS_SESSION_SPEAKER	8
-#define BASS_IOS_SESSION_DISABLE	0x10
-#define BASS_IOS_SESSION_DEACTIVATE	0x20
-#define BASS_IOS_SESSION_AIRPLAY	0x40
-#define BASS_IOS_SESSION_BTHFP		0x80
-#define BASS_IOS_SESSION_BTA2DP		0x100
+#define BASS_IOS_SESSION_MIX 1
+#define BASS_IOS_SESSION_DUCK 2
+#define BASS_IOS_SESSION_AMBIENT 4
+#define BASS_IOS_SESSION_SPEAKER 8
+#define BASS_IOS_SESSION_DISABLE 0x10
+#define BASS_IOS_SESSION_DEACTIVATE 0x20
+#define BASS_IOS_SESSION_AIRPLAY 0x40
+#define BASS_IOS_SESSION_BTHFP 0x80
+#define BASS_IOS_SESSION_BTA2DP 0x100
 
 // BASS_Init flags
-#define BASS_DEVICE_8BITS		1		// unused
-#define BASS_DEVICE_MONO		2		// mono
-#define BASS_DEVICE_3D			4		// unused
-#define BASS_DEVICE_16BITS		8		// limit output to 16-bit
-#define BASS_DEVICE_NODOWNMIX	0x10	// don't downmix multi-channel
-#define BASS_DEVICE_REINIT		0x80	// reinitialize
-#define BASS_DEVICE_LATENCY		0x100	// unused
-#define BASS_DEVICE_CPSPEAKERS	0x400	// unused
-#define BASS_DEVICE_SPEAKERS	0x800	// force enabling of speaker assignment
-#define BASS_DEVICE_NOSPEAKER	0x1000	// ignore speaker arrangement
-#define BASS_DEVICE_DMIX		0x2000	// use ALSA "dmix" plugin
-#define BASS_DEVICE_FREQ		0x4000	// set device sample rate
-#define BASS_DEVICE_STEREO		0x8000	// limit output to stereo
-#define BASS_DEVICE_HOG			0x10000	// hog/exclusive mode
-#define BASS_DEVICE_AUDIOTRACK	0x20000	// use AudioTrack output
-#define BASS_DEVICE_DSOUND		0x40000	// use DirectSound output
-#define BASS_DEVICE_SOFTWARE	0x80000	// disable hardware/fastpath output
-#define BASS_DEVICE_OPENSLES	0x100000 // use OpenSLES output
-#define BASS_DEVICE_APPLEVOICE	0x200000 // use Apple voice processing
+#define BASS_DEVICE_8BITS 1             // unused
+#define BASS_DEVICE_MONO 2              // mono
+#define BASS_DEVICE_3D 4                // unused
+#define BASS_DEVICE_16BITS 8            // limit output to 16-bit
+#define BASS_DEVICE_NODOWNMIX 0x10      // don't downmix multi-channel
+#define BASS_DEVICE_REINIT 0x80         // reinitialize
+#define BASS_DEVICE_LATENCY 0x100       // unused
+#define BASS_DEVICE_CPSPEAKERS 0x400    // unused
+#define BASS_DEVICE_SPEAKERS 0x800      // force enabling of speaker assignment
+#define BASS_DEVICE_NOSPEAKER 0x1000    // ignore speaker arrangement
+#define BASS_DEVICE_DMIX 0x2000         // use ALSA "dmix" plugin
+#define BASS_DEVICE_FREQ 0x4000         // set device sample rate
+#define BASS_DEVICE_STEREO 0x8000       // limit output to stereo
+#define BASS_DEVICE_HOG 0x10000         // hog/exclusive mode
+#define BASS_DEVICE_AUDIOTRACK 0x20000  // use AudioTrack output
+#define BASS_DEVICE_DSOUND 0x40000      // use DirectSound output
+#define BASS_DEVICE_SOFTWARE 0x80000    // disable hardware/fastpath output
+#define BASS_DEVICE_OPENSLES 0x100000   // use OpenSLES output
+#define BASS_DEVICE_APPLEVOICE 0x200000 // use Apple voice processing
 
 // DirectSound interfaces (for use with BASS_GetDSoundObject)
-#define BASS_OBJECT_DS		1	// IDirectSound
-#define BASS_OBJECT_DS3DL	2	// IDirectSound3DListener
+#define BASS_OBJECT_DS 1    // IDirectSound
+#define BASS_OBJECT_DS3DL 2 // IDirectSound3DListener
 
 // Device info structure
 typedef struct {
-#if defined(_WIN32_WCE) || (defined(WINAPI_FAMILY) && WINAPI_FAMILY != WINAPI_FAMILY_DESKTOP_APP)
-	const wchar_t *name;	// description
-	const wchar_t *driver;	// driver
+#if defined(_WIN32_WCE) ||                                                     \
+    (defined(WINAPI_FAMILY) && WINAPI_FAMILY != WINAPI_FAMILY_DESKTOP_APP)
+  const wchar_t *name;   // description
+  const wchar_t *driver; // driver
 #else
-	const char *name;	// description
-	const char *driver;	// driver
+  const char *name;   // description
+  const char *driver; // driver
 #endif
-	DWORD flags;
+  DWORD flags;
 } BASS_DEVICEINFO;
 
 // BASS_DEVICEINFO flags
-#define BASS_DEVICE_ENABLED		1
-#define BASS_DEVICE_DEFAULT		2
-#define BASS_DEVICE_INIT		4
-#define BASS_DEVICE_LOOPBACK	8
-#define BASS_DEVICE_DEFAULTCOM	0x80
+#define BASS_DEVICE_ENABLED 1
+#define BASS_DEVICE_DEFAULT 2
+#define BASS_DEVICE_INIT 4
+#define BASS_DEVICE_LOOPBACK 8
+#define BASS_DEVICE_DEFAULTCOM 0x80
 
-#define BASS_DEVICE_TYPE_MASK			0xff000000
-#define BASS_DEVICE_TYPE_NETWORK		0x01000000
-#define BASS_DEVICE_TYPE_SPEAKERS		0x02000000
-#define BASS_DEVICE_TYPE_LINE			0x03000000
-#define BASS_DEVICE_TYPE_HEADPHONES		0x04000000
-#define BASS_DEVICE_TYPE_MICROPHONE		0x05000000
-#define BASS_DEVICE_TYPE_HEADSET		0x06000000
-#define BASS_DEVICE_TYPE_HANDSET		0x07000000
-#define BASS_DEVICE_TYPE_DIGITAL		0x08000000
-#define BASS_DEVICE_TYPE_SPDIF			0x09000000
-#define BASS_DEVICE_TYPE_HDMI			0x0a000000
-#define BASS_DEVICE_TYPE_DISPLAYPORT	0x40000000
+#define BASS_DEVICE_TYPE_MASK 0xff000000
+#define BASS_DEVICE_TYPE_NETWORK 0x01000000
+#define BASS_DEVICE_TYPE_SPEAKERS 0x02000000
+#define BASS_DEVICE_TYPE_LINE 0x03000000
+#define BASS_DEVICE_TYPE_HEADPHONES 0x04000000
+#define BASS_DEVICE_TYPE_MICROPHONE 0x05000000
+#define BASS_DEVICE_TYPE_HEADSET 0x06000000
+#define BASS_DEVICE_TYPE_HANDSET 0x07000000
+#define BASS_DEVICE_TYPE_DIGITAL 0x08000000
+#define BASS_DEVICE_TYPE_SPDIF 0x09000000
+#define BASS_DEVICE_TYPE_HDMI 0x0a000000
+#define BASS_DEVICE_TYPE_DISPLAYPORT 0x40000000
 
 // BASS_GetDeviceInfo flags
-#define BASS_DEVICES_AIRPLAY	0x1000000
+#define BASS_DEVICES_AIRPLAY 0x1000000
 
 typedef struct {
-	DWORD flags;	// device capabilities (DSCAPS_xxx flags)
-	DWORD hwsize;	// unused
-	DWORD hwfree;	// unused
-	DWORD freesam;	// unused
-	DWORD free3d;	// unused
-	DWORD minrate;	// unused
-	DWORD maxrate;	// unused
-	BOOL eax;		// unused
-	DWORD minbuf;	// recommended minimum buffer length in ms
-	DWORD dsver;	// DirectSound version
-	DWORD latency;	// average delay (in ms) before start of playback
-	DWORD initflags; // BASS_Init "flags" parameter
-	DWORD speakers; // number of speakers available
-	DWORD freq;		// current output rate
+  DWORD flags;     // device capabilities (DSCAPS_xxx flags)
+  DWORD hwsize;    // unused
+  DWORD hwfree;    // unused
+  DWORD freesam;   // unused
+  DWORD free3d;    // unused
+  DWORD minrate;   // unused
+  DWORD maxrate;   // unused
+  BOOL eax;        // unused
+  DWORD minbuf;    // recommended minimum buffer length in ms
+  DWORD dsver;     // DirectSound version
+  DWORD latency;   // average delay (in ms) before start of playback
+  DWORD initflags; // BASS_Init "flags" parameter
+  DWORD speakers;  // number of speakers available
+  DWORD freq;      // current output rate
 } BASS_INFO;
 
 // BASS_INFO flags (from DSOUND.H)
-#define DSCAPS_EMULDRIVER		0x00000020	// device does not have hardware DirectSound support
-#define DSCAPS_CERTIFIED		0x00000040	// device driver has been certified by Microsoft
+#define DSCAPS_EMULDRIVER                                                      \
+  0x00000020 // device does not have hardware DirectSound support
+#define DSCAPS_CERTIFIED                                                       \
+  0x00000040 // device driver has been certified by Microsoft
 
-#define DSCAPS_HARDWARE			0x80000000	// hardware mixed
+#define DSCAPS_HARDWARE 0x80000000 // hardware mixed
 
 // Recording device info structure
 typedef struct {
-	DWORD flags;	// device capabilities (DSCCAPS_xxx flags)
-	DWORD formats;	// supported standard formats (WAVE_FORMAT_xxx flags)
-	DWORD inputs;	// number of inputs
-	BOOL singlein;	// TRUE = only 1 input can be set at a time
-	DWORD freq;		// current input rate
+  DWORD flags;   // device capabilities (DSCCAPS_xxx flags)
+  DWORD formats; // supported standard formats (WAVE_FORMAT_xxx flags)
+  DWORD inputs;  // number of inputs
+  BOOL singlein; // TRUE = only 1 input can be set at a time
+  DWORD freq;    // current input rate
 } BASS_RECORDINFO;
 
 // BASS_RECORDINFO flags (from DSOUND.H)
-#define DSCCAPS_EMULDRIVER		DSCAPS_EMULDRIVER	// device does not have hardware DirectSound recording support
-#define DSCCAPS_CERTIFIED		DSCAPS_CERTIFIED	// device driver has been certified by Microsoft
+#define DSCCAPS_EMULDRIVER                                                     \
+  DSCAPS_EMULDRIVER // device does not have hardware DirectSound recording
+                    // support
+#define DSCCAPS_CERTIFIED                                                      \
+  DSCAPS_CERTIFIED // device driver has been certified by Microsoft
 
 // filetypes
-#define BASS_FILE_NAME			0		// filename
-#define BASS_FILE_MEM			1		// memory
-#define BASS_FILE_MEMCOPY		3		// memory to copy
-#define BASS_FILE_HANDLE		4		// handle/descriptor
+#define BASS_FILE_NAME 0    // filename
+#define BASS_FILE_MEM 1     // memory
+#define BASS_FILE_MEMCOPY 3 // memory to copy
+#define BASS_FILE_HANDLE 4  // handle/descriptor
 
 // Sample info structure
 typedef struct {
-	DWORD freq;		// default playback rate
-	float volume;	// default volume (0-1)
-	float pan;		// default pan (-1=left, 0=middle, 1=right)
-	DWORD flags;	// BASS_SAMPLE_xxx flags
-	DWORD length;	// length (in bytes)
-	DWORD max;		// maximum simultaneous playbacks
-	DWORD origres;	// original resolution
-	DWORD chans;	// number of channels
-	DWORD mingap;	// minimum gap (ms) between creating channels
-	DWORD mode3d;	// BASS_3DMODE_xxx mode
-	float mindist;	// minimum distance
-	float maxdist;	// maximum distance
-	DWORD iangle;	// angle of inside projection cone
-	DWORD oangle;	// angle of outside projection cone
-	float outvol;	// delta-volume outside the projection cone
-	DWORD vam;		// unused
-	DWORD priority;	// unused
+  DWORD freq;     // default playback rate
+  float volume;   // default volume (0-1)
+  float pan;      // default pan (-1=left, 0=middle, 1=right)
+  DWORD flags;    // BASS_SAMPLE_xxx flags
+  DWORD length;   // length (in bytes)
+  DWORD max;      // maximum simultaneous playbacks
+  DWORD origres;  // original resolution
+  DWORD chans;    // number of channels
+  DWORD mingap;   // minimum gap (ms) between creating channels
+  DWORD mode3d;   // BASS_3DMODE_xxx mode
+  float mindist;  // minimum distance
+  float maxdist;  // maximum distance
+  DWORD iangle;   // angle of inside projection cone
+  DWORD oangle;   // angle of outside projection cone
+  float outvol;   // delta-volume outside the projection cone
+  DWORD vam;      // unused
+  DWORD priority; // unused
 } BASS_SAMPLE;
 
-#define BASS_SAMPLE_8BITS		1	// 8 bit
-#define BASS_SAMPLE_MONO		2	// mono
-#define BASS_SAMPLE_LOOP		4	// looped
-#define BASS_SAMPLE_3D			8	// 3D functionality
-#define BASS_SAMPLE_SOFTWARE	0x10	// unused
-#define BASS_SAMPLE_MUTEMAX		0x20	// mute at max distance (3D only)
-#define BASS_SAMPLE_NOREORDER	0x40	// don't reorder channels to match speakers
-#define BASS_SAMPLE_FX			0x80	// unused
-#define BASS_SAMPLE_FLOAT		0x100	// 32 bit floating-point
-#define BASS_SAMPLE_OVER_VOL	0x10000	// override lowest volume
-#define BASS_SAMPLE_OVER_POS	0x20000	// override longest playing
-#define BASS_SAMPLE_OVER_DIST	0x30000 // override furthest from listener (3D only)
+#define BASS_SAMPLE_8BITS 1          // 8 bit
+#define BASS_SAMPLE_MONO 2           // mono
+#define BASS_SAMPLE_LOOP 4           // looped
+#define BASS_SAMPLE_3D 8             // 3D functionality
+#define BASS_SAMPLE_SOFTWARE 0x10    // unused
+#define BASS_SAMPLE_MUTEMAX 0x20     // mute at max distance (3D only)
+#define BASS_SAMPLE_NOREORDER 0x40   // don't reorder channels to match speakers
+#define BASS_SAMPLE_FX 0x80          // unused
+#define BASS_SAMPLE_FLOAT 0x100      // 32 bit floating-point
+#define BASS_SAMPLE_OVER_VOL 0x10000 // override lowest volume
+#define BASS_SAMPLE_OVER_POS 0x20000 // override longest playing
+#define BASS_SAMPLE_OVER_DIST                                                  \
+  0x30000 // override furthest from listener (3D only)
 
-#define BASS_STREAM_PRESCAN		0x20000 // scan file for accurate seeking and length
-#define BASS_STREAM_AUTOFREE	0x40000	// automatically free the stream when it stops/ends
-#define BASS_STREAM_RESTRATE	0x80000	// restrict the download rate of internet file stream
-#define BASS_STREAM_BLOCK		0x100000 // download internet file stream in small blocks
-#define BASS_STREAM_DECODE		0x200000 // don't play the stream, only decode
-#define BASS_STREAM_STATUS		0x800000 // give server status info (HTTP/ICY tags) in DOWNLOADPROC
+#define BASS_STREAM_PRESCAN 0x20000 // scan file for accurate seeking and length
+#define BASS_STREAM_AUTOFREE                                                   \
+  0x40000 // automatically free the stream when it stops/ends
+#define BASS_STREAM_RESTRATE                                                   \
+  0x80000 // restrict the download rate of internet file stream
+#define BASS_STREAM_BLOCK                                                      \
+  0x100000 // download internet file stream in small blocks
+#define BASS_STREAM_DECODE 0x200000 // don't play the stream, only decode
+#define BASS_STREAM_STATUS                                                     \
+  0x800000 // give server status info (HTTP/ICY tags) in DOWNLOADPROC
 
-#define BASS_MP3_IGNOREDELAY	0x200 // ignore LAME/Xing/VBRI/iTunes delay & padding info
-#define BASS_MP3_SETPOS			BASS_STREAM_PRESCAN
+#define BASS_MP3_IGNOREDELAY                                                   \
+  0x200 // ignore LAME/Xing/VBRI/iTunes delay & padding info
+#define BASS_MP3_SETPOS BASS_STREAM_PRESCAN
 
-#define BASS_MUSIC_FLOAT		BASS_SAMPLE_FLOAT
-#define BASS_MUSIC_MONO			BASS_SAMPLE_MONO
-#define BASS_MUSIC_LOOP			BASS_SAMPLE_LOOP
-#define BASS_MUSIC_3D			BASS_SAMPLE_3D
-#define BASS_MUSIC_FX			BASS_SAMPLE_FX
-#define BASS_MUSIC_AUTOFREE		BASS_STREAM_AUTOFREE
-#define BASS_MUSIC_DECODE		BASS_STREAM_DECODE
-#define BASS_MUSIC_PRESCAN		BASS_STREAM_PRESCAN	// calculate playback length
-#define BASS_MUSIC_CALCLEN		BASS_MUSIC_PRESCAN
-#define BASS_MUSIC_RAMP			0x200	// normal ramping
-#define BASS_MUSIC_RAMPS		0x400	// sensitive ramping
-#define BASS_MUSIC_SURROUND		0x800	// surround sound
-#define BASS_MUSIC_SURROUND2	0x1000	// surround sound (mode 2)
-#define BASS_MUSIC_FT2PAN		0x2000	// apply FastTracker 2 panning to XM files
-#define BASS_MUSIC_FT2MOD		0x2000	// play .MOD as FastTracker 2 does
-#define BASS_MUSIC_PT1MOD		0x4000	// play .MOD as ProTracker 1 does
-#define BASS_MUSIC_NONINTER		0x10000	// non-interpolated sample mixing
-#define BASS_MUSIC_SINCINTER	0x800000 // sinc interpolated sample mixing
-#define BASS_MUSIC_POSRESET		0x8000	// stop all notes when moving position
-#define BASS_MUSIC_POSRESETEX	0x400000 // stop all notes and reset bmp/etc when moving position
-#define BASS_MUSIC_STOPBACK		0x80000	// stop the music on a backwards jump effect
-#define BASS_MUSIC_NOSAMPLE		0x100000 // don't load the samples
+#define BASS_MUSIC_FLOAT BASS_SAMPLE_FLOAT
+#define BASS_MUSIC_MONO BASS_SAMPLE_MONO
+#define BASS_MUSIC_LOOP BASS_SAMPLE_LOOP
+#define BASS_MUSIC_3D BASS_SAMPLE_3D
+#define BASS_MUSIC_FX BASS_SAMPLE_FX
+#define BASS_MUSIC_AUTOFREE BASS_STREAM_AUTOFREE
+#define BASS_MUSIC_DECODE BASS_STREAM_DECODE
+#define BASS_MUSIC_PRESCAN BASS_STREAM_PRESCAN // calculate playback length
+#define BASS_MUSIC_CALCLEN BASS_MUSIC_PRESCAN
+#define BASS_MUSIC_RAMP 0x200         // normal ramping
+#define BASS_MUSIC_RAMPS 0x400        // sensitive ramping
+#define BASS_MUSIC_SURROUND 0x800     // surround sound
+#define BASS_MUSIC_SURROUND2 0x1000   // surround sound (mode 2)
+#define BASS_MUSIC_FT2PAN 0x2000      // apply FastTracker 2 panning to XM files
+#define BASS_MUSIC_FT2MOD 0x2000      // play .MOD as FastTracker 2 does
+#define BASS_MUSIC_PT1MOD 0x4000      // play .MOD as ProTracker 1 does
+#define BASS_MUSIC_NONINTER 0x10000   // non-interpolated sample mixing
+#define BASS_MUSIC_SINCINTER 0x800000 // sinc interpolated sample mixing
+#define BASS_MUSIC_POSRESET 0x8000    // stop all notes when moving position
+#define BASS_MUSIC_POSRESETEX                                                  \
+  0x400000 // stop all notes and reset bmp/etc when moving position
+#define BASS_MUSIC_STOPBACK 0x80000 // stop the music on a backwards jump effect
+#define BASS_MUSIC_NOSAMPLE 0x100000 // don't load the samples
 
 // Speaker assignment flags
-#define BASS_SPEAKER_FRONT		0x1000000	// front speakers
-#define BASS_SPEAKER_REAR		0x2000000	// rear speakers
-#define BASS_SPEAKER_CENLFE		0x3000000	// center & LFE speakers (5.1)
-#define BASS_SPEAKER_SIDE		0x4000000	// side speakers (7.1)
-#define BASS_SPEAKER_N(n)		((n)<<24)	// n'th pair of speakers (max 15)
-#define BASS_SPEAKER_LEFT		0x10000000	// modifier: left
-#define BASS_SPEAKER_RIGHT		0x20000000	// modifier: right
-#define BASS_SPEAKER_FRONTLEFT	BASS_SPEAKER_FRONT | BASS_SPEAKER_LEFT
-#define BASS_SPEAKER_FRONTRIGHT	BASS_SPEAKER_FRONT | BASS_SPEAKER_RIGHT
-#define BASS_SPEAKER_REARLEFT	BASS_SPEAKER_REAR | BASS_SPEAKER_LEFT
-#define BASS_SPEAKER_REARRIGHT	BASS_SPEAKER_REAR | BASS_SPEAKER_RIGHT
-#define BASS_SPEAKER_CENTER		BASS_SPEAKER_CENLFE | BASS_SPEAKER_LEFT
-#define BASS_SPEAKER_LFE		BASS_SPEAKER_CENLFE | BASS_SPEAKER_RIGHT
-#define BASS_SPEAKER_SIDELEFT	BASS_SPEAKER_SIDE | BASS_SPEAKER_LEFT
-#define BASS_SPEAKER_SIDERIGHT	BASS_SPEAKER_SIDE | BASS_SPEAKER_RIGHT
-#define BASS_SPEAKER_REAR2		BASS_SPEAKER_SIDE
-#define BASS_SPEAKER_REAR2LEFT	BASS_SPEAKER_SIDELEFT
-#define BASS_SPEAKER_REAR2RIGHT	BASS_SPEAKER_SIDERIGHT
+#define BASS_SPEAKER_FRONT 0x1000000  // front speakers
+#define BASS_SPEAKER_REAR 0x2000000   // rear speakers
+#define BASS_SPEAKER_CENLFE 0x3000000 // center & LFE speakers (5.1)
+#define BASS_SPEAKER_SIDE 0x4000000   // side speakers (7.1)
+#define BASS_SPEAKER_N(n) ((n) << 24) // n'th pair of speakers (max 15)
+#define BASS_SPEAKER_LEFT 0x10000000  // modifier: left
+#define BASS_SPEAKER_RIGHT 0x20000000 // modifier: right
+#define BASS_SPEAKER_FRONTLEFT BASS_SPEAKER_FRONT | BASS_SPEAKER_LEFT
+#define BASS_SPEAKER_FRONTRIGHT BASS_SPEAKER_FRONT | BASS_SPEAKER_RIGHT
+#define BASS_SPEAKER_REARLEFT BASS_SPEAKER_REAR | BASS_SPEAKER_LEFT
+#define BASS_SPEAKER_REARRIGHT BASS_SPEAKER_REAR | BASS_SPEAKER_RIGHT
+#define BASS_SPEAKER_CENTER BASS_SPEAKER_CENLFE | BASS_SPEAKER_LEFT
+#define BASS_SPEAKER_LFE BASS_SPEAKER_CENLFE | BASS_SPEAKER_RIGHT
+#define BASS_SPEAKER_SIDELEFT BASS_SPEAKER_SIDE | BASS_SPEAKER_LEFT
+#define BASS_SPEAKER_SIDERIGHT BASS_SPEAKER_SIDE | BASS_SPEAKER_RIGHT
+#define BASS_SPEAKER_REAR2 BASS_SPEAKER_SIDE
+#define BASS_SPEAKER_REAR2LEFT BASS_SPEAKER_SIDELEFT
+#define BASS_SPEAKER_REAR2RIGHT BASS_SPEAKER_SIDERIGHT
 
-#define BASS_ASYNCFILE			0x40000000	// read file asynchronously
-#define BASS_UNICODE			0x80000000	// UTF-16
+#define BASS_ASYNCFILE 0x40000000 // read file asynchronously
+#define BASS_UNICODE 0x80000000   // UTF-16
 
-#define BASS_RECORD_OPENSLES	0x1000	// use OpenSLES
-#define BASS_RECORD_PAUSE		0x8000	// start recording paused
+#define BASS_RECORD_OPENSLES 0x1000 // use OpenSLES
+#define BASS_RECORD_PAUSE 0x8000    // start recording paused
 
 // DX7 voice allocation & management flags
-#define BASS_VAM_HARDWARE		1
-#define BASS_VAM_SOFTWARE		2
-#define BASS_VAM_TERM_TIME		4
-#define BASS_VAM_TERM_DIST		8
-#define BASS_VAM_TERM_PRIO		0x10
+#define BASS_VAM_HARDWARE 1
+#define BASS_VAM_SOFTWARE 2
+#define BASS_VAM_TERM_TIME 4
+#define BASS_VAM_TERM_DIST 8
+#define BASS_VAM_TERM_PRIO 0x10
 
 // Channel info structure
 typedef struct {
-	DWORD freq;		// default playback rate
-	DWORD chans;	// channels
-	DWORD flags;
-	DWORD ctype;	// type of channel
-	DWORD origres;	// original resolution
-	HPLUGIN plugin;
-	HSAMPLE sample;
-	const char *filename;
+  DWORD freq;  // default playback rate
+  DWORD chans; // channels
+  DWORD flags;
+  DWORD ctype;   // type of channel
+  DWORD origres; // original resolution
+  HPLUGIN plugin;
+  HSAMPLE sample;
+  const char *filename;
 } BASS_CHANNELINFO;
 
-#define BASS_ORIGRES_FLOAT		0x10000
+#define BASS_ORIGRES_FLOAT 0x10000
 
 // BASS_CHANNELINFO types
-#define BASS_CTYPE_SAMPLE		1
-#define BASS_CTYPE_RECORD		2
-#define BASS_CTYPE_STREAM		0x10000
-#define BASS_CTYPE_STREAM_VORBIS	0x10002
-#define BASS_CTYPE_STREAM_OGG	0x10002
-#define BASS_CTYPE_STREAM_MP1	0x10003
-#define BASS_CTYPE_STREAM_MP2	0x10004
-#define BASS_CTYPE_STREAM_MP3	0x10005
-#define BASS_CTYPE_STREAM_AIFF	0x10006
-#define BASS_CTYPE_STREAM_CA	0x10007
-#define BASS_CTYPE_STREAM_MF	0x10008
-#define BASS_CTYPE_STREAM_AM	0x10009
-#define BASS_CTYPE_STREAM_SAMPLE	0x1000a
-#define BASS_CTYPE_STREAM_DUMMY		0x18000
-#define BASS_CTYPE_STREAM_DEVICE	0x18001
-#define BASS_CTYPE_STREAM_WAV	0x40000 // WAVE flag (LOWORD=codec)
-#define BASS_CTYPE_STREAM_WAV_PCM	0x50001
-#define BASS_CTYPE_STREAM_WAV_FLOAT	0x50003
-#define BASS_CTYPE_MUSIC_MOD	0x20000
-#define BASS_CTYPE_MUSIC_MTM	0x20001
-#define BASS_CTYPE_MUSIC_S3M	0x20002
-#define BASS_CTYPE_MUSIC_XM		0x20003
-#define BASS_CTYPE_MUSIC_IT		0x20004
-#define BASS_CTYPE_MUSIC_MO3	0x00100 // MO3 flag
+#define BASS_CTYPE_SAMPLE 1
+#define BASS_CTYPE_RECORD 2
+#define BASS_CTYPE_STREAM 0x10000
+#define BASS_CTYPE_STREAM_VORBIS 0x10002
+#define BASS_CTYPE_STREAM_OGG 0x10002
+#define BASS_CTYPE_STREAM_MP1 0x10003
+#define BASS_CTYPE_STREAM_MP2 0x10004
+#define BASS_CTYPE_STREAM_MP3 0x10005
+#define BASS_CTYPE_STREAM_AIFF 0x10006
+#define BASS_CTYPE_STREAM_CA 0x10007
+#define BASS_CTYPE_STREAM_MF 0x10008
+#define BASS_CTYPE_STREAM_AM 0x10009
+#define BASS_CTYPE_STREAM_SAMPLE 0x1000a
+#define BASS_CTYPE_STREAM_DUMMY 0x18000
+#define BASS_CTYPE_STREAM_DEVICE 0x18001
+#define BASS_CTYPE_STREAM_WAV 0x40000 // WAVE flag (LOWORD=codec)
+#define BASS_CTYPE_STREAM_WAV_PCM 0x50001
+#define BASS_CTYPE_STREAM_WAV_FLOAT 0x50003
+#define BASS_CTYPE_MUSIC_MOD 0x20000
+#define BASS_CTYPE_MUSIC_MTM 0x20001
+#define BASS_CTYPE_MUSIC_S3M 0x20002
+#define BASS_CTYPE_MUSIC_XM 0x20003
+#define BASS_CTYPE_MUSIC_IT 0x20004
+#define BASS_CTYPE_MUSIC_MO3 0x00100 // MO3 flag
 
 // BASS_PluginLoad flags
-#define BASS_PLUGIN_PROC		1
+#define BASS_PLUGIN_PROC 1
 
 typedef struct {
-	DWORD ctype;		// channel type
-#if defined(_WIN32_WCE) || (defined(WINAPI_FAMILY) && WINAPI_FAMILY != WINAPI_FAMILY_DESKTOP_APP)
-	const wchar_t *name;	// format description
-	const wchar_t *exts;	// file extension filter (*.ext1;*.ext2;etc...)
+  DWORD ctype; // channel type
+#if defined(_WIN32_WCE) ||                                                     \
+    (defined(WINAPI_FAMILY) && WINAPI_FAMILY != WINAPI_FAMILY_DESKTOP_APP)
+  const wchar_t *name; // format description
+  const wchar_t *exts; // file extension filter (*.ext1;*.ext2;etc...)
 #else
-	const char *name;	// format description
-	const char *exts;	// file extension filter (*.ext1;*.ext2;etc...)
+  const char *name; // format description
+  const char *exts; // file extension filter (*.ext1;*.ext2;etc...)
 #endif
 } BASS_PLUGINFORM;
 
 typedef struct {
-	DWORD version;					// version (same form as BASS_GetVersion)
-	DWORD formatc;					// number of formats
-	const BASS_PLUGINFORM *formats;	// the array of formats
+  DWORD version;                  // version (same form as BASS_GetVersion)
+  DWORD formatc;                  // number of formats
+  const BASS_PLUGINFORM *formats; // the array of formats
 } BASS_PLUGININFO;
 
 // 3D vector (for 3D positions/velocities/orientations)
 typedef struct BASS_3DVECTOR {
 #ifdef __cplusplus
-	BASS_3DVECTOR() {}
-	BASS_3DVECTOR(float _x, float _y, float _z) : x(_x), y(_y), z(_z) {}
+  BASS_3DVECTOR() {}
+  BASS_3DVECTOR(float _x, float _y, float _z) : x(_x), y(_y), z(_z) {}
 #endif
-	float x;	// +=right, -=left
-	float y;	// +=up, -=down
-	float z;	// +=front, -=behind
+  float x; // +=right, -=left
+  float y; // +=up, -=down
+  float z; // +=front, -=behind
 } BASS_3DVECTOR;
 
 // 3D channel modes
-#define BASS_3DMODE_NORMAL		0	// normal 3D processing
-#define BASS_3DMODE_RELATIVE	1	// position is relative to the listener
-#define BASS_3DMODE_OFF			2	// no 3D processing
+#define BASS_3DMODE_NORMAL 0   // normal 3D processing
+#define BASS_3DMODE_RELATIVE 1 // position is relative to the listener
+#define BASS_3DMODE_OFF 2      // no 3D processing
 
 // software 3D mixing algorithms (used with BASS_CONFIG_3DALGORITHM)
-#define BASS_3DALG_DEFAULT	0
-#define BASS_3DALG_OFF		1
-#define BASS_3DALG_FULL		2
-#define BASS_3DALG_LIGHT	3
+#define BASS_3DALG_DEFAULT 0
+#define BASS_3DALG_OFF 1
+#define BASS_3DALG_FULL 2
+#define BASS_3DALG_LIGHT 3
 
 // BASS_SampleGetChannel flags
-#define BASS_SAMCHAN_NEW		1	// get a new playback channel
-#define BASS_SAMCHAN_STREAM		2	// create a stream
+#define BASS_SAMCHAN_NEW 1    // get a new playback channel
+#define BASS_SAMCHAN_STREAM 2 // create a stream
 
-typedef DWORD (CALLBACK STREAMPROC)(HSTREAM handle, void *buffer, DWORD length, void *user);
+typedef DWORD(CALLBACK STREAMPROC)(HSTREAM handle, void *buffer, DWORD length,
+                                   void *user);
 /* User stream callback function.
 handle : The stream that needs writing
 buffer : Buffer to write the samples in
 length : Number of bytes to write
 user   : The 'user' parameter value given when calling BASS_StreamCreate
-RETURN : Number of bytes written. Set the BASS_STREAMPROC_END flag to end the stream. */
+RETURN : Number of bytes written. Set the BASS_STREAMPROC_END flag to end the
+stream. */
 
-#define BASS_STREAMPROC_END		0x80000000	// end of user stream flag
+#define BASS_STREAMPROC_END 0x80000000 // end of user stream flag
 
 // Special STREAMPROCs
-#define STREAMPROC_DUMMY		(STREAMPROC*)0		// "dummy" stream
-#define STREAMPROC_PUSH			(STREAMPROC*)-1		// push stream
-#define STREAMPROC_DEVICE		(STREAMPROC*)-2		// device mix stream
-#define STREAMPROC_DEVICE_3D	(STREAMPROC*)-3		// device 3D mix stream
+#define STREAMPROC_DUMMY (STREAMPROC *)0      // "dummy" stream
+#define STREAMPROC_PUSH (STREAMPROC *)-1      // push stream
+#define STREAMPROC_DEVICE (STREAMPROC *)-2    // device mix stream
+#define STREAMPROC_DEVICE_3D (STREAMPROC *)-3 // device 3D mix stream
 
 // BASS_StreamCreateFileUser file systems
-#define STREAMFILE_NOBUFFER		0
-#define STREAMFILE_BUFFER		1
-#define STREAMFILE_BUFFERPUSH	2
+#define STREAMFILE_NOBUFFER 0
+#define STREAMFILE_BUFFER 1
+#define STREAMFILE_BUFFERPUSH 2
 
 // User file callback functions
-typedef void (CALLBACK FILECLOSEPROC)(void *user);
-typedef QWORD (CALLBACK FILELENPROC)(void *user);
-typedef DWORD (CALLBACK FILEREADPROC)(void *buffer, DWORD length, void *user);
-typedef BOOL (CALLBACK FILESEEKPROC)(QWORD offset, void *user);
+typedef void(CALLBACK FILECLOSEPROC)(void *user);
+typedef QWORD(CALLBACK FILELENPROC)(void *user);
+typedef DWORD(CALLBACK FILEREADPROC)(void *buffer, DWORD length, void *user);
+typedef BOOL(CALLBACK FILESEEKPROC)(QWORD offset, void *user);
 typedef void *(CALLBACK FILEOPENPROC)(const char *filename, DWORD flags);
 
 typedef struct {
-	FILECLOSEPROC *close;
-	FILELENPROC *length;
-	FILEREADPROC *read;
-	FILESEEKPROC *seek;
+  FILECLOSEPROC *close;
+  FILELENPROC *length;
+  FILEREADPROC *read;
+  FILESEEKPROC *seek;
 } BASS_FILEPROCS;
 
 typedef struct {
-	FILECLOSEPROC *close;
-	FILELENPROC *length;
-	FILEREADPROC *read;
-	FILESEEKPROC *seek;
-	FILEOPENPROC *open;
+  FILECLOSEPROC *close;
+  FILELENPROC *length;
+  FILEREADPROC *read;
+  FILESEEKPROC *seek;
+  FILEOPENPROC *open;
 } BASS_FILEOPENPROCS;
 
 // BASS_StreamPutFileData options
-#define BASS_FILEDATA_END		0	// end & close the file
+#define BASS_FILEDATA_END 0 // end & close the file
 
 // BASS_StreamGetFilePosition modes
-#define BASS_FILEPOS_CURRENT	0
-#define BASS_FILEPOS_DECODE		BASS_FILEPOS_CURRENT
-#define BASS_FILEPOS_DOWNLOAD	1
-#define BASS_FILEPOS_END		2
-#define BASS_FILEPOS_START		3
-#define BASS_FILEPOS_CONNECTED	4
-#define BASS_FILEPOS_BUFFER		5
-#define BASS_FILEPOS_SOCKET		6
-#define BASS_FILEPOS_ASYNCBUF	7
-#define BASS_FILEPOS_SIZE		8
-#define BASS_FILEPOS_BUFFERING	9
-#define BASS_FILEPOS_AVAILABLE	10
+#define BASS_FILEPOS_CURRENT 0
+#define BASS_FILEPOS_DECODE BASS_FILEPOS_CURRENT
+#define BASS_FILEPOS_DOWNLOAD 1
+#define BASS_FILEPOS_END 2
+#define BASS_FILEPOS_START 3
+#define BASS_FILEPOS_CONNECTED 4
+#define BASS_FILEPOS_BUFFER 5
+#define BASS_FILEPOS_SOCKET 6
+#define BASS_FILEPOS_ASYNCBUF 7
+#define BASS_FILEPOS_SIZE 8
+#define BASS_FILEPOS_BUFFERING 9
+#define BASS_FILEPOS_AVAILABLE 10
 
-typedef void (CALLBACK DOWNLOADPROC)(const void *buffer, DWORD length, void *user);
+typedef void(CALLBACK DOWNLOADPROC)(const void *buffer, DWORD length,
+                                    void *user);
 /* Internet stream download callback function.
 buffer : Buffer containing the downloaded data... NULL=end of download
 length : Number of bytes in the buffer
 user   : The 'user' parameter value given when calling BASS_StreamCreateURL */
 
 // BASS_ChannelSetSync types
-#define BASS_SYNC_POS			0
-#define BASS_SYNC_END			2
-#define BASS_SYNC_META			4
-#define BASS_SYNC_SLIDE			5
-#define BASS_SYNC_STALL			6
-#define BASS_SYNC_DOWNLOAD		7
-#define BASS_SYNC_FREE			8
-#define BASS_SYNC_SETPOS		11
-#define BASS_SYNC_MUSICPOS		10
-#define BASS_SYNC_MUSICINST		1
-#define BASS_SYNC_MUSICFX		3
-#define BASS_SYNC_OGG_CHANGE	12
-#define BASS_SYNC_DEV_FAIL		14
-#define BASS_SYNC_DEV_FORMAT	15
-#define BASS_SYNC_POS_RAW		16
-#define BASS_SYNC_THREAD		0x20000000	// flag: call sync in other thread
-#define BASS_SYNC_MIXTIME		0x40000000	// flag: sync at mixtime, else at playtime
-#define BASS_SYNC_ONETIME		0x80000000	// flag: sync only once, else continuously
+#define BASS_SYNC_POS 0
+#define BASS_SYNC_END 2
+#define BASS_SYNC_META 4
+#define BASS_SYNC_SLIDE 5
+#define BASS_SYNC_STALL 6
+#define BASS_SYNC_DOWNLOAD 7
+#define BASS_SYNC_FREE 8
+#define BASS_SYNC_SETPOS 11
+#define BASS_SYNC_MUSICPOS 10
+#define BASS_SYNC_MUSICINST 1
+#define BASS_SYNC_MUSICFX 3
+#define BASS_SYNC_OGG_CHANGE 12
+#define BASS_SYNC_DEV_FAIL 14
+#define BASS_SYNC_DEV_FORMAT 15
+#define BASS_SYNC_POS_RAW 16
+#define BASS_SYNC_THREAD 0x20000000  // flag: call sync in other thread
+#define BASS_SYNC_MIXTIME 0x40000000 // flag: sync at mixtime, else at playtime
+#define BASS_SYNC_ONETIME 0x80000000 // flag: sync only once, else continuously
 
-typedef void (CALLBACK SYNCPROC)(HSYNC handle, DWORD channel, DWORD data, void *user);
+typedef void(CALLBACK SYNCPROC)(HSYNC handle, DWORD channel, DWORD data,
+                                void *user);
 /* Sync callback function.
 handle : The sync that has occured
 channel: Channel that the sync occured in
 data   : Additional data associated with the sync's occurance
 user   : The 'user' parameter given when calling BASS_ChannelSetSync */
 
-typedef void (CALLBACK DSPPROC)(HDSP handle, DWORD channel, void *buffer, DWORD length, void *user);
+typedef void(CALLBACK DSPPROC)(HDSP handle, DWORD channel, void *buffer,
+                               DWORD length, void *user);
 /* DSP callback function.
 handle : The DSP handle
 channel: Channel that the DSP is being applied to
@@ -580,7 +599,8 @@ buffer : Buffer to apply the DSP to
 length : Number of bytes in the buffer
 user   : The 'user' parameter given when calling BASS_ChannelSetDSP */
 
-typedef BOOL (CALLBACK RECORDPROC)(HRECORD handle, const void *buffer, DWORD length, void *user);
+typedef BOOL(CALLBACK RECORDPROC)(HRECORD handle, const void *buffer,
+                                  DWORD length, void *user);
 /* Recording callback function.
 handle : The recording handle
 buffer : Buffer containing the recorded sample data
@@ -589,252 +609,258 @@ user   : The 'user' parameter value given when calling BASS_RecordStart
 RETURN : TRUE = continue recording, FALSE = stop */
 
 // Special RECORDPROCs
-#define RECORDPROC_NONE			(RECORDPROC*)0	// no RECORDPROC
-#define RECORDPROC_TRUE			(RECORDPROC*)-1	// only "return true"
+#define RECORDPROC_NONE (RECORDPROC *)0  // no RECORDPROC
+#define RECORDPROC_TRUE (RECORDPROC *)-1 // only "return true"
 
 // BASS_ChannelIsActive return values
-#define BASS_ACTIVE_STOPPED			0
-#define BASS_ACTIVE_PLAYING			1
-#define BASS_ACTIVE_STALLED			2
-#define BASS_ACTIVE_PAUSED			3
-#define BASS_ACTIVE_PAUSED_DEVICE	4
+#define BASS_ACTIVE_STOPPED 0
+#define BASS_ACTIVE_PLAYING 1
+#define BASS_ACTIVE_STALLED 2
+#define BASS_ACTIVE_PAUSED 3
+#define BASS_ACTIVE_PAUSED_DEVICE 4
 
 // Channel attributes
-#define BASS_ATTRIB_FREQ			1
-#define BASS_ATTRIB_VOL				2
-#define BASS_ATTRIB_PAN				3
-#define BASS_ATTRIB_EAXMIX			4
-#define BASS_ATTRIB_NOBUFFER		5
-#define BASS_ATTRIB_VBR				6
-#define BASS_ATTRIB_CPU				7
-#define BASS_ATTRIB_SRC				8
-#define BASS_ATTRIB_NET_RESUME		9
-#define BASS_ATTRIB_SCANINFO		10
-#define BASS_ATTRIB_NORAMP			11
-#define BASS_ATTRIB_BITRATE			12
-#define BASS_ATTRIB_BUFFER			13
-#define BASS_ATTRIB_GRANULE			14
-#define BASS_ATTRIB_USER			15
-#define BASS_ATTRIB_TAIL			16
-#define BASS_ATTRIB_PUSH_LIMIT		17
-#define BASS_ATTRIB_DOWNLOADPROC	18
-#define BASS_ATTRIB_VOLDSP			19
-#define BASS_ATTRIB_VOLDSP_PRIORITY	20
-#define BASS_ATTRIB_MUSIC_AMPLIFY	0x100
-#define BASS_ATTRIB_MUSIC_PANSEP	0x101
-#define BASS_ATTRIB_MUSIC_PSCALER	0x102
-#define BASS_ATTRIB_MUSIC_BPM		0x103
-#define BASS_ATTRIB_MUSIC_SPEED		0x104
+#define BASS_ATTRIB_FREQ 1
+#define BASS_ATTRIB_VOL 2
+#define BASS_ATTRIB_PAN 3
+#define BASS_ATTRIB_EAXMIX 4
+#define BASS_ATTRIB_NOBUFFER 5
+#define BASS_ATTRIB_VBR 6
+#define BASS_ATTRIB_CPU 7
+#define BASS_ATTRIB_SRC 8
+#define BASS_ATTRIB_NET_RESUME 9
+#define BASS_ATTRIB_SCANINFO 10
+#define BASS_ATTRIB_NORAMP 11
+#define BASS_ATTRIB_BITRATE 12
+#define BASS_ATTRIB_BUFFER 13
+#define BASS_ATTRIB_GRANULE 14
+#define BASS_ATTRIB_USER 15
+#define BASS_ATTRIB_TAIL 16
+#define BASS_ATTRIB_PUSH_LIMIT 17
+#define BASS_ATTRIB_DOWNLOADPROC 18
+#define BASS_ATTRIB_VOLDSP 19
+#define BASS_ATTRIB_VOLDSP_PRIORITY 20
+#define BASS_ATTRIB_MUSIC_AMPLIFY 0x100
+#define BASS_ATTRIB_MUSIC_PANSEP 0x101
+#define BASS_ATTRIB_MUSIC_PSCALER 0x102
+#define BASS_ATTRIB_MUSIC_BPM 0x103
+#define BASS_ATTRIB_MUSIC_SPEED 0x104
 #define BASS_ATTRIB_MUSIC_VOL_GLOBAL 0x105
-#define BASS_ATTRIB_MUSIC_ACTIVE	0x106
-#define BASS_ATTRIB_MUSIC_VOL_CHAN	0x200 // + channel #
-#define BASS_ATTRIB_MUSIC_VOL_INST	0x300 // + instrument #
+#define BASS_ATTRIB_MUSIC_ACTIVE 0x106
+#define BASS_ATTRIB_MUSIC_VOL_CHAN 0x200 // + channel #
+#define BASS_ATTRIB_MUSIC_VOL_INST 0x300 // + instrument #
 
 // BASS_ChannelSlideAttribute flags
-#define BASS_SLIDE_LOG				0x1000000
+#define BASS_SLIDE_LOG 0x1000000
 
 // BASS_ChannelGetData flags
-#define BASS_DATA_AVAILABLE	0			// query how much data is buffered
-#define BASS_DATA_NOREMOVE	0x10000000	// flag: don't remove data from recording buffer
-#define BASS_DATA_FIXED		0x20000000	// unused
-#define BASS_DATA_FLOAT		0x40000000	// flag: return floating-point sample data
-#define BASS_DATA_FFT256	0x80000000	// 256 sample FFT
-#define BASS_DATA_FFT512	0x80000001	// 512 FFT
-#define BASS_DATA_FFT1024	0x80000002	// 1024 FFT
-#define BASS_DATA_FFT2048	0x80000003	// 2048 FFT
-#define BASS_DATA_FFT4096	0x80000004	// 4096 FFT
-#define BASS_DATA_FFT8192	0x80000005	// 8192 FFT
-#define BASS_DATA_FFT16384	0x80000006	// 16384 FFT
-#define BASS_DATA_FFT32768	0x80000007	// 32768 FFT
-#define BASS_DATA_FFT_INDIVIDUAL 0x10	// FFT flag: FFT for each channel, else all combined
-#define BASS_DATA_FFT_NOWINDOW	0x20	// FFT flag: no Hanning window
-#define BASS_DATA_FFT_REMOVEDC	0x40	// FFT flag: pre-remove DC bias
-#define BASS_DATA_FFT_COMPLEX	0x80	// FFT flag: return complex data
-#define BASS_DATA_FFT_NYQUIST	0x100	// FFT flag: return extra Nyquist value
+#define BASS_DATA_AVAILABLE 0 // query how much data is buffered
+#define BASS_DATA_NOREMOVE                                                     \
+  0x10000000 // flag: don't remove data from recording buffer
+#define BASS_DATA_FIXED 0x20000000    // unused
+#define BASS_DATA_FLOAT 0x40000000    // flag: return floating-point sample data
+#define BASS_DATA_FFT256 0x80000000   // 256 sample FFT
+#define BASS_DATA_FFT512 0x80000001   // 512 FFT
+#define BASS_DATA_FFT1024 0x80000002  // 1024 FFT
+#define BASS_DATA_FFT2048 0x80000003  // 2048 FFT
+#define BASS_DATA_FFT4096 0x80000004  // 4096 FFT
+#define BASS_DATA_FFT8192 0x80000005  // 8192 FFT
+#define BASS_DATA_FFT16384 0x80000006 // 16384 FFT
+#define BASS_DATA_FFT32768 0x80000007 // 32768 FFT
+#define BASS_DATA_FFT_INDIVIDUAL                                               \
+  0x10 // FFT flag: FFT for each channel, else all combined
+#define BASS_DATA_FFT_NOWINDOW 0x20 // FFT flag: no Hanning window
+#define BASS_DATA_FFT_REMOVEDC 0x40 // FFT flag: pre-remove DC bias
+#define BASS_DATA_FFT_COMPLEX 0x80  // FFT flag: return complex data
+#define BASS_DATA_FFT_NYQUIST 0x100 // FFT flag: return extra Nyquist value
 
 // BASS_ChannelGetLevelEx flags
-#define BASS_LEVEL_MONO		1	// get mono level
-#define BASS_LEVEL_STEREO	2	// get stereo level
-#define BASS_LEVEL_RMS		4	// get RMS levels
-#define BASS_LEVEL_VOLPAN	8	// apply VOL/PAN attributes to the levels
-#define BASS_LEVEL_NOREMOVE	0x10	// don't remove data from recording buffer
+#define BASS_LEVEL_MONO 1        // get mono level
+#define BASS_LEVEL_STEREO 2      // get stereo level
+#define BASS_LEVEL_RMS 4         // get RMS levels
+#define BASS_LEVEL_VOLPAN 8      // apply VOL/PAN attributes to the levels
+#define BASS_LEVEL_NOREMOVE 0x10 // don't remove data from recording buffer
 
 // BASS_ChannelGetTags types : what's returned
-#define BASS_TAG_ID3		0	// ID3v1 tags : TAG_ID3 structure
-#define BASS_TAG_ID3V2		1	// ID3v2 tags : variable length block
-#define BASS_TAG_OGG		2	// OGG comments : series of null-terminated UTF-8 strings
-#define BASS_TAG_HTTP		3	// HTTP headers : series of null-terminated ASCII strings
-#define BASS_TAG_ICY		4	// ICY headers : series of null-terminated ANSI strings
-#define BASS_TAG_META		5	// ICY metadata : ANSI string
-#define BASS_TAG_APE		6	// APE tags : series of null-terminated UTF-8 strings
-#define BASS_TAG_MP4 		7	// MP4/iTunes metadata : series of null-terminated UTF-8 strings
-#define BASS_TAG_WMA		8	// WMA tags : series of null-terminated UTF-8 strings
-#define BASS_TAG_VENDOR		9	// OGG encoder : UTF-8 string
-#define BASS_TAG_LYRICS3	10	// Lyric3v2 tag : ASCII string
-#define BASS_TAG_CA_CODEC	11	// CoreAudio codec info : TAG_CA_CODEC structure
-#define BASS_TAG_MF			13	// Media Foundation tags : series of null-terminated UTF-8 strings
-#define BASS_TAG_WAVEFORMAT	14	// WAVE format : WAVEFORMATEEX structure
-#define BASS_TAG_AM_NAME	16	// Android Media codec name : ASCII string
-#define BASS_TAG_ID3V2_2	17	// ID3v2 tags (2nd block) : variable length block
-#define BASS_TAG_AM_MIME	18	// Android Media MIME type : ASCII string
-#define BASS_TAG_LOCATION	19	// redirected URL : ASCII string
-#define BASS_TAG_ID3V2_BINARY	20	// ID3v2 tags : TAB_BINARY
-#define BASS_TAG_ID3V2_2_BINARY	21	// ID3v2 tags (2nd block) : TAB_BINARY
-#define BASS_TAG_RIFF_INFO	0x100 // RIFF "INFO" tags : series of null-terminated ANSI strings
-#define BASS_TAG_RIFF_BEXT	0x101 // RIFF/BWF "bext" tags : TAG_BEXT structure
-#define BASS_TAG_RIFF_CART	0x102 // RIFF/BWF "cart" tags : TAG_CART structure
-#define BASS_TAG_RIFF_DISP	0x103 // RIFF "DISP" text tag : ANSI string
-#define BASS_TAG_RIFF_CUE	0x104 // RIFF "cue " chunk : TAG_CUE structure
-#define BASS_TAG_RIFF_SMPL	0x105 // RIFF "smpl" chunk : TAG_SMPL structure
-#define BASS_TAG_APE_BINARY	0x1000	// + index #, binary APE tag : TAG_APE_BINARY structure
-#define BASS_TAG_MP4_COVERART	0x1400 // + index #, MP4 cover art : TAG_BINARY structure
-#define BASS_TAG_MUSIC_NAME		0x10000	// MOD music name : ANSI string
-#define BASS_TAG_MUSIC_MESSAGE	0x10001	// MOD message : ANSI string
-#define BASS_TAG_MUSIC_ORDERS	0x10002	// MOD order list : BYTE array of pattern numbers
-#define BASS_TAG_MUSIC_AUTH		0x10003	// MOD author : UTF-8 string
-#define BASS_TAG_MUSIC_INST		0x10100	// + instrument #, MOD instrument name : ANSI string
-#define BASS_TAG_MUSIC_CHAN		0x10200	// + channel #, MOD channel name : ANSI string
-#define BASS_TAG_MUSIC_SAMPLE	0x10300	// + sample #, MOD sample name : ANSI string
-#define BASS_TAG_INCREF		0x20000000 // flag: increment channel's reference count
+#define BASS_TAG_ID3 0   // ID3v1 tags : TAG_ID3 structure
+#define BASS_TAG_ID3V2 1 // ID3v2 tags : variable length block
+#define BASS_TAG_OGG 2 // OGG comments : series of null-terminated UTF-8 strings
+#define BASS_TAG_HTTP                                                          \
+  3                    // HTTP headers : series of null-terminated ASCII strings
+#define BASS_TAG_ICY 4 // ICY headers : series of null-terminated ANSI strings
+#define BASS_TAG_META 5 // ICY metadata : ANSI string
+#define BASS_TAG_APE 6  // APE tags : series of null-terminated UTF-8 strings
+#define BASS_TAG_MP4                                                           \
+  7 // MP4/iTunes metadata : series of null-terminated UTF-8 strings
+#define BASS_TAG_WMA 8    // WMA tags : series of null-terminated UTF-8 strings
+#define BASS_TAG_VENDOR 9 // OGG encoder : UTF-8 string
+#define BASS_TAG_LYRICS3 10  // Lyric3v2 tag : ASCII string
+#define BASS_TAG_CA_CODEC 11 // CoreAudio codec info : TAG_CA_CODEC structure
+#define BASS_TAG_MF                                                            \
+  13 // Media Foundation tags : series of null-terminated UTF-8 strings
+#define BASS_TAG_WAVEFORMAT 14 // WAVE format : WAVEFORMATEEX structure
+#define BASS_TAG_AM_NAME 16    // Android Media codec name : ASCII string
+#define BASS_TAG_ID3V2_2 17    // ID3v2 tags (2nd block) : variable length block
+#define BASS_TAG_AM_MIME 18    // Android Media MIME type : ASCII string
+#define BASS_TAG_LOCATION 19   // redirected URL : ASCII string
+#define BASS_TAG_ID3V2_BINARY 20   // ID3v2 tags : TAB_BINARY
+#define BASS_TAG_ID3V2_2_BINARY 21 // ID3v2 tags (2nd block) : TAB_BINARY
+#define BASS_TAG_RIFF_INFO                                                     \
+  0x100 // RIFF "INFO" tags : series of null-terminated ANSI strings
+#define BASS_TAG_RIFF_BEXT 0x101 // RIFF/BWF "bext" tags : TAG_BEXT structure
+#define BASS_TAG_RIFF_CART 0x102 // RIFF/BWF "cart" tags : TAG_CART structure
+#define BASS_TAG_RIFF_DISP 0x103 // RIFF "DISP" text tag : ANSI string
+#define BASS_TAG_RIFF_CUE 0x104  // RIFF "cue " chunk : TAG_CUE structure
+#define BASS_TAG_RIFF_SMPL 0x105 // RIFF "smpl" chunk : TAG_SMPL structure
+#define BASS_TAG_APE_BINARY                                                    \
+  0x1000 // + index #, binary APE tag : TAG_APE_BINARY structure
+#define BASS_TAG_MP4_COVERART                                                  \
+  0x1400 // + index #, MP4 cover art : TAG_BINARY structure
+#define BASS_TAG_MUSIC_NAME 0x10000    // MOD music name : ANSI string
+#define BASS_TAG_MUSIC_MESSAGE 0x10001 // MOD message : ANSI string
+#define BASS_TAG_MUSIC_ORDERS                                                  \
+  0x10002 // MOD order list : BYTE array of pattern numbers
+#define BASS_TAG_MUSIC_AUTH 0x10003 // MOD author : UTF-8 string
+#define BASS_TAG_MUSIC_INST                                                    \
+  0x10100 // + instrument #, MOD instrument name : ANSI string
+#define BASS_TAG_MUSIC_CHAN                                                    \
+  0x10200 // + channel #, MOD channel name : ANSI string
+#define BASS_TAG_MUSIC_SAMPLE                                                  \
+  0x10300                          // + sample #, MOD sample name : ANSI string
+#define BASS_TAG_INCREF 0x20000000 // flag: increment channel's reference count
 
 // ID3v1 tag structure
 typedef struct {
-	char id[3];
-	char title[30];
-	char artist[30];
-	char album[30];
-	char year[4];
-	char comment[30];
-	BYTE genre;
+  char id[3];
+  char title[30];
+  char artist[30];
+  char album[30];
+  char year[4];
+  char comment[30];
+  BYTE genre;
 } TAG_ID3;
 
 // Binary tag structure
 typedef struct {
-	const void *data;
-	DWORD length;
+  const void *data;
+  DWORD length;
 } TAG_BINARY;
 
 // Binary APE tag structure
 typedef struct {
-	const char *key;
-	const void *data;
-	DWORD length;
+  const char *key;
+  const void *data;
+  DWORD length;
 } TAG_APE_BINARY;
 
 // BWF "bext" tag structure
 #ifdef _MSC_VER
 #pragma warning(push)
-#pragma warning(disable:4200)
+#pragma warning(disable : 4200)
 #endif
-#pragma pack(push,1)
+#pragma pack(push, 1)
 typedef struct {
-	char Description[256];			// description
-	char Originator[32];			// name of the originator
-	char OriginatorReference[32];	// reference of the originator
-	char OriginationDate[10];		// date of creation (yyyy-mm-dd)
-	char OriginationTime[8];		// time of creation (hh-mm-ss)
-	QWORD TimeReference;			// first sample count since midnight (little-endian)
-	WORD Version;					// BWF version (little-endian)
-	BYTE UMID[64];					// SMPTE UMID
-	BYTE Reserved[190];
-#if defined(__GNUC__) && __GNUC__<3
-	char CodingHistory[0];			// history
-#elif 1 // change to 0 if compiler fails the following line
-	char CodingHistory[];			// history
+  char Description[256];        // description
+  char Originator[32];          // name of the originator
+  char OriginatorReference[32]; // reference of the originator
+  char OriginationDate[10];     // date of creation (yyyy-mm-dd)
+  char OriginationTime[8];      // time of creation (hh-mm-ss)
+  QWORD TimeReference; // first sample count since midnight (little-endian)
+  WORD Version;        // BWF version (little-endian)
+  BYTE UMID[64];       // SMPTE UMID
+  BYTE Reserved[190];
+#if defined(__GNUC__) && __GNUC__ < 3
+  char CodingHistory[0]; // history
+#elif 1                  // change to 0 if compiler fails the following line
+  char CodingHistory[]; // history
 #else
-	char CodingHistory[1];			// history
+  char CodingHistory[1]; // history
 #endif
 } TAG_BEXT;
 #pragma pack(pop)
 
 // BWF "cart" tag structures
-typedef struct
-{
-	DWORD dwUsage;					// FOURCC timer usage ID
-	DWORD dwValue;					// timer value in samples from head
+typedef struct {
+  DWORD dwUsage; // FOURCC timer usage ID
+  DWORD dwValue; // timer value in samples from head
 } TAG_CART_TIMER;
 
-typedef struct
-{
-	char Version[4];				// version of the data structure
-	char Title[64];					// title of cart audio sequence
-	char Artist[64];				// artist or creator name
-	char CutID[64];					// cut number identification
-	char ClientID[64];				// client identification
-	char Category[64];				// category ID, PSA, NEWS, etc
-	char Classification[64];		// classification or auxiliary key
-	char OutCue[64];				// out cue text
-	char StartDate[10];				// yyyy-mm-dd
-	char StartTime[8];				// hh:mm:ss
-	char EndDate[10];				// yyyy-mm-dd
-	char EndTime[8];				// hh:mm:ss
-	char ProducerAppID[64];			// name of vendor or application
-	char ProducerAppVersion[64];	// version of producer application
-	char UserDef[64];				// user defined text
-	DWORD dwLevelReference;			// sample value for 0 dB reference
-	TAG_CART_TIMER PostTimer[8];	// 8 time markers after head
-	char Reserved[276];
-	char URL[1024];					// uniform resource locator
-#if defined(__GNUC__) && __GNUC__<3
-	char TagText[0];				// free form text for scripts or tags
-#elif 1 // change to 0 if compiler fails the following line
-	char TagText[];					// free form text for scripts or tags
+typedef struct {
+  char Version[4];             // version of the data structure
+  char Title[64];              // title of cart audio sequence
+  char Artist[64];             // artist or creator name
+  char CutID[64];              // cut number identification
+  char ClientID[64];           // client identification
+  char Category[64];           // category ID, PSA, NEWS, etc
+  char Classification[64];     // classification or auxiliary key
+  char OutCue[64];             // out cue text
+  char StartDate[10];          // yyyy-mm-dd
+  char StartTime[8];           // hh:mm:ss
+  char EndDate[10];            // yyyy-mm-dd
+  char EndTime[8];             // hh:mm:ss
+  char ProducerAppID[64];      // name of vendor or application
+  char ProducerAppVersion[64]; // version of producer application
+  char UserDef[64];            // user defined text
+  DWORD dwLevelReference;      // sample value for 0 dB reference
+  TAG_CART_TIMER PostTimer[8]; // 8 time markers after head
+  char Reserved[276];
+  char URL[1024]; // uniform resource locator
+#if defined(__GNUC__) && __GNUC__ < 3
+  char TagText[0]; // free form text for scripts or tags
+#elif 1            // change to 0 if compiler fails the following line
+  char TagText[]; // free form text for scripts or tags
 #else
-	char TagText[1];				// free form text for scripts or tags
+  char TagText[1]; // free form text for scripts or tags
 #endif
 } TAG_CART;
 
 // RIFF "cue " tag structures
-typedef struct
-{
-	DWORD dwName;
-	DWORD dwPosition;
-	DWORD fccChunk;
-	DWORD dwChunkStart;
-	DWORD dwBlockStart;
-	DWORD dwSampleOffset;
+typedef struct {
+  DWORD dwName;
+  DWORD dwPosition;
+  DWORD fccChunk;
+  DWORD dwChunkStart;
+  DWORD dwBlockStart;
+  DWORD dwSampleOffset;
 } TAG_CUE_POINT;
 
-typedef struct
-{
-	DWORD dwCuePoints;
-#if defined(__GNUC__) && __GNUC__<3
-	TAG_CUE_POINT CuePoints[0];
+typedef struct {
+  DWORD dwCuePoints;
+#if defined(__GNUC__) && __GNUC__ < 3
+  TAG_CUE_POINT CuePoints[0];
 #elif 1 // change to 0 if compiler fails the following line
-	TAG_CUE_POINT CuePoints[];
+  TAG_CUE_POINT CuePoints[];
 #else
-	TAG_CUE_POINT CuePoints[1];
+  TAG_CUE_POINT CuePoints[1];
 #endif
 } TAG_CUE;
 
 // RIFF "smpl" tag structures
-typedef struct
-{
-	DWORD dwIdentifier;
-	DWORD dwType;
-	DWORD dwStart;
-	DWORD dwEnd;
-	DWORD dwFraction;
-	DWORD dwPlayCount;
+typedef struct {
+  DWORD dwIdentifier;
+  DWORD dwType;
+  DWORD dwStart;
+  DWORD dwEnd;
+  DWORD dwFraction;
+  DWORD dwPlayCount;
 } TAG_SMPL_LOOP;
 
-typedef struct
-{
-	DWORD dwManufacturer;
-	DWORD dwProduct;
-	DWORD dwSamplePeriod;
-	DWORD dwMIDIUnityNote;
-	DWORD dwMIDIPitchFraction;
-	DWORD dwSMPTEFormat;
-	DWORD dwSMPTEOffset;
-	DWORD cSampleLoops;
-	DWORD cbSamplerData;
-#if defined(__GNUC__) && __GNUC__<3
-	TAG_SMPL_LOOP SampleLoops[0];
+typedef struct {
+  DWORD dwManufacturer;
+  DWORD dwProduct;
+  DWORD dwSamplePeriod;
+  DWORD dwMIDIUnityNote;
+  DWORD dwMIDIPitchFraction;
+  DWORD dwSMPTEFormat;
+  DWORD dwSMPTEOffset;
+  DWORD cSampleLoops;
+  DWORD cbSamplerData;
+#if defined(__GNUC__) && __GNUC__ < 3
+  TAG_SMPL_LOOP SampleLoops[0];
 #elif 1 // change to 0 if compiler fails the following line
-	TAG_SMPL_LOOP SampleLoops[];
+  TAG_SMPL_LOOP SampleLoops[];
 #else
-	TAG_SMPL_LOOP SampleLoops[1];
+  TAG_SMPL_LOOP SampleLoops[1];
 #endif
 } TAG_SMPL;
 #ifdef _MSC_VER
@@ -843,180 +869,182 @@ typedef struct
 
 // CoreAudio codec info structure
 typedef struct {
-	DWORD ftype;					// file format
-	DWORD atype;					// audio format
-	const char *name;				// description
+  DWORD ftype;      // file format
+  DWORD atype;      // audio format
+  const char *name; // description
 } TAG_CA_CODEC;
 
 #ifndef _WAVEFORMATEX_
 #define _WAVEFORMATEX_
-#pragma pack(push,1)
-typedef struct tWAVEFORMATEX
-{
-	WORD wFormatTag;
-	WORD nChannels;
-	DWORD nSamplesPerSec;
-	DWORD nAvgBytesPerSec;
-	WORD nBlockAlign;
-	WORD wBitsPerSample;
-	WORD cbSize;
+#pragma pack(push, 1)
+typedef struct tWAVEFORMATEX {
+  WORD wFormatTag;
+  WORD nChannels;
+  DWORD nSamplesPerSec;
+  DWORD nAvgBytesPerSec;
+  WORD nBlockAlign;
+  WORD wBitsPerSample;
+  WORD cbSize;
 } WAVEFORMATEX, *PWAVEFORMATEX, *LPWAVEFORMATEX;
 typedef const WAVEFORMATEX *LPCWAVEFORMATEX;
 #pragma pack(pop)
 #endif
 
 // BASS_ChannelGetLength/GetPosition/SetPosition modes
-#define BASS_POS_BYTE			0		// byte position
-#define BASS_POS_MUSIC_ORDER	1		// order.row position, MAKELONG(order,row)
-#define BASS_POS_OGG			3		// OGG bitstream number
-#define BASS_POS_RAW			6		// monotonic byte position
-#define BASS_POS_END			0x10	// trimmed end position
-#define BASS_POS_LOOP			0x11	// loop start positiom
-#define BASS_POS_FLUSH			0x1000000 // flag: flush decoder/FX buffers
-#define BASS_POS_RESET			0x2000000 // flag: reset user file buffers
-#define BASS_POS_RELATIVE		0x4000000 // flag: seek relative to the current position
-#define BASS_POS_INEXACT		0x8000000 // flag: allow seeking to inexact position
-#define BASS_POS_DECODE			0x10000000 // flag: get the decoding (not playing) position
-#define BASS_POS_DECODETO		0x20000000 // flag: decode to the position instead of seeking
-#define BASS_POS_SCAN			0x40000000 // flag: scan to the position
+#define BASS_POS_BYTE 0          // byte position
+#define BASS_POS_MUSIC_ORDER 1   // order.row position, MAKELONG(order,row)
+#define BASS_POS_OGG 3           // OGG bitstream number
+#define BASS_POS_RAW 6           // monotonic byte position
+#define BASS_POS_END 0x10        // trimmed end position
+#define BASS_POS_LOOP 0x11       // loop start positiom
+#define BASS_POS_FLUSH 0x1000000 // flag: flush decoder/FX buffers
+#define BASS_POS_RESET 0x2000000 // flag: reset user file buffers
+#define BASS_POS_RELATIVE                                                      \
+  0x4000000 // flag: seek relative to the current position
+#define BASS_POS_INEXACT 0x8000000 // flag: allow seeking to inexact position
+#define BASS_POS_DECODE                                                        \
+  0x10000000 // flag: get the decoding (not playing) position
+#define BASS_POS_DECODETO                                                      \
+  0x20000000 // flag: decode to the position instead of seeking
+#define BASS_POS_SCAN 0x40000000 // flag: scan to the position
 
 // BASS_ChannelSetDevice/GetDevice option
-#define BASS_NODEVICE		0x20000
+#define BASS_NODEVICE 0x20000
 
 // BASS_RecordSetInput flags
-#define BASS_INPUT_OFF		0x10000
-#define BASS_INPUT_ON		0x20000
+#define BASS_INPUT_OFF 0x10000
+#define BASS_INPUT_ON 0x20000
 
-#define BASS_INPUT_TYPE_MASK		0xff000000
-#define BASS_INPUT_TYPE_UNDEF		0x00000000
-#define BASS_INPUT_TYPE_DIGITAL		0x01000000
-#define BASS_INPUT_TYPE_LINE		0x02000000
-#define BASS_INPUT_TYPE_MIC			0x03000000
-#define BASS_INPUT_TYPE_SYNTH		0x04000000
-#define BASS_INPUT_TYPE_CD			0x05000000
-#define BASS_INPUT_TYPE_PHONE		0x06000000
-#define BASS_INPUT_TYPE_SPEAKER		0x07000000
-#define BASS_INPUT_TYPE_WAVE		0x08000000
-#define BASS_INPUT_TYPE_AUX			0x09000000
-#define BASS_INPUT_TYPE_ANALOG		0x0a000000
+#define BASS_INPUT_TYPE_MASK 0xff000000
+#define BASS_INPUT_TYPE_UNDEF 0x00000000
+#define BASS_INPUT_TYPE_DIGITAL 0x01000000
+#define BASS_INPUT_TYPE_LINE 0x02000000
+#define BASS_INPUT_TYPE_MIC 0x03000000
+#define BASS_INPUT_TYPE_SYNTH 0x04000000
+#define BASS_INPUT_TYPE_CD 0x05000000
+#define BASS_INPUT_TYPE_PHONE 0x06000000
+#define BASS_INPUT_TYPE_SPEAKER 0x07000000
+#define BASS_INPUT_TYPE_WAVE 0x08000000
+#define BASS_INPUT_TYPE_AUX 0x09000000
+#define BASS_INPUT_TYPE_ANALOG 0x0a000000
 
 // BASS_ChannelSetDSPEx flags
-#define BASS_DSP_READONLY			1
-#define BASS_DSP_FLOAT				2
-#define BASS_DSP_FREECALL			4
-#define BASS_DSP_BYPASS				0x400000
-#define BASS_DSP_MONO_N(n)			((n)<<24)
-#define BASS_DSP_STEREO_N(n)		(BASS_DSP_MONO_N(n) | 0x800000)
+#define BASS_DSP_READONLY 1
+#define BASS_DSP_FLOAT 2
+#define BASS_DSP_FREECALL 4
+#define BASS_DSP_BYPASS 0x400000
+#define BASS_DSP_MONO_N(n) ((n) << 24)
+#define BASS_DSP_STEREO_N(n) (BASS_DSP_MONO_N(n) | 0x800000)
 
 // BASS_ChannelSetFX effect types
-#define BASS_FX_DX8_CHORUS			0
-#define BASS_FX_DX8_COMPRESSOR		1
-#define BASS_FX_DX8_DISTORTION		2
-#define BASS_FX_DX8_ECHO			3
-#define BASS_FX_DX8_FLANGER			4
-#define BASS_FX_DX8_GARGLE			5
-#define BASS_FX_DX8_I3DL2REVERB		6
-#define BASS_FX_DX8_PARAMEQ			7
-#define BASS_FX_DX8_REVERB			8
-#define BASS_FX_VOLUME				9
+#define BASS_FX_DX8_CHORUS 0
+#define BASS_FX_DX8_COMPRESSOR 1
+#define BASS_FX_DX8_DISTORTION 2
+#define BASS_FX_DX8_ECHO 3
+#define BASS_FX_DX8_FLANGER 4
+#define BASS_FX_DX8_GARGLE 5
+#define BASS_FX_DX8_I3DL2REVERB 6
+#define BASS_FX_DX8_PARAMEQ 7
+#define BASS_FX_DX8_REVERB 8
+#define BASS_FX_VOLUME 9
 
 typedef struct {
-	float       fWetDryMix;
-	float       fDepth;
-	float       fFeedback;
-	float       fFrequency;
-	DWORD       lWaveform;	// 0=triangle, 1=sine
-	float       fDelay;
-	DWORD       lPhase;		// BASS_DX8_PHASE_xxx
+  float fWetDryMix;
+  float fDepth;
+  float fFeedback;
+  float fFrequency;
+  DWORD lWaveform; // 0=triangle, 1=sine
+  float fDelay;
+  DWORD lPhase; // BASS_DX8_PHASE_xxx
 } BASS_DX8_CHORUS;
 
 typedef struct {
-	float   fGain;
-	float   fAttack;
-	float   fRelease;
-	float   fThreshold;
-	float   fRatio;
-	float   fPredelay;
+  float fGain;
+  float fAttack;
+  float fRelease;
+  float fThreshold;
+  float fRatio;
+  float fPredelay;
 } BASS_DX8_COMPRESSOR;
 
 typedef struct {
-	float   fGain;
-	float   fEdge;
-	float   fPostEQCenterFrequency;
-	float   fPostEQBandwidth;
-	float   fPreLowpassCutoff;
+  float fGain;
+  float fEdge;
+  float fPostEQCenterFrequency;
+  float fPostEQBandwidth;
+  float fPreLowpassCutoff;
 } BASS_DX8_DISTORTION;
 
 typedef struct {
-	float   fWetDryMix;
-	float   fFeedback;
-	float   fLeftDelay;
-	float   fRightDelay;
-	BOOL    lPanDelay;
+  float fWetDryMix;
+  float fFeedback;
+  float fLeftDelay;
+  float fRightDelay;
+  BOOL lPanDelay;
 } BASS_DX8_ECHO;
 
 typedef struct {
-	float       fWetDryMix;
-	float       fDepth;
-	float       fFeedback;
-	float       fFrequency;
-	DWORD       lWaveform;	// 0=triangle, 1=sine
-	float       fDelay;
-	DWORD       lPhase;		// BASS_DX8_PHASE_xxx
+  float fWetDryMix;
+  float fDepth;
+  float fFeedback;
+  float fFrequency;
+  DWORD lWaveform; // 0=triangle, 1=sine
+  float fDelay;
+  DWORD lPhase; // BASS_DX8_PHASE_xxx
 } BASS_DX8_FLANGER;
 
 typedef struct {
-	DWORD       dwRateHz;               // Rate of modulation in hz
-	DWORD       dwWaveShape;            // 0=triangle, 1=square
+  DWORD dwRateHz;    // Rate of modulation in hz
+  DWORD dwWaveShape; // 0=triangle, 1=square
 } BASS_DX8_GARGLE;
 
 typedef struct {
-	int     lRoom;                  // [-10000, 0]      default: -1000 mB
-	int     lRoomHF;                // [-10000, 0]      default: 0 mB
-	float   flRoomRolloffFactor;    // [0.0, 10.0]      default: 0.0
-	float   flDecayTime;            // [0.1, 20.0]      default: 1.49s
-	float   flDecayHFRatio;         // [0.1, 2.0]       default: 0.83
-	int     lReflections;           // [-10000, 1000]   default: -2602 mB
-	float   flReflectionsDelay;     // [0.0, 0.3]       default: 0.007 s
-	int     lReverb;                // [-10000, 2000]   default: 200 mB
-	float   flReverbDelay;          // [0.0, 0.1]       default: 0.011 s
-	float   flDiffusion;            // [0.0, 100.0]     default: 100.0 %
-	float   flDensity;              // [0.0, 100.0]     default: 100.0 %
-	float   flHFReference;          // [20.0, 20000.0]  default: 5000.0 Hz
+  int lRoom;                 // [-10000, 0]      default: -1000 mB
+  int lRoomHF;               // [-10000, 0]      default: 0 mB
+  float flRoomRolloffFactor; // [0.0, 10.0]      default: 0.0
+  float flDecayTime;         // [0.1, 20.0]      default: 1.49s
+  float flDecayHFRatio;      // [0.1, 2.0]       default: 0.83
+  int lReflections;          // [-10000, 1000]   default: -2602 mB
+  float flReflectionsDelay;  // [0.0, 0.3]       default: 0.007 s
+  int lReverb;               // [-10000, 2000]   default: 200 mB
+  float flReverbDelay;       // [0.0, 0.1]       default: 0.011 s
+  float flDiffusion;         // [0.0, 100.0]     default: 100.0 %
+  float flDensity;           // [0.0, 100.0]     default: 100.0 %
+  float flHFReference;       // [20.0, 20000.0]  default: 5000.0 Hz
 } BASS_DX8_I3DL2REVERB;
 
 typedef struct {
-	float   fCenter;
-	float   fBandwidth;
-	float   fGain;
+  float fCenter;
+  float fBandwidth;
+  float fGain;
 } BASS_DX8_PARAMEQ;
 
 typedef struct {
-	float   fInGain;                // [-96.0,0.0]            default: 0.0 dB
-	float   fReverbMix;             // [-96.0,0.0]            default: 0.0 db
-	float   fReverbTime;            // [0.001,3000.0]         default: 1000.0 ms
-	float   fHighFreqRTRatio;       // [0.001,0.999]          default: 0.001
+  float fInGain;          // [-96.0,0.0]            default: 0.0 dB
+  float fReverbMix;       // [-96.0,0.0]            default: 0.0 db
+  float fReverbTime;      // [0.001,3000.0]         default: 1000.0 ms
+  float fHighFreqRTRatio; // [0.001,0.999]          default: 0.001
 } BASS_DX8_REVERB;
 
-#define BASS_DX8_PHASE_NEG_180        0
-#define BASS_DX8_PHASE_NEG_90         1
-#define BASS_DX8_PHASE_ZERO           2
-#define BASS_DX8_PHASE_90             3
-#define BASS_DX8_PHASE_180            4
+#define BASS_DX8_PHASE_NEG_180 0
+#define BASS_DX8_PHASE_NEG_90 1
+#define BASS_DX8_PHASE_ZERO 2
+#define BASS_DX8_PHASE_90 3
+#define BASS_DX8_PHASE_180 4
 
 typedef struct {
-	float fTarget;
-	float fCurrent;
-	float fTime;
-	DWORD lCurve;
+  float fTarget;
+  float fCurrent;
+  float fTime;
+  DWORD lCurve;
 } BASS_FX_VOLUME_PARAM;
 
-typedef void (CALLBACK IOSNOTIFYPROC)(DWORD status);
+typedef void(CALLBACK IOSNOTIFYPROC)(DWORD status);
 /* iOS notification callback function.
 status : The notification (BASS_IOSNOTIFY_xxx) */
 
-#define BASS_IOSNOTIFY_INTERRUPT		1	// interruption started
-#define BASS_IOSNOTIFY_INTERRUPT_END	2	// interruption ended
+#define BASS_IOSNOTIFY_INTERRUPT 1     // interruption started
+#define BASS_IOSNOTIFY_INTERRUPT_END 2 // interruption ended
 
 BOOL BASSDEF(BASS_SetConfig)(DWORD option, DWORD value);
 DWORD BASSDEF(BASS_GetConfig)(DWORD option);
@@ -1026,10 +1054,13 @@ DWORD BASSDEF(BASS_GetVersion)(void);
 int BASSDEF(BASS_ErrorGetCode)(void);
 
 BOOL BASSDEF(BASS_GetDeviceInfo)(DWORD device, BASS_DEVICEINFO *info);
-#if defined(_WIN32) && !defined(_WIN32_WCE) && !(defined(WINAPI_FAMILY) && WINAPI_FAMILY != WINAPI_FAMILY_DESKTOP_APP)
-BOOL BASSDEF(BASS_Init)(int device, DWORD freq, DWORD flags, HWND win, const void *dsguid);
+#if defined(_WIN32) && !defined(_WIN32_WCE) &&                                 \
+    !(defined(WINAPI_FAMILY) && WINAPI_FAMILY != WINAPI_FAMILY_DESKTOP_APP)
+BOOL BASSDEF(BASS_Init)(int device, DWORD freq, DWORD flags, HWND win,
+                        const void *dsguid);
 #else
-BOOL BASSDEF(BASS_Init)(int device, DWORD freq, DWORD flags, void *win, const void *dsguid);
+BOOL BASSDEF(BASS_Init)(int device, DWORD freq, DWORD flags, void *win,
+                        const void *dsguid);
 #endif
 BOOL BASSDEF(BASS_Free)(void);
 BOOL BASSDEF(BASS_SetDevice)(DWORD device);
@@ -1043,14 +1074,19 @@ BOOL BASSDEF(BASS_Update)(DWORD length);
 float BASSDEF(BASS_GetCPU)(void);
 BOOL BASSDEF(BASS_SetVolume)(float volume);
 float BASSDEF(BASS_GetVolume)(void);
-#if defined(_WIN32) && !defined(_WIN32_WCE) && !(defined(WINAPI_FAMILY) && WINAPI_FAMILY != WINAPI_FAMILY_DESKTOP_APP)
+#if defined(_WIN32) && !defined(_WIN32_WCE) &&                                 \
+    !(defined(WINAPI_FAMILY) && WINAPI_FAMILY != WINAPI_FAMILY_DESKTOP_APP)
 void *BASSDEF(BASS_GetDSoundObject)(DWORD object);
 #endif
 
 BOOL BASSDEF(BASS_Set3DFactors)(float distf, float rollf, float doppf);
 BOOL BASSDEF(BASS_Get3DFactors)(float *distf, float *rollf, float *doppf);
-BOOL BASSDEF(BASS_Set3DPosition)(const BASS_3DVECTOR *pos, const BASS_3DVECTOR *vel, const BASS_3DVECTOR *front, const BASS_3DVECTOR *top);
-BOOL BASSDEF(BASS_Get3DPosition)(BASS_3DVECTOR *pos, BASS_3DVECTOR *vel, BASS_3DVECTOR *front, BASS_3DVECTOR *top);
+BOOL BASSDEF(BASS_Set3DPosition)(const BASS_3DVECTOR *pos,
+                                 const BASS_3DVECTOR *vel,
+                                 const BASS_3DVECTOR *front,
+                                 const BASS_3DVECTOR *top);
+BOOL BASSDEF(BASS_Get3DPosition)(BASS_3DVECTOR *pos, BASS_3DVECTOR *vel,
+                                 BASS_3DVECTOR *front, BASS_3DVECTOR *top);
 void BASSDEF(BASS_Apply3D)(void);
 
 HPLUGIN BASSDEF(BASS_PluginLoad)(const char *file, DWORD flags);
@@ -1058,8 +1094,10 @@ BOOL BASSDEF(BASS_PluginFree)(HPLUGIN handle);
 BOOL BASSDEF(BASS_PluginEnable)(HPLUGIN handle, BOOL enable);
 const BASS_PLUGININFO *BASSDEF(BASS_PluginGetInfo)(HPLUGIN handle);
 
-HSAMPLE BASSDEF(BASS_SampleLoad)(DWORD filetype, const void *file, QWORD offset, DWORD length, DWORD max, DWORD flags);
-HSAMPLE BASSDEF(BASS_SampleCreate)(DWORD length, DWORD freq, DWORD chans, DWORD max, DWORD flags);
+HSAMPLE BASSDEF(BASS_SampleLoad)(DWORD filetype, const void *file, QWORD offset,
+                                 DWORD length, DWORD max, DWORD flags);
+HSAMPLE BASSDEF(BASS_SampleCreate)(DWORD length, DWORD freq, DWORD chans,
+                                   DWORD max, DWORD flags);
 BOOL BASSDEF(BASS_SampleFree)(HSAMPLE handle);
 BOOL BASSDEF(BASS_SampleSetData)(HSAMPLE handle, const void *buffer);
 BOOL BASSDEF(BASS_SampleGetData)(HSAMPLE handle, void *buffer);
@@ -1069,17 +1107,26 @@ DWORD BASSDEF(BASS_SampleGetChannel)(HSAMPLE handle, DWORD flags);
 DWORD BASSDEF(BASS_SampleGetChannels)(HSAMPLE handle, HCHANNEL *channels);
 BOOL BASSDEF(BASS_SampleStop)(HSAMPLE handle);
 
-HSTREAM BASSDEF(BASS_StreamCreate)(DWORD freq, DWORD chans, DWORD flags, STREAMPROC *proc, void *user);
-HSTREAM BASSDEF(BASS_StreamCreateFile)(DWORD filetype, const void *file, QWORD offset, QWORD length, DWORD flags);
-HSTREAM BASSDEF(BASS_StreamCreateURL)(const char *url, DWORD offset, DWORD flags, DOWNLOADPROC *proc, void *user);
-HSTREAM BASSDEF(BASS_StreamCreateFileUser)(DWORD system, DWORD flags, const BASS_FILEPROCS *proc, void *user);
+HSTREAM BASSDEF(BASS_StreamCreate)(DWORD freq, DWORD chans, DWORD flags,
+                                   STREAMPROC *proc, void *user);
+HSTREAM BASSDEF(BASS_StreamCreateFile)(DWORD filetype, const void *file,
+                                       QWORD offset, QWORD length, DWORD flags);
+HSTREAM BASSDEF(BASS_StreamCreateURL)(const char *url, DWORD offset,
+                                      DWORD flags, DOWNLOADPROC *proc,
+                                      void *user);
+HSTREAM BASSDEF(BASS_StreamCreateFileUser)(DWORD system, DWORD flags,
+                                           const BASS_FILEPROCS *proc,
+                                           void *user);
 BOOL BASSDEF(BASS_StreamCancel)(void *user);
 BOOL BASSDEF(BASS_StreamFree)(HSTREAM handle);
 QWORD BASSDEF(BASS_StreamGetFilePosition)(HSTREAM handle, DWORD mode);
-DWORD BASSDEF(BASS_StreamPutData)(HSTREAM handle, const void *buffer, DWORD length);
-DWORD BASSDEF(BASS_StreamPutFileData)(HSTREAM handle, const void *buffer, DWORD length);
+DWORD BASSDEF(BASS_StreamPutData)(HSTREAM handle, const void *buffer,
+                                  DWORD length);
+DWORD BASSDEF(BASS_StreamPutFileData)(HSTREAM handle, const void *buffer,
+                                      DWORD length);
 
-HMUSIC BASSDEF(BASS_MusicLoad)(DWORD filetype, const void *file, QWORD offset, DWORD length, DWORD flags, DWORD freq);
+HMUSIC BASSDEF(BASS_MusicLoad)(DWORD filetype, const void *file, QWORD offset,
+                               DWORD length, DWORD flags, DWORD freq);
 BOOL BASSDEF(BASS_MusicFree)(HMUSIC handle);
 
 BOOL BASSDEF(BASS_RecordGetDeviceInfo)(DWORD device, BASS_DEVICEINFO *info);
@@ -1091,7 +1138,8 @@ BOOL BASSDEF(BASS_RecordGetInfo)(BASS_RECORDINFO *info);
 const char *BASSDEF(BASS_RecordGetInputName)(int input);
 BOOL BASSDEF(BASS_RecordSetInput)(int input, DWORD flags, float volume);
 DWORD BASSDEF(BASS_RecordGetInput)(int input, float *volume);
-HRECORD BASSDEF(BASS_RecordStart)(DWORD freq, DWORD chans, DWORD flags, RECORDPROC *proc, void *user);
+HRECORD BASSDEF(BASS_RecordStart)(DWORD freq, DWORD chans, DWORD flags,
+                                  RECORDPROC *proc, void *user);
 
 double BASSDEF(BASS_ChannelBytes2Seconds)(DWORD handle, QWORD pos);
 QWORD BASSDEF(BASS_ChannelSeconds2Bytes)(DWORD handle, double pos);
@@ -1110,27 +1158,43 @@ BOOL BASSDEF(BASS_ChannelStop)(DWORD handle);
 BOOL BASSDEF(BASS_ChannelPause)(DWORD handle);
 BOOL BASSDEF(BASS_ChannelUpdate)(DWORD handle, DWORD length);
 BOOL BASSDEF(BASS_ChannelSetAttribute)(DWORD handle, DWORD attrib, float value);
-BOOL BASSDEF(BASS_ChannelGetAttribute)(DWORD handle, DWORD attrib, float *value);
-BOOL BASSDEF(BASS_ChannelSlideAttribute)(DWORD handle, DWORD attrib, float value, DWORD time);
+BOOL BASSDEF(BASS_ChannelGetAttribute)(DWORD handle, DWORD attrib,
+                                       float *value);
+BOOL BASSDEF(BASS_ChannelSlideAttribute)(DWORD handle, DWORD attrib,
+                                         float value, DWORD time);
 BOOL BASSDEF(BASS_ChannelIsSliding)(DWORD handle, DWORD attrib);
-BOOL BASSDEF(BASS_ChannelSetAttributeEx)(DWORD handle, DWORD attrib, void *value, DWORD size);
-DWORD BASSDEF(BASS_ChannelGetAttributeEx)(DWORD handle, DWORD attrib, void *value, DWORD size);
-BOOL BASSDEF(BASS_ChannelSet3DAttributes)(DWORD handle, int mode, float min, float max, int iangle, int oangle, float outvol);
-BOOL BASSDEF(BASS_ChannelGet3DAttributes)(DWORD handle, DWORD *mode, float *min, float *max, DWORD *iangle, DWORD *oangle, float *outvol);
-BOOL BASSDEF(BASS_ChannelSet3DPosition)(DWORD handle, const BASS_3DVECTOR *pos, const BASS_3DVECTOR *orient, const BASS_3DVECTOR *vel);
-BOOL BASSDEF(BASS_ChannelGet3DPosition)(DWORD handle, BASS_3DVECTOR *pos, BASS_3DVECTOR *orient, BASS_3DVECTOR *vel);
+BOOL BASSDEF(BASS_ChannelSetAttributeEx)(DWORD handle, DWORD attrib,
+                                         void *value, DWORD size);
+DWORD BASSDEF(BASS_ChannelGetAttributeEx)(DWORD handle, DWORD attrib,
+                                          void *value, DWORD size);
+BOOL BASSDEF(BASS_ChannelSet3DAttributes)(DWORD handle, int mode, float min,
+                                          float max, int iangle, int oangle,
+                                          float outvol);
+BOOL BASSDEF(BASS_ChannelGet3DAttributes)(DWORD handle, DWORD *mode, float *min,
+                                          float *max, DWORD *iangle,
+                                          DWORD *oangle, float *outvol);
+BOOL BASSDEF(BASS_ChannelSet3DPosition)(DWORD handle, const BASS_3DVECTOR *pos,
+                                        const BASS_3DVECTOR *orient,
+                                        const BASS_3DVECTOR *vel);
+BOOL BASSDEF(BASS_ChannelGet3DPosition)(DWORD handle, BASS_3DVECTOR *pos,
+                                        BASS_3DVECTOR *orient,
+                                        BASS_3DVECTOR *vel);
 QWORD BASSDEF(BASS_ChannelGetLength)(DWORD handle, DWORD mode);
 BOOL BASSDEF(BASS_ChannelSetPosition)(DWORD handle, QWORD pos, DWORD mode);
 QWORD BASSDEF(BASS_ChannelGetPosition)(DWORD handle, DWORD mode);
 DWORD BASSDEF(BASS_ChannelGetLevel)(DWORD handle);
-BOOL BASSDEF(BASS_ChannelGetLevelEx)(DWORD handle, float *levels, float length, DWORD flags);
+BOOL BASSDEF(BASS_ChannelGetLevelEx)(DWORD handle, float *levels, float length,
+                                     DWORD flags);
 DWORD BASSDEF(BASS_ChannelGetData)(DWORD handle, void *buffer, DWORD length);
-HSYNC BASSDEF(BASS_ChannelSetSync)(DWORD handle, DWORD type, QWORD param, SYNCPROC *proc, void *user);
+HSYNC BASSDEF(BASS_ChannelSetSync)(DWORD handle, DWORD type, QWORD param,
+                                   SYNCPROC *proc, void *user);
 BOOL BASSDEF(BASS_ChannelRemoveSync)(DWORD handle, HSYNC sync);
 BOOL BASSDEF(BASS_ChannelSetLink)(DWORD handle, DWORD chan);
 BOOL BASSDEF(BASS_ChannelRemoveLink)(DWORD handle, DWORD chan);
-HDSP BASSDEF(BASS_ChannelSetDSP)(DWORD handle, DSPPROC *proc, void *user, int priority);
-HDSP BASSDEF(BASS_ChannelSetDSPEx)(DWORD handle, DSPPROC *proc, void *user, int priority, DWORD flags);
+HDSP BASSDEF(BASS_ChannelSetDSP)(DWORD handle, DSPPROC *proc, void *user,
+                                 int priority);
+HDSP BASSDEF(BASS_ChannelSetDSPEx)(DWORD handle, DSPPROC *proc, void *user,
+                                   int priority, DWORD flags);
 BOOL BASSDEF(BASS_ChannelRemoveDSP)(DWORD handle, HDSP dsp);
 HFX BASSDEF(BASS_ChannelSetFX)(DWORD handle, DWORD type, int priority);
 BOOL BASSDEF(BASS_ChannelRemoveFX)(DWORD handle, HFX fx);
@@ -1146,34 +1210,40 @@ BOOL BASSDEF(BASS_FXFree)(DWORD handle);
 }
 
 #if defined(_WIN32) && !defined(NOBASSOVERLOADS)
-static inline HPLUGIN BASS_PluginLoad(const WCHAR *file, DWORD flags)
-{
-	return BASS_PluginLoad((const char*)file, flags | BASS_UNICODE);
+static inline HPLUGIN BASS_PluginLoad(const WCHAR *file, DWORD flags) {
+  return BASS_PluginLoad((const char *)file, flags | BASS_UNICODE);
 }
 
-static inline HMUSIC BASS_MusicLoad(DWORD filetype, const WCHAR *file, QWORD offset, DWORD length, DWORD flags, DWORD freq)
-{
-	return BASS_MusicLoad(filetype, (const void*)file, offset, length, flags | BASS_UNICODE, freq);
+static inline HMUSIC BASS_MusicLoad(DWORD filetype, const WCHAR *file,
+                                    QWORD offset, DWORD length, DWORD flags,
+                                    DWORD freq) {
+  return BASS_MusicLoad(filetype, (const void *)file, offset, length,
+                        flags | BASS_UNICODE, freq);
 }
 
-static inline HSAMPLE BASS_SampleLoad(DWORD filetype, const WCHAR *file, QWORD offset, DWORD length, DWORD max, DWORD flags)
-{
-	return BASS_SampleLoad(filetype, (const void*)file, offset, length, max, flags | BASS_UNICODE);
+static inline HSAMPLE BASS_SampleLoad(DWORD filetype, const WCHAR *file,
+                                      QWORD offset, DWORD length, DWORD max,
+                                      DWORD flags) {
+  return BASS_SampleLoad(filetype, (const void *)file, offset, length, max,
+                         flags | BASS_UNICODE);
 }
 
-static inline HSTREAM BASS_StreamCreateFile(DWORD filetype, const WCHAR *file, QWORD offset, QWORD length, DWORD flags)
-{
-	return BASS_StreamCreateFile(filetype, (const void*)file, offset, length, flags | BASS_UNICODE);
+static inline HSTREAM BASS_StreamCreateFile(DWORD filetype, const WCHAR *file,
+                                            QWORD offset, QWORD length,
+                                            DWORD flags) {
+  return BASS_StreamCreateFile(filetype, (const void *)file, offset, length,
+                               flags | BASS_UNICODE);
 }
 
-static inline HSTREAM BASS_StreamCreateURL(const WCHAR *url, DWORD offset, DWORD flags, DOWNLOADPROC *proc, void *user)
-{
-	return BASS_StreamCreateURL((const char*)url, offset, flags | BASS_UNICODE, proc, user);
+static inline HSTREAM BASS_StreamCreateURL(const WCHAR *url, DWORD offset,
+                                           DWORD flags, DOWNLOADPROC *proc,
+                                           void *user) {
+  return BASS_StreamCreateURL((const char *)url, offset, flags | BASS_UNICODE,
+                              proc, user);
 }
 
-static inline BOOL BASS_SetConfigPtr(DWORD option, const WCHAR *value)
-{
-	return BASS_SetConfigPtr(option | BASS_UNICODE, (const void*)value);
+static inline BOOL BASS_SetConfigPtr(DWORD option, const WCHAR *value) {
+  return BASS_SetConfigPtr(option | BASS_UNICODE, (const void *)value);
 }
 #endif
 #endif

--- a/cleo_plugins/DebugUtils/DebugUtils.cpp
+++ b/cleo_plugins/DebugUtils/DebugUtils.cpp
@@ -1,8 +1,8 @@
-#include <windows.h> // keyboard
 #include <deque>
-#include <map>
 #include <fstream>
+#include <map>
 #include <sstream>
+#include <windows.h> // keyboard
 
 #include "CMessages.h"
 #include "CTimer.h"
@@ -15,414 +15,400 @@
 using namespace CLEO;
 using namespace plugin;
 
-class DebugUtils
-{
+class DebugUtils {
 public:
-    static ScreenLog screenLog;
+  static ScreenLog screenLog;
 
-    struct PausedScriptInfo 
-    { 
-        CRunningScript* ptr;
-        std::string msg;
-        PausedScriptInfo(CRunningScript* ptr, const char* msg) : ptr(ptr), msg(msg) {}
-    };
-    static std::deque<PausedScriptInfo> pausedScripts;
+  struct PausedScriptInfo {
+    CRunningScript *ptr;
+    std::string msg;
+    PausedScriptInfo(CRunningScript *ptr, const char *msg)
+        : ptr(ptr), msg(msg) {}
+  };
+  static std::deque<PausedScriptInfo> pausedScripts;
 
-    static ScriptLog currScript;
+  static ScriptLog currScript;
 
-    // limits for processing after which script is considered hanging
-    static size_t configLimitCommand;
-    static size_t configLimitTime;
+  // limits for processing after which script is considered hanging
+  static size_t configLimitCommand;
+  static size_t configLimitTime;
 
-    // breakpoint continue keys
-    static const int KeyFirst = VK_F5;
-    static const size_t KeyCount = 8; // F5 to F12
-    static bool keysReleased; // none of continue keys was pressed during previous frame
+  // breakpoint continue keys
+  static const int KeyFirst = VK_F5;
+  static const size_t KeyCount = 8; // F5 to F12
+  static bool
+      keysReleased; // none of continue keys was pressed during previous frame
 
-    static std::map<std::string, std::ofstream> logFiles;
+  static std::map<std::string, std::ofstream> logFiles;
 
-    DebugUtils()
-    {
-        if (!PluginCheckCleoVersion()) return;
+  DebugUtils() {
+    if (!PluginCheckCleoVersion())
+      return;
 
-        auto config = GetConfigFilename();
-        configLimitCommand = GetPrivateProfileInt("Limits", "Command", 2000000, config.c_str()); // 2 milion commands
-        configLimitTime = GetPrivateProfileInt("Limits", "Time", 5, config.c_str()); // 5 seconds
+    auto config = GetConfigFilename();
+    configLimitCommand = GetPrivateProfileInt(
+        "Limits", "Command", 2000000, config.c_str()); // 2 milion commands
+    configLimitTime =
+        GetPrivateProfileInt("Limits", "Time", 5, config.c_str()); // 5 seconds
 
-        // register opcodes
-        CLEO_RegisterOpcode(0x00C3, Opcode_DebugOn);
-        CLEO_RegisterOpcode(0x00C4, Opcode_DebugOff);
-        CLEO_RegisterOpcode(0x2100, Opcode_Breakpoint);
-        CLEO_RegisterOpcode(0x2101, Opcode_Trace);
-        CLEO_RegisterOpcode(0x2102, Opcode_LogToFile);
+    // register opcodes
+    CLEO_RegisterOpcode(0x00C3, Opcode_DebugOn);
+    CLEO_RegisterOpcode(0x00C4, Opcode_DebugOff);
+    CLEO_RegisterOpcode(0x2100, Opcode_Breakpoint);
+    CLEO_RegisterOpcode(0x2101, Opcode_Trace);
+    CLEO_RegisterOpcode(0x2102, Opcode_LogToFile);
 
-        // original Rockstar's script debugging opcodes
-        if(GetPrivateProfileInt("General", "LegacyDebugOpcodes", 0, config.c_str()) != 0)
-        {
-            CLEO_RegisterOpcode(0x0662, Opcode_PrintString);
-            CLEO_RegisterOpcode(0x0663, Opcode_PrintInt);
-            CLEO_RegisterOpcode(0x0664, Opcode_PrintFloat);
-        }
-
-        // register event callbacks
-        CLEO_RegisterCallback(eCallbackId::GameBegin, OnGameBegin);
-        CLEO_RegisterCallback(eCallbackId::Log, OnLog);
-        CLEO_RegisterCallback(eCallbackId::DrawingFinished, OnDrawingFinished);
-        CLEO_RegisterCallback(eCallbackId::ScriptProcessBefore, OnScriptProcess);
-        CLEO_RegisterCallback(eCallbackId::ScriptOpcodeProcessBefore, OnScriptOpcodeProcessBefore);
-        CLEO_RegisterCallback(eCallbackId::ScriptsFinalize, OnScriptsFinalize);
+    // original Rockstar's script debugging opcodes
+    if (GetPrivateProfileInt("General", "LegacyDebugOpcodes", 0,
+                             config.c_str()) != 0) {
+      CLEO_RegisterOpcode(0x0662, Opcode_PrintString);
+      CLEO_RegisterOpcode(0x0663, Opcode_PrintInt);
+      CLEO_RegisterOpcode(0x0664, Opcode_PrintFloat);
     }
 
-    ~DebugUtils()
+    // register event callbacks
+    CLEO_RegisterCallback(eCallbackId::GameBegin, OnGameBegin);
+    CLEO_RegisterCallback(eCallbackId::Log, OnLog);
+    CLEO_RegisterCallback(eCallbackId::DrawingFinished, OnDrawingFinished);
+    CLEO_RegisterCallback(eCallbackId::ScriptProcessBefore, OnScriptProcess);
+    CLEO_RegisterCallback(eCallbackId::ScriptOpcodeProcessBefore,
+                          OnScriptOpcodeProcessBefore);
+    CLEO_RegisterCallback(eCallbackId::ScriptsFinalize, OnScriptsFinalize);
+  }
+
+  ~DebugUtils() {
+    CLEO_UnregisterCallback(eCallbackId::GameBegin, OnGameBegin);
+    CLEO_UnregisterCallback(eCallbackId::Log, OnLog);
+    CLEO_UnregisterCallback(eCallbackId::DrawingFinished, OnDrawingFinished);
+    CLEO_UnregisterCallback(eCallbackId::ScriptProcessBefore, OnScriptProcess);
+    CLEO_UnregisterCallback(eCallbackId::ScriptOpcodeProcessBefore,
+                            OnScriptOpcodeProcessBefore);
+    CLEO_UnregisterCallback(eCallbackId::ScriptsFinalize, OnScriptsFinalize);
+  }
+
+  // ---------------------------------------------- event callbacks
+  // -------------------------------------------------
+
+  static void WINAPI OnGameBegin(DWORD saveSlot) { screenLog.Clear(); }
+
+  static void WINAPI OnScriptsFinalize() {
+    pausedScripts.clear();
+    logFiles.clear(); // close all
+  }
+
+  static void WINAPI OnDrawingFinished() {
+    auto GTA_GetKeyState = (SHORT(__stdcall *)(
+        int))0x0081E64C; // use ingame function as GetKeyState might look like
+                         // keylogger to some AV software
+
+    // log messages
+    screenLog.Draw();
+
+    // draw active breakpoints list
+    if (!pausedScripts.empty() &&
+        (CTimer::m_FrameCounter & 0xE) != 0) // flashing
     {
-        CLEO_UnregisterCallback(eCallbackId::GameBegin, OnGameBegin);
-        CLEO_UnregisterCallback(eCallbackId::Log, OnLog);
-        CLEO_UnregisterCallback(eCallbackId::DrawingFinished, OnDrawingFinished);
-        CLEO_UnregisterCallback(eCallbackId::ScriptProcessBefore, OnScriptProcess);
-        CLEO_UnregisterCallback(eCallbackId::ScriptOpcodeProcessBefore, OnScriptOpcodeProcessBefore);
-        CLEO_UnregisterCallback(eCallbackId::ScriptsFinalize, OnScriptsFinalize);
-    }
-
-    // ---------------------------------------------- event callbacks -------------------------------------------------
-
-    static void WINAPI OnGameBegin(DWORD saveSlot)
-    {
-        screenLog.Clear();
-    }
-
-    static void WINAPI OnScriptsFinalize()
-    {
-        pausedScripts.clear();
-        logFiles.clear(); // close all
-    }
-
-    static void WINAPI OnDrawingFinished()
-    {
-        auto GTA_GetKeyState = (SHORT (__stdcall*)(int))0x0081E64C; // use ingame function as GetKeyState might look like keylogger to some AV software
-
-        // log messages
-        screenLog.Draw();
-
-        // draw active breakpoints list
-        if (!pausedScripts.empty() &&
-            (CTimer::m_FrameCounter & 0xE) != 0) // flashing
-        {
-            for (size_t i = 0; i < pausedScripts.size(); i++)
-            {
-                std::ostringstream ss;
-                ss << "Script '" << pausedScripts[i].ptr->GetName() << "' breakpoint";
-
-                if(!pausedScripts[i].msg.empty()) // named breakpoint
-                {
-                    ss << " '" << pausedScripts[i].msg << "'";
-                }
-
-                if(i < KeyCount)
-                {
-                    ss << " (F" << 5 + i << ")";
-                }
-
-                screenLog.DrawLine(ss.str().c_str(), i);
-            }
-
-            // for some reason last string on print list is always drawn incorrectly
-            // Walkaround: add one extra dummy line then
-            screenLog.DrawLine("_~n~_~n~_", 500);
-        }
-
-        // update keys state
-        if(!keysReleased)
-        {
-            keysReleased = true;
-            for (size_t i = 0; i < KeyCount; i++)
-            {
-                auto state = GTA_GetKeyState(KeyFirst + i);
-                if (state & 0x8000) // key down
-                {
-                    keysReleased = false;
-                    break;
-                }
-            }
-        }
-        else // ready for next press
-        {
-            const size_t count = std::min(pausedScripts.size(), KeyCount);
-            for (size_t i = 0; i < count; i++)
-            {
-                auto state = GTA_GetKeyState(KeyFirst + i);
-                if (state & 0x8000) // key down
-                {
-                    keysReleased = false;
-
-                    if (!CTimer::m_CodePause)
-                    {
-                        std::stringstream ss;
-                        ss << "Script breakpoint ";
-                        if (!pausedScripts[i].msg.empty()) ss << "'" << pausedScripts[i].msg << "' "; // TODO: restore color if custom was used in name
-                        ss << "released in '" << pausedScripts[i].ptr->GetName() << "'";
-                        CLEO_Log(eLogLevel::Debug, ss.str().c_str());
-                    }
-
-                    if (CTimer::m_CodePause)
-                    {
-                        CLEO_Log(eLogLevel::Debug, "Game unpaused");
-                        CTimer::m_CodePause = false;
-                    }
-
-                    pausedScripts.erase(pausedScripts.begin() + i);
-
-                    break; // breakpoint continue
-                }
-            }
-        }
-
-        // this should be called at end of scripts processing
-        // but PluginSDK, SAMP etc. call single scripts/callbacks outside of the processing queue
-        currScript.Clear(); // make sure current script log does not persists to next render frame
-    }
-
-    static bool WINAPI OnScriptProcess(CRunningScript* thread)
-    {
-        currScript.Begin(thread);
-
-        for (size_t i = 0; i < pausedScripts.size(); i++)
-        {
-            if (pausedScripts[i].ptr == thread)
-            {
-                return false; // script paused, do not process
-            }
-        }
-
-        return true;
-    }
-
-    static OpcodeResult WINAPI OnScriptOpcodeProcessBefore(CRunningScript* thread, DWORD opcode)
-    {
-        currScript.ProcessCommand(thread);
-
-        // script per render frame commands limit
-        if (configLimitCommand > 0 && currScript.commandCounter > configLimitCommand)
-        {
-            // add comma separators into huge numbers
-            std::string limitStr;
-            auto limit = configLimitCommand;
-            while (limit >= 1000)
-            {
-                limitStr = StringPrintf(",%03d%s", limit % 1000, limitStr.c_str());
-                limit /= 1000;
-            }
-            limitStr = StringPrintf("%d%s", limit, limitStr.c_str());
-
-            SHOW_ERROR("Over %s commands executed in a single frame by script %s \nTo prevent the game from freezing, CLEO suspended this script.\n\nTo supress this error, increase 'Command' property in %s.ini file and restart the game.", limitStr.c_str(), ScriptInfoStr(thread).c_str(), TARGET_NAME);
-            return thread->Suspend();
-        }
-
-        // script per frame time execution limit
-        if (currScript.commandCounter % 1000 == 0) // check once every 1000 commands
-        {
-            if (configLimitTime > 0 && currScript.GetElapsedSeconds() > configLimitTime)
-            {
-                SHOW_ERROR("Over %d seconds of lag in a single frame by script %s \nTo prevent the game from freezing, CLEO suspended this script.\n\nTo supress this error, increase 'Time' property in %s.ini file and restart the game.", configLimitTime, ScriptInfoStr(thread).c_str(), TARGET_NAME);
-                return thread->Suspend();
-            }
-        }
-
-        return OR_NONE;
-    }
-
-    static void WINAPI OnLog(eLogLevel level, const char* msg)
-    {
-        screenLog.Add(level, msg);
-    }
-
-    // ---------------------------------------------- opcodes -------------------------------------------------
-
-    // 00C3=0, debug_on
-    static OpcodeResult __stdcall Opcode_DebugOn(CRunningScript* thread)
-    {
-        CLEO_SetScriptDebugMode(thread, true);
-
-        return OR_CONTINUE;
-    }
-
-    // 00C4=0, debug_off
-    static OpcodeResult __stdcall Opcode_DebugOff(CRunningScript* thread)
-    {
-        CLEO_SetScriptDebugMode(thread, false);
-
-        return OR_CONTINUE;
-    }
-
-    // 2100=-1, breakpoint ...
-    static OpcodeResult __stdcall Opcode_Breakpoint(CRunningScript* thread)
-    {
-        if (!CLEO_GetScriptDebugMode(thread))
-        {
-            CLEO_SkipUnusedVarArgs(thread);
-            return OR_CONTINUE;
-        }
-
-        bool blocking = true; // pause entire game logic
-        std::string name = "";
-
-        // bool param - blocking
-        auto paramType = thread->PeekDataType();
-        if(paramType == DT_BYTE)
-        {
-            blocking = CLEO_GetIntOpcodeParam(thread) != 0;
-        }
-
-        paramType = thread->PeekDataType();
-        if (paramType == eDataType::DT_END)
-        {
-            thread->IncPtr(); // consume arguments terminator
-        }
-        else // breakpoint formatted name string
-        {
-            OPCODE_READ_PARAM_STRING_FORMATTED(nameStr);
-            CMessages::InsertPlayerControlKeysInString(nameStr);
-            name = nameStr;
-        }
-
-        pausedScripts.emplace_back(thread, name.c_str());
-
-        std::stringstream ss;
-        ss << "Script breakpoint";
-        if (!name.empty()) ss << " '" << name << "'";
-        ss << " captured in '" << thread->GetName() << "'";
-        CLEO_Log(eLogLevel::Debug, ss.str().c_str());
-
-        if(blocking)
-        {
-            CLEO_Log(eLogLevel::Debug, "Game paused");
-            CTimer::m_CodePause = true;
-        }
-
-        return OR_INTERRUPT;
-    }
-
-    // 2101=-1, trace %1s% ...
-    static OpcodeResult __stdcall Opcode_Trace(CRunningScript* thread)
-    {
-        if (!CLEO_GetScriptDebugMode(thread))
-        {
-            CLEO_SkipUnusedVarArgs(thread);
-            return OR_CONTINUE;
-        }
-
-        OPCODE_READ_PARAM_STRING_FORMATTED(message);
-        CMessages::InsertPlayerControlKeysInString(message);
-
-        CLEO_Log(eLogLevel::Debug, message);
-        return OR_CONTINUE;
-    }
-
-    // 2102=-1, log_to_file %1s% timestamp %2d% text %3s% ...
-    static OpcodeResult __stdcall Opcode_LogToFile(CRunningScript* thread)
-    {
-        auto filestr = CLEO_ReadStringOpcodeParam(thread);
-
-        // normalized absolute filepath
-        std::string filename(MAX_PATH, '\0');
-        const size_t len = strlen(filestr);
-        for(size_t i = 0; i < len; i++)
-        {
-            if(filestr[i] == '/')
-                filename[i] = '\\';
-            else
-                filename[i] = std::tolower(filestr[i]);
-        }
-        CLEO_ResolvePath(thread, filename.data(), MAX_PATH);
-        filename.resize(strlen(filename.data())); // clip to actual cstr len
-
-        auto it = logFiles.find(filename);
-        if(it == logFiles.end()) // not opened yet
-        {
-            it = logFiles.emplace(std::piecewise_construct, std::make_tuple(filename), std::make_tuple(filename, std::ios_base::app)).first;
-        }
-
-        auto& file = it->second;
-        if(!file.good())
-        {
-            std::ostringstream ss;
-            ss << "Failed to open log file '" << filename << "'";
-            CLEO_Log(eLogLevel::Error, ss.str().c_str());
-
-            CLEO_SkipUnusedVarArgs(thread);
-            return OR_CONTINUE;
-        }
-
-        // time stamp
-        if(CLEO_GetIntOpcodeParam(thread) != 0)
-        {
-            SYSTEMTIME t;
-            GetLocalTime(&t);
-            static char szBuf[64];
-            sprintf_s(szBuf, "%02d/%02d/%04d %02d:%02d:%02d.%03d ", t.wDay, t.wMonth, t.wYear, t.wHour, t.wMinute, t.wSecond, t.wMilliseconds);
-            file << szBuf;
-        }
-
-        OPCODE_READ_PARAM_STRING_FORMATTED(message);
-        CMessages::InsertPlayerControlKeysInString(message);
-
-        file << message << std::endl;
-
-        return OR_CONTINUE;
-    }
-
-    // 0662=1, printstring %1s%
-    static OpcodeResult __stdcall Opcode_PrintString(CRunningScript* thread)
-    {
-        if (!CLEO_GetScriptDebugMode(thread))
-        {
-            CLEO_SkipOpcodeParams(thread, 1);
-            return OR_CONTINUE;
-        }
-
-        auto text = CLEO_ReadStringOpcodeParam(thread);
-
-        CLEO_Log(eLogLevel::Debug, text);
-
-        return OR_CONTINUE;
-    }
-
-    // 0663=1, printint %1s% %2d%
-    static OpcodeResult __stdcall Opcode_PrintInt(CRunningScript* thread)
-    {
-        if (!CLEO_GetScriptDebugMode(thread))
-        {
-            CLEO_SkipOpcodeParams(thread, 2);
-            return OR_CONTINUE;
-        }
-
-        auto text = CLEO_ReadStringOpcodeParam(thread);
-        auto value = CLEO_GetIntOpcodeParam(thread);
-
+      for (size_t i = 0; i < pausedScripts.size(); i++) {
         std::ostringstream ss;
-        ss << text << ": " << value;
-        CLEO_Log(eLogLevel::Debug, ss.str().c_str());
+        ss << "Script '" << pausedScripts[i].ptr->GetName() << "' breakpoint";
 
-        return OR_CONTINUE;
-    }
-
-    // 0664=1, printfloat %1s% %2f%
-    static OpcodeResult __stdcall Opcode_PrintFloat(CRunningScript* thread)
-    {
-        if (!CLEO_GetScriptDebugMode(thread))
+        if (!pausedScripts[i].msg.empty()) // named breakpoint
         {
-            CLEO_SkipOpcodeParams(thread, 2);
-            return OR_CONTINUE;
+          ss << " '" << pausedScripts[i].msg << "'";
         }
 
-        auto text = CLEO_ReadStringOpcodeParam(thread);
-        auto value = CLEO_GetFloatOpcodeParam(thread);
+        if (i < KeyCount) {
+          ss << " (F" << 5 + i << ")";
+        }
 
-        std::ostringstream ss;
-        ss << text << ": " << value;
-        CLEO_Log(eLogLevel::Debug, ss.str().c_str());
+        screenLog.DrawLine(ss.str().c_str(), i);
+      }
 
-        return OR_CONTINUE;
+      // for some reason last string on print list is always drawn incorrectly
+      // Walkaround: add one extra dummy line then
+      screenLog.DrawLine("_~n~_~n~_", 500);
     }
+
+    // update keys state
+    if (!keysReleased) {
+      keysReleased = true;
+      for (size_t i = 0; i < KeyCount; i++) {
+        auto state = GTA_GetKeyState(KeyFirst + i);
+        if (state & 0x8000) // key down
+        {
+          keysReleased = false;
+          break;
+        }
+      }
+    } else // ready for next press
+    {
+      const size_t count = std::min(pausedScripts.size(), KeyCount);
+      for (size_t i = 0; i < count; i++) {
+        auto state = GTA_GetKeyState(KeyFirst + i);
+        if (state & 0x8000) // key down
+        {
+          keysReleased = false;
+
+          if (!CTimer::m_CodePause) {
+            std::stringstream ss;
+            ss << "Script breakpoint ";
+            if (!pausedScripts[i].msg.empty())
+              ss << "'" << pausedScripts[i].msg
+                 << "' "; // TODO: restore color if custom was used in name
+            ss << "released in '" << pausedScripts[i].ptr->GetName() << "'";
+            CLEO_Log(eLogLevel::Debug, ss.str().c_str());
+          }
+
+          if (CTimer::m_CodePause) {
+            CLEO_Log(eLogLevel::Debug, "Game unpaused");
+            CTimer::m_CodePause = false;
+          }
+
+          pausedScripts.erase(pausedScripts.begin() + i);
+
+          break; // breakpoint continue
+        }
+      }
+    }
+
+    // this should be called at end of scripts processing
+    // but PluginSDK, SAMP etc. call single scripts/callbacks outside of the
+    // processing queue
+    currScript.Clear(); // make sure current script log does not persists to
+                        // next render frame
+  }
+
+  static bool WINAPI OnScriptProcess(CRunningScript *thread) {
+    currScript.Begin(thread);
+
+    for (size_t i = 0; i < pausedScripts.size(); i++) {
+      if (pausedScripts[i].ptr == thread) {
+        return false; // script paused, do not process
+      }
+    }
+
+    return true;
+  }
+
+  static OpcodeResult WINAPI OnScriptOpcodeProcessBefore(CRunningScript *thread,
+                                                         DWORD opcode) {
+    currScript.ProcessCommand(thread);
+
+    // script per render frame commands limit
+    if (configLimitCommand > 0 &&
+        currScript.commandCounter > configLimitCommand) {
+      // add comma separators into huge numbers
+      std::string limitStr;
+      auto limit = configLimitCommand;
+      while (limit >= 1000) {
+        limitStr = StringPrintf(",%03d%s", limit % 1000, limitStr.c_str());
+        limit /= 1000;
+      }
+      limitStr = StringPrintf("%d%s", limit, limitStr.c_str());
+
+      SHOW_ERROR("Over %s commands executed in a single frame by script %s "
+                 "\nTo prevent the game from freezing, CLEO suspended this "
+                 "script.\n\nTo supress this error, increase 'Command' "
+                 "property in %s.ini file and restart the game.",
+                 limitStr.c_str(), ScriptInfoStr(thread).c_str(), TARGET_NAME);
+      return thread->Suspend();
+    }
+
+    // script per frame time execution limit
+    if (currScript.commandCounter % 1000 == 0) // check once every 1000 commands
+    {
+      if (configLimitTime > 0 &&
+          currScript.GetElapsedSeconds() > configLimitTime) {
+        SHOW_ERROR("Over %d seconds of lag in a single frame by script %s \nTo "
+                   "prevent the game from freezing, CLEO suspended this "
+                   "script.\n\nTo supress this error, increase 'Time' property "
+                   "in %s.ini file and restart the game.",
+                   configLimitTime, ScriptInfoStr(thread).c_str(), TARGET_NAME);
+        return thread->Suspend();
+      }
+    }
+
+    return OR_NONE;
+  }
+
+  static void WINAPI OnLog(eLogLevel level, const char *msg) {
+    screenLog.Add(level, msg);
+  }
+
+  // ---------------------------------------------- opcodes
+  // -------------------------------------------------
+
+  // 00C3=0, debug_on
+  static OpcodeResult __stdcall Opcode_DebugOn(CRunningScript *thread) {
+    CLEO_SetScriptDebugMode(thread, true);
+
+    return OR_CONTINUE;
+  }
+
+  // 00C4=0, debug_off
+  static OpcodeResult __stdcall Opcode_DebugOff(CRunningScript *thread) {
+    CLEO_SetScriptDebugMode(thread, false);
+
+    return OR_CONTINUE;
+  }
+
+  // 2100=-1, breakpoint ...
+  static OpcodeResult __stdcall Opcode_Breakpoint(CRunningScript *thread) {
+    if (!CLEO_GetScriptDebugMode(thread)) {
+      CLEO_SkipUnusedVarArgs(thread);
+      return OR_CONTINUE;
+    }
+
+    bool blocking = true; // pause entire game logic
+    std::string name = "";
+
+    // bool param - blocking
+    auto paramType = thread->PeekDataType();
+    if (paramType == DT_BYTE) {
+      blocking = CLEO_GetIntOpcodeParam(thread) != 0;
+    }
+
+    paramType = thread->PeekDataType();
+    if (paramType == eDataType::DT_END) {
+      thread->IncPtr(); // consume arguments terminator
+    } else              // breakpoint formatted name string
+    {
+      OPCODE_READ_PARAM_STRING_FORMATTED(nameStr);
+      CMessages::InsertPlayerControlKeysInString(nameStr);
+      name = nameStr;
+    }
+
+    pausedScripts.emplace_back(thread, name.c_str());
+
+    std::stringstream ss;
+    ss << "Script breakpoint";
+    if (!name.empty())
+      ss << " '" << name << "'";
+    ss << " captured in '" << thread->GetName() << "'";
+    CLEO_Log(eLogLevel::Debug, ss.str().c_str());
+
+    if (blocking) {
+      CLEO_Log(eLogLevel::Debug, "Game paused");
+      CTimer::m_CodePause = true;
+    }
+
+    return OR_INTERRUPT;
+  }
+
+  // 2101=-1, trace %1s% ...
+  static OpcodeResult __stdcall Opcode_Trace(CRunningScript *thread) {
+    if (!CLEO_GetScriptDebugMode(thread)) {
+      CLEO_SkipUnusedVarArgs(thread);
+      return OR_CONTINUE;
+    }
+
+    OPCODE_READ_PARAM_STRING_FORMATTED(message);
+    CMessages::InsertPlayerControlKeysInString(message);
+
+    CLEO_Log(eLogLevel::Debug, message);
+    return OR_CONTINUE;
+  }
+
+  // 2102=-1, log_to_file %1s% timestamp %2d% text %3s% ...
+  static OpcodeResult __stdcall Opcode_LogToFile(CRunningScript *thread) {
+    auto filestr = CLEO_ReadStringOpcodeParam(thread);
+
+    // normalized absolute filepath
+    std::string filename(MAX_PATH, '\0');
+    const size_t len = strlen(filestr);
+    for (size_t i = 0; i < len; i++) {
+      if (filestr[i] == '/')
+        filename[i] = '\\';
+      else
+        filename[i] = std::tolower(filestr[i]);
+    }
+    CLEO_ResolvePath(thread, filename.data(), MAX_PATH);
+    filename.resize(strlen(filename.data())); // clip to actual cstr len
+
+    auto it = logFiles.find(filename);
+    if (it == logFiles.end()) // not opened yet
+    {
+      it = logFiles
+               .emplace(std::piecewise_construct, std::make_tuple(filename),
+                        std::make_tuple(filename, std::ios_base::app))
+               .first;
+    }
+
+    auto &file = it->second;
+    if (!file.good()) {
+      std::ostringstream ss;
+      ss << "Failed to open log file '" << filename << "'";
+      CLEO_Log(eLogLevel::Error, ss.str().c_str());
+
+      CLEO_SkipUnusedVarArgs(thread);
+      return OR_CONTINUE;
+    }
+
+    // time stamp
+    if (CLEO_GetIntOpcodeParam(thread) != 0) {
+      SYSTEMTIME t;
+      GetLocalTime(&t);
+      static char szBuf[64];
+      sprintf_s(szBuf, "%02d/%02d/%04d %02d:%02d:%02d.%03d ", t.wDay, t.wMonth,
+                t.wYear, t.wHour, t.wMinute, t.wSecond, t.wMilliseconds);
+      file << szBuf;
+    }
+
+    OPCODE_READ_PARAM_STRING_FORMATTED(message);
+    CMessages::InsertPlayerControlKeysInString(message);
+
+    file << message << std::endl;
+
+    return OR_CONTINUE;
+  }
+
+  // 0662=1, printstring %1s%
+  static OpcodeResult __stdcall Opcode_PrintString(CRunningScript *thread) {
+    if (!CLEO_GetScriptDebugMode(thread)) {
+      CLEO_SkipOpcodeParams(thread, 1);
+      return OR_CONTINUE;
+    }
+
+    auto text = CLEO_ReadStringOpcodeParam(thread);
+
+    CLEO_Log(eLogLevel::Debug, text);
+
+    return OR_CONTINUE;
+  }
+
+  // 0663=1, printint %1s% %2d%
+  static OpcodeResult __stdcall Opcode_PrintInt(CRunningScript *thread) {
+    if (!CLEO_GetScriptDebugMode(thread)) {
+      CLEO_SkipOpcodeParams(thread, 2);
+      return OR_CONTINUE;
+    }
+
+    auto text = CLEO_ReadStringOpcodeParam(thread);
+    auto value = CLEO_GetIntOpcodeParam(thread);
+
+    std::ostringstream ss;
+    ss << text << ": " << value;
+    CLEO_Log(eLogLevel::Debug, ss.str().c_str());
+
+    return OR_CONTINUE;
+  }
+
+  // 0664=1, printfloat %1s% %2f%
+  static OpcodeResult __stdcall Opcode_PrintFloat(CRunningScript *thread) {
+    if (!CLEO_GetScriptDebugMode(thread)) {
+      CLEO_SkipOpcodeParams(thread, 2);
+      return OR_CONTINUE;
+    }
+
+    auto text = CLEO_ReadStringOpcodeParam(thread);
+    auto value = CLEO_GetFloatOpcodeParam(thread);
+
+    std::ostringstream ss;
+    ss << text << ": " << value;
+    CLEO_Log(eLogLevel::Debug, ss.str().c_str());
+
+    return OR_CONTINUE;
+  }
 } DebugUtils;
 
 ScreenLog DebugUtils::screenLog = {};
@@ -432,4 +418,3 @@ size_t DebugUtils::configLimitCommand;
 size_t DebugUtils::configLimitTime;
 bool DebugUtils::keysReleased = true;
 std::map<std::string, std::ofstream> DebugUtils::logFiles;
-

--- a/cleo_plugins/DebugUtils/ScreenLog.cpp
+++ b/cleo_plugins/DebugUtils/ScreenLog.cpp
@@ -4,228 +4,220 @@
 
 DWORD ScreenLog::timeDisplay = 1000;
 
-ScreenLog::ScreenLog()
-{
-    scrollOffset = 0.0f;
-    Init();
+ScreenLog::ScreenLog() {
+  scrollOffset = 0.0f;
+  Init();
 }
 
-void ScreenLog::Init()
-{
-    auto ConfigReadHex = [](const char* section, const char* key, DWORD defValue, const char* filename)
-    {
-        char buff[32] = { 0 };
-        if (!GetPrivateProfileString(section, key, "", buff, sizeof(buff), filename))
-            return defValue;
+void ScreenLog::Init() {
+  auto ConfigReadHex = [](const char *section, const char *key, DWORD defValue,
+                          const char *filename) {
+    char buff[32] = {0};
+    if (!GetPrivateProfileString(section, key, "", buff, sizeof(buff),
+                                 filename))
+      return defValue;
 
-        char* end;
-        DWORD result = strtoul(buff, &end, 16);
+    char *end;
+    DWORD result = strtoul(buff, &end, 16);
 
-        if (*end != '\0')
-            return defValue; // any invalid char
+    if (*end != '\0')
+      return defValue; // any invalid char
 
-        return result;
+    return result;
+  };
+
+  // load settings from ini file
+  auto config = GetConfigFilename();
+
+  level = (eLogLevel)GetPrivateProfileInt(
+      "ScreenLog", "Level", (DWORD)eLogLevel::None, config.c_str());
+  maxMessages =
+      GetPrivateProfileInt("ScreenLog", "MessagesMax", 40, config.c_str());
+  timeDisplay =
+      GetPrivateProfileInt("ScreenLog", "MessageTime", 6000, config.c_str());
+  timeFadeout = 3000;
+
+  fontSize =
+      0.01f * GetPrivateProfileInt("ScreenLog", "FontSize", 60, config.c_str());
+  fontStyle = (eFontStyle)GetPrivateProfileInt(
+      "ScreenLog", "FontStyle", eFontStyle::FONT_SUBTITLES, config.c_str());
+
+  fontColor[(size_t)eLogLevel::Error] = CRGBA(ConfigReadHex(
+      "ScreenLog", "ColorError", fontColor[(size_t)eLogLevel::Error].ToInt(),
+      config.c_str()));
+  fontColor[(size_t)eLogLevel::Debug] = CRGBA(ConfigReadHex(
+      "ScreenLog", "ColorDebug", fontColor[(size_t)eLogLevel::Debug].ToInt(),
+      config.c_str()));
+  fontColor[(size_t)eLogLevel::Default] = CRGBA(ConfigReadHex(
+      "ScreenLog", "ColorSystem", fontColor[(size_t)eLogLevel::Default].ToInt(),
+      config.c_str()));
+}
+
+void ScreenLog::Add(eLogLevel level, const char *msg) {
+  if (level > this->level) {
+    return;
+  }
+
+  Entry entry(level, msg);
+  if (!entries.empty() && entries.front() == entry) {
+    entries.front().Repeat(); // duplicated
+  } else {
+    entries.push_front(std::move(entry));
+
+    bool full = entries.size() >= maxMessages;
+    if (full)
+      entries.resize(maxMessages);
+
+    // update scroll pos
+    float sizeY = fontSize * RsGlobal.maximumHeight / 448.0f;
+    size_t lines = CountLines(std::string(msg));
+
+    if (!full)
+      scrollOffset += 18.0f * lines * sizeY;
+    else
+      scrollOffset = 0.0f; // do not animate if list was full
+  }
+}
+
+void ScreenLog::Clear() { entries.clear(); }
+
+void ScreenLog::Draw() {
+  // scroll animation
+  static DWORD prevTime;
+  DWORD currTime = GetTickCount(); // game independent
+  if (scrollOffset > 0.001f) {
+    float delta = 0.01f * (currTime - prevTime);
+    scrollOffset *= std::max(0.9f - delta, 0.0f);
+  } else
+    scrollOffset = 0.0f;
+  prevTime = currTime;
+
+  // clean up expired entries
+  while (!entries.empty()) {
+    if (entries.back().timeLeft < (-0.001f * timeFadeout))
+      entries.pop_back();
+    else
+      break;
+  }
+
+  if (entries.empty()) {
+    scrollOffset = 0.0f;
+    return; // nothing to print
+  }
+
+  CFont::SetBackground(false, false);
+  CFont::SetWrapx(99999999.0f); // no line wrap
+  CFont::SetFontStyle(fontStyle);
+  CFont::SetEdge(1);
+  CFont::SetProportional(true);
+
+  const float aspect = (float)RsGlobal.maximumWidth / RsGlobal.maximumHeight;
+  float sizeX = fontSize * 0.58f * RsGlobal.maximumWidth / 640.0f / aspect;
+  float sizeY = fontSize * RsGlobal.maximumHeight / 448.0f;
+  CFont::SetScale(sizeX, sizeY);
+
+  CFont::SetOrientation(ALIGN_LEFT);
+  float posX = 15.0f * sizeX;
+  float posY = 7.0f * sizeY - scrollOffset;
+
+  // count total lines
+  int lines = 0;
+  for (auto &entry : entries) {
+    lines += CountLines(entry.msg);
+  }
+
+  float elapsed = 0.001f * (CTimer::m_snTimeInMilliseconds -
+                            CTimer::m_snPreviousTimeInMilliseconds);
+  float elapsedAlt = elapsed;
+  float rowTime = -0.001f * timeFadeout;
+  for (auto it = entries.rbegin(); it != entries.rend();
+       it++) // draw from oldest
+  {
+    auto &entry = *it;
+
+    if (entry.timeLeft > 0.0f) {
+      if (entry.timeLeft < elapsedAlt)
+        entry.timeLeft = 0.0f; // do not skip fade
+      else
+        entry.timeLeft -= elapsedAlt;
+    } else
+      entry.timeLeft -= elapsed; // fade out
+
+    elapsedAlt *= 0.98f; // keep every next line longer
+
+    rowTime = std::max(rowTime, entry.timeLeft); // carred on from older entries
+
+    BYTE alpha = 255;
+    if (rowTime < 0) {
+      float fadeProgress = -rowTime / (0.001f * timeFadeout);
+      fadeProgress = std::clamp(fadeProgress, 0.0f, 1.0f);
+      fadeProgress = 1.0f - fadeProgress; // fade out
+      fadeProgress = sqrtf(fadeProgress);
+      alpha = (BYTE)(fadeProgress * 0xFF);
     };
 
-    // load settings from ini file
-    auto config = GetConfigFilename();
+    auto color = fontColor[(size_t)entry.level];
+    alpha = std::min(alpha, color.a);
+    color.a = alpha;
 
-    level = (eLogLevel)GetPrivateProfileInt("ScreenLog", "Level", (DWORD)eLogLevel::None, config.c_str());
-    maxMessages = GetPrivateProfileInt("ScreenLog", "MessagesMax", 40, config.c_str());
-    timeDisplay = GetPrivateProfileInt("ScreenLog", "MessageTime", 6000, config.c_str());
-    timeFadeout = 3000;
-
-    fontSize = 0.01f * GetPrivateProfileInt("ScreenLog", "FontSize", 60, config.c_str());
-    fontStyle = (eFontStyle)GetPrivateProfileInt("ScreenLog", "FontStyle", eFontStyle::FONT_SUBTITLES, config.c_str());
-
-    fontColor[(size_t)eLogLevel::Error] = CRGBA(ConfigReadHex("ScreenLog", "ColorError", fontColor[(size_t)eLogLevel::Error].ToInt(), config.c_str()));
-    fontColor[(size_t)eLogLevel::Debug] = CRGBA(ConfigReadHex("ScreenLog", "ColorDebug", fontColor[(size_t)eLogLevel::Debug].ToInt(), config.c_str()));
-    fontColor[(size_t)eLogLevel::Default] = CRGBA(ConfigReadHex("ScreenLog", "ColorSystem", fontColor[(size_t)eLogLevel::Default].ToInt(), config.c_str()));
-}
-
-void ScreenLog::Add(eLogLevel level, const char* msg)
-{
-    if (level > this->level)
-    {
-        return;
-    }
-
-    Entry entry(level, msg);
-    if(!entries.empty() && entries.front() == entry)
-    {
-        entries.front().Repeat(); // duplicated
-    }
-    else
-    {
-        entries.push_front(std::move(entry));
-
-        bool full = entries.size() >= maxMessages;
-        if (full) entries.resize(maxMessages);
-
-        // update scroll pos
-        float sizeY = fontSize * RsGlobal.maximumHeight / 448.0f;
-        size_t lines = CountLines(std::string(msg));
-
-        if(!full)
-            scrollOffset += 18.0f * lines * sizeY;
-        else
-            scrollOffset = 0.0f; // do not animate if list was full
-    }
-}
-
-void ScreenLog::Clear()
-{
-    entries.clear();
-}
-
-void ScreenLog::Draw()
-{
-    // scroll animation
-    static DWORD prevTime;
-    DWORD currTime = GetTickCount(); // game independent
-    if (scrollOffset > 0.001f)
-    {
-        float delta = 0.01f * (currTime - prevTime);
-        scrollOffset *= std::max(0.9f - delta, 0.0f);
-    }
-    else
-        scrollOffset = 0.0f;
-    prevTime = currTime;
-
-    // clean up expired entries
-    while(!entries.empty())
-    {
-        if(entries.back().timeLeft < (-0.001f * timeFadeout))
-            entries.pop_back();
-        else
-            break;
-    }
-
-    if (entries.empty())
-    {
-        scrollOffset = 0.0f;
-        return; // nothing to print
-    }
-
-    CFont::SetBackground(false, false);
-    CFont::SetWrapx(99999999.0f); // no line wrap
-    CFont::SetFontStyle(fontStyle);
-    CFont::SetEdge(1);
-    CFont::SetProportional(true);
-
-    const float aspect = (float)RsGlobal.maximumWidth / RsGlobal.maximumHeight;
-    float sizeX = fontSize * 0.58f * RsGlobal.maximumWidth / 640.0f / aspect;
-    float sizeY = fontSize * RsGlobal.maximumHeight / 448.0f;
-    CFont::SetScale(sizeX, sizeY);
-
-    CFont::SetOrientation(ALIGN_LEFT);
-    float posX = 15.0f * sizeX;
-    float posY = 7.0f * sizeY - scrollOffset;
-
-    // count total lines
-    int lines = 0;
-    for (auto& entry : entries)
-    {
-        lines += CountLines(entry.msg);
-    }
-
-    float elapsed = 0.001f * (CTimer::m_snTimeInMilliseconds - CTimer::m_snPreviousTimeInMilliseconds);
-    float elapsedAlt = elapsed;
-    float rowTime = -0.001f * timeFadeout;
-    for(auto it = entries.rbegin(); it != entries.rend(); it++) // draw from oldest
-    {
-        auto& entry = *it;
-
-        if(entry.timeLeft > 0.0f)
-        {
-            if(entry.timeLeft < elapsedAlt)
-                entry.timeLeft = 0.0f; // do not skip fade
-            else
-                entry.timeLeft -= elapsedAlt;
-        }
-        else
-            entry.timeLeft -= elapsed; // fade out
-
-        elapsedAlt *= 0.98f; // keep every next line longer
-
-        rowTime = std::max(rowTime, entry.timeLeft); // carred on from older entries
-        
-        BYTE alpha = 255;
-        if (rowTime < 0)
-        {
-            float fadeProgress = -rowTime / (0.001f * timeFadeout);
-            fadeProgress = std::clamp(fadeProgress, 0.0f, 1.0f);
-            fadeProgress = 1.0f - fadeProgress; // fade out
-            fadeProgress = sqrtf(fadeProgress);
-            alpha = (BYTE)(fadeProgress * 0xFF);
-        };
-
-        auto color = fontColor[(size_t)entry.level];
-        alpha = std::min(alpha, color.a);
-        color.a = alpha;
-
-        CFont::SetColor(color);
-
-        alpha = std::clamp(int(alpha * alpha) / 255, 0, 255); // corrected for fadeout
-        CFont::SetDropColor(CRGBA(0, 0, 0, alpha));
-
-        lines -= CountLines(entry.msg);
-        float y = posY + 18.0f * sizeY * lines;
-
-        CFont::PrintString(posX, y, entry.GetMsg());
-    }
-
-    // for some reason last string on print list is always drawn incorrectly
-    // Walkaround: add one extra dummy line then
-    CFont::PrintString(0.0f, -500.0f, "_~n~_~n~_"); 
-}
-
-void ScreenLog::DrawLine(const char* msg, size_t row)
-{
-    CFont::SetBackground(false, false);
-    CFont::SetWrapx(99999999.0f); // no line wrap
-    CFont::SetFontStyle(fontStyle);
-    CFont::SetEdge(1);
-    CFont::SetProportional(true);
-
-    const float aspect = (float)RsGlobal.maximumWidth / RsGlobal.maximumHeight;
-    float sizeX = fontSize * 0.55f * RsGlobal.maximumWidth / 640.0f / aspect;
-    float sizeY = fontSize * RsGlobal.maximumHeight / 448.0f;
-    CFont::SetScale(sizeX, sizeY);
-
-    CFont::SetOrientation(ALIGN_RIGHT);
-    float posX = (float)RsGlobal.maximumWidth - 15.0f * sizeX;
-    
-    //if(FrontEndMenuManager.m_bHudOn)
-    float posY = 0.25f * RsGlobal.maximumHeight;
-    posY += 18.0f * sizeY * row;
-
-    auto color = fontColor[(size_t)eLogLevel::Error];
     CFont::SetColor(color);
-    CFont::SetDropColor(CRGBA(0, 0, 0, color.a));
 
-    CFont::PrintString(posX, posY, msg);
+    alpha =
+        std::clamp(int(alpha * alpha) / 255, 0, 255); // corrected for fadeout
+    CFont::SetDropColor(CRGBA(0, 0, 0, alpha));
+
+    lines -= CountLines(entry.msg);
+    float y = posY + 18.0f * sizeY * lines;
+
+    CFont::PrintString(posX, y, entry.GetMsg());
+  }
+
+  // for some reason last string on print list is always drawn incorrectly
+  // Walkaround: add one extra dummy line then
+  CFont::PrintString(0.0f, -500.0f, "_~n~_~n~_");
 }
 
-size_t ScreenLog::CountLines(std::string& msg)
-{
-    size_t lines = 1;
+void ScreenLog::DrawLine(const char *msg, size_t row) {
+  CFont::SetBackground(false, false);
+  CFont::SetWrapx(99999999.0f); // no line wrap
+  CFont::SetFontStyle(fontStyle);
+  CFont::SetEdge(1);
+  CFont::SetProportional(true);
 
-    size_t pos = 0;
-    while ((pos = msg.find("~n~", pos)) != std::string::npos)
-    {
-        lines++;
-        pos += 3; // pattern length
-    }
+  const float aspect = (float)RsGlobal.maximumWidth / RsGlobal.maximumHeight;
+  float sizeX = fontSize * 0.55f * RsGlobal.maximumWidth / 640.0f / aspect;
+  float sizeY = fontSize * RsGlobal.maximumHeight / 448.0f;
+  CFont::SetScale(sizeX, sizeY);
 
-    lines += std::count(msg.begin(), msg.end(), '\n');
+  CFont::SetOrientation(ALIGN_RIGHT);
+  float posX = (float)RsGlobal.maximumWidth - 15.0f * sizeX;
 
-    return lines;
+  // if(FrontEndMenuManager.m_bHudOn)
+  float posY = 0.25f * RsGlobal.maximumHeight;
+  posY += 18.0f * sizeY * row;
+
+  auto color = fontColor[(size_t)eLogLevel::Error];
+  CFont::SetColor(color);
+  CFont::SetDropColor(CRGBA(0, 0, 0, color.a));
+
+  CFont::PrintString(posX, posY, msg);
 }
 
-DWORD ScreenLog::GetTime()
-{
-    //return GetTickCount();
-    return CTimer::m_snPreviousTimeInMillisecondsNonClipped;
+size_t ScreenLog::CountLines(std::string &msg) {
+  size_t lines = 1;
+
+  size_t pos = 0;
+  while ((pos = msg.find("~n~", pos)) != std::string::npos) {
+    lines++;
+    pos += 3; // pattern length
+  }
+
+  lines += std::count(msg.begin(), msg.end(), '\n');
+
+  return lines;
 }
 
+DWORD ScreenLog::GetTime() {
+  // return GetTickCount();
+  return CTimer::m_snPreviousTimeInMillisecondsNonClipped;
+}

--- a/cleo_plugins/DebugUtils/ScreenLog.h
+++ b/cleo_plugins/DebugUtils/ScreenLog.h
@@ -1,132 +1,123 @@
 #pragma once
-#include "CLEO.h"
 #include "CFont.h"
+#include "CLEO.h"
 #include "CRGBA.h"
 #include <deque>
 #include <string>
 
 using namespace CLEO;
 
-class ScreenLog
-{
+class ScreenLog {
 public:
-    static DWORD timeDisplay; // miliseconds
+  static DWORD timeDisplay; // miliseconds
 
-    ScreenLog();
+  ScreenLog();
 
-    void Init();
-    void Add(eLogLevel level, const char* msg);
-    void Clear();
-    void Draw();
-    void DrawLine(const char* msg, size_t row = 0);
+  void Init();
+  void Add(eLogLevel level, const char *msg);
+  void Clear();
+  void Draw();
+  void DrawLine(const char *msg, size_t row = 0);
 
 private:
+  eLogLevel level;
+  size_t maxMessages;
+  float fontSize;
+  eFontStyle fontStyle;
+  DWORD timeFadeout; // miliseconds
+
+  CRGBA fontColor[4] = {
+      // colors for eLogLevel
+      CRGBA(0xDD, 0xDD, 0xDD, 0xFF), // None
+      CRGBA(0xFF, 0x30, 0xFF, 0xFF), // Error
+      CRGBA(0xFF, 0xEE, 0x30, 0xFF), // User
+      CRGBA(0xDD, 0xDD, 0xDD, 0xFF), // Default
+  };
+
+  struct Entry {
     eLogLevel level;
-    size_t maxMessages;
-    float fontSize;
-    eFontStyle fontStyle;
-    DWORD timeFadeout; // miliseconds
+    std::string msg;
+    size_t msgStartPos;
+    float timeLeft;
+    size_t repeats;
 
-    CRGBA fontColor[4] = { // colors for eLogLevel
-        CRGBA(0xDD, 0xDD, 0xDD, 0xFF), // None
-        CRGBA(0xFF, 0x30, 0xFF, 0xFF), // Error
-        CRGBA(0xFF, 0xEE, 0x30, 0xFF), // User
-        CRGBA(0xDD, 0xDD, 0xDD, 0xFF), // Default
-    };
+    static const size_t Repeat_Prefix_Len =
+        16; // extra characters for repeat count text
 
-    struct Entry
-    {
-        eLogLevel level;
-        std::string msg;
-        size_t msgStartPos;
-        float timeLeft;
-        size_t repeats;
+    Entry() : level(eLogLevel::Default), msg(""), timeLeft(0.0f), repeats(1) {}
 
-        static const size_t Repeat_Prefix_Len = 16; // extra characters for repeat count text
+    Entry(eLogLevel level, const char *msg) : level(level), repeats(1) {
+      if (msg != nullptr) {
+        auto len = strlen(msg);
+        this->msg.reserve(Repeat_Prefix_Len + len);
 
-        Entry() :
-            level(eLogLevel::Default),
-            msg(""),
-            timeLeft(0.0f),
-            repeats(1)
-        {
+        // repeat prefix
+        this->msg.resize(Repeat_Prefix_Len - 2);
+        this->msg.push_back(':');
+        this->msg.push_back(' ');
+        msgStartPos = Repeat_Prefix_Len; // prefix not present
+
+        // copy input message
+        for (size_t i = 0; i < len; i++) {
+          const char c = msg[i];
+          switch (c) {
+          case '\n':
+            this->msg += "~n~";
+            break;
+
+          // characters not represented correctly by game's font texture
+          case '{':
+          case '}':
+            this->msg.push_back('_');
+            break;
+
+          default:
+            this->msg.push_back(c);
+          }
         }
 
-        Entry(eLogLevel level, const char* msg) :
-            level(level), 
-            repeats(1)
+        if (!this->msg.empty() &&
+            this->msg.back() == ' ') // a bug(?) in game prevents drawing texts
+                                     // ending with whitespace
         {
-            if(msg != nullptr)
-            {
-                auto len = strlen(msg);
-                this->msg.reserve(Repeat_Prefix_Len + len);
-
-                // repeat prefix
-                this->msg.resize(Repeat_Prefix_Len - 2);
-                this->msg.push_back(':');
-                this->msg.push_back(' ');
-                msgStartPos = Repeat_Prefix_Len; // prefix not present
-
-                // copy input message
-                for(size_t i = 0; i < len; i++)
-                {
-                    const char c = msg[i];
-                    switch(c)
-                    {
-                        case '\n':
-                            this->msg += "~n~";
-                            break;
-
-                        // characters not represented correctly by game's font texture
-                        case '{':
-                        case '}':
-                            this->msg.push_back('_');
-                            break;
-                            
-                        default:
-                            this->msg.push_back(c);
-                    }
-                }
-
-                if(!this->msg.empty() && this->msg.back() == ' ') // a bug(?) in game prevents drawing texts ending with whitespace
-                {
-                    this->msg.back() = '_'; // '_' is drawn as empty character too
-                }
-            }
-
-            ResetTime();
+          this->msg.back() = '_'; // '_' is drawn as empty character too
         }
+      }
 
-        void Repeat()
-        {
-            ResetTime();
-            repeats++;
+      ResetTime();
+    }
 
-            std::string prefix = "x" + std::to_string(repeats);
-            msgStartPos = Repeat_Prefix_Len - 2 - prefix.length(); // and ": "
-            msg.replace(msgStartPos, prefix.length(), prefix);
-        }
+    void Repeat() {
+      ResetTime();
+      repeats++;
 
-        void ResetTime()
-        {
-            timeLeft = std::min<size_t>(msg.length(), 200) * 0.055f; // 18 letters peer second reading speed
-            timeLeft = std::max(timeLeft, 0.001f * ScreenLog::timeDisplay); // not shorter than defined in config
-        }
+      std::string prefix = "x" + std::to_string(repeats);
+      msgStartPos = Repeat_Prefix_Len - 2 - prefix.length(); // and ": "
+      msg.replace(msgStartPos, prefix.length(), prefix);
+    }
 
-        const char* GetMsg(bool prefix = true) const
-        {
-            return msg.c_str() + (prefix ? msgStartPos : Repeat_Prefix_Len);
-        }
+    void ResetTime() {
+      timeLeft = std::min<size_t>(msg.length(), 200) *
+                 0.055f; // 18 letters peer second reading speed
+      timeLeft = std::max(
+          timeLeft,
+          0.001f *
+              ScreenLog::timeDisplay); // not shorter than defined in config
+    }
 
-        bool operator==(const Entry& other) const
-        {
-            return level == other.level && !strcmp(GetMsg(false), other.GetMsg(false));
-        }
-    };
+    const char *GetMsg(bool prefix = true) const {
+      return msg.c_str() + (prefix ? msgStartPos : Repeat_Prefix_Len);
+    }
 
-    static size_t CountLines(std::string& msg);
-    static DWORD GetTime();
+    bool operator==(const Entry &other) const {
+      return level == other.level &&
+             !strcmp(GetMsg(false), other.GetMsg(false));
+    }
+  };
 
-    std::deque<Entry> entries;
-    float scrollOffset;
+  static size_t CountLines(std::string &msg);
+  static DWORD GetTime();
+
+  std::deque<Entry> entries;
+  float scrollOffset;
 };

--- a/cleo_plugins/DebugUtils/ScriptLog.h
+++ b/cleo_plugins/DebugUtils/ScriptLog.h
@@ -2,36 +2,31 @@
 #include "CLEO.h"
 #include <ctime>
 
-struct ScriptLog
-{
-    CRunningScript* thread = nullptr;
-    clock_t startTime = 0;
-    size_t commandCounter = 0;
+struct ScriptLog {
+  CRunningScript *thread = nullptr;
+  clock_t startTime = 0;
+  size_t commandCounter = 0;
 
-    void Begin(CRunningScript* thread)
-    {
-        this->thread = thread;
-        startTime = clock();
-        commandCounter = 0;
-    }
+  void Begin(CRunningScript *thread) {
+    this->thread = thread;
+    startTime = clock();
+    commandCounter = 0;
+  }
 
-    void Clear()
-    {
-        thread = nullptr;
-        startTime = 0;
-        commandCounter = 0;
-    }
+  void Clear() {
+    thread = nullptr;
+    startTime = 0;
+    commandCounter = 0;
+  }
 
-    void ProcessCommand(CRunningScript* thread)
-    {
-        if (this->thread != thread) Begin(thread);
+  void ProcessCommand(CRunningScript *thread) {
+    if (this->thread != thread)
+      Begin(thread);
 
-        commandCounter++;
-    }
+    commandCounter++;
+  }
 
-    inline size_t GetElapsedSeconds() const
-    {
-        return (clock() - startTime) / CLOCKS_PER_SEC;
-    }
+  inline size_t GetElapsedSeconds() const {
+    return (clock() - startTime) / CLOCKS_PER_SEC;
+  }
 };
-

--- a/cleo_plugins/FileSystemOperations/FileSystemOperations.cpp
+++ b/cleo_plugins/FileSystemOperations/FileSystemOperations.cpp
@@ -1,7 +1,7 @@
-#include "plugin.h"
 #include "CLEO.h"
 #include "CLEO_Utils.h"
 #include "FileUtils.h"
+#include "plugin.h"
 
 #include <filesystem>
 #include <set>
@@ -10,794 +10,752 @@ using namespace CLEO;
 using namespace plugin;
 namespace FS = std::filesystem;
 
-#define OPCODE_READ_PARAM_FILE_HANDLE(handle) auto handle = (DWORD)OPCODE_READ_PARAM_PTR(); \
-    if(m_hFiles.find(handle) == m_hFiles.end()) { auto info = ScriptInfoStr(thread); SHOW_ERROR("Invalid or already closed '0x%X' file handle param in script %s \nScript suspended.", handle, info.c_str()); return thread->Suspend(); }
+#define OPCODE_READ_PARAM_FILE_HANDLE(handle)                                  \
+  auto handle = (DWORD)OPCODE_READ_PARAM_PTR();                                \
+  if (m_hFiles.find(handle) == m_hFiles.end()) {                               \
+    auto info = ScriptInfoStr(thread);                                         \
+    SHOW_ERROR("Invalid or already closed '0x%X' file handle param in script " \
+               "%s \nScript suspended.",                                       \
+               handle, info.c_str());                                          \
+    return thread->Suspend();                                                  \
+  }
 
-class FileSystemOperations 
-{
+class FileSystemOperations {
 public:
-    static std::set<DWORD> m_hFiles;
-    static std::set<HANDLE> m_hFileSearches;
+  static std::set<DWORD> m_hFiles;
+  static std::set<HANDLE> m_hFileSearches;
 
-    static void WINAPI OnFinalizeScriptObjects()
-    {
-        // clean up opened files
-        for (auto handle : m_hFiles) File::close(handle);
-        m_hFiles.clear();
+  static void WINAPI OnFinalizeScriptObjects() {
+    // clean up opened files
+    for (auto handle : m_hFiles)
+      File::close(handle);
+    m_hFiles.clear();
 
-        // clean up file searches
-        for (auto handle : m_hFileSearches) FindClose(handle);
-        m_hFileSearches.clear();
-    }
+    // clean up file searches
+    for (auto handle : m_hFileSearches)
+      FindClose(handle);
+    m_hFileSearches.clear();
+  }
 
-    FileSystemOperations() 
-    {
-        if (!PluginCheckCleoVersion()) return;
+  FileSystemOperations() {
+    if (!PluginCheckCleoVersion())
+      return;
 
-        File::initialize(CLEO_GetGameVersion()); // file utils
+    File::initialize(CLEO_GetGameVersion()); // file utils
 
-        //register opcodes
-        CLEO_RegisterOpcode(0x0A99, opcode_0A99); // set_current_directory
-        CLEO_RegisterOpcode(0x0A9A, opcode_0A9A); // openfile
-        CLEO_RegisterOpcode(0x0A9B, opcode_0A9B); // closefile
-        CLEO_RegisterOpcode(0x0A9C, opcode_0A9C); // get_file_size
-        CLEO_RegisterOpcode(0x0A9D, opcode_0A9D); // read_from_file
-        CLEO_RegisterOpcode(0x0A9E, opcode_0A9E); // write_to_file 
+    // register opcodes
+    CLEO_RegisterOpcode(0x0A99, opcode_0A99); // set_current_directory
+    CLEO_RegisterOpcode(0x0A9A, opcode_0A9A); // openfile
+    CLEO_RegisterOpcode(0x0A9B, opcode_0A9B); // closefile
+    CLEO_RegisterOpcode(0x0A9C, opcode_0A9C); // get_file_size
+    CLEO_RegisterOpcode(0x0A9D, opcode_0A9D); // read_from_file
+    CLEO_RegisterOpcode(0x0A9E, opcode_0A9E); // write_to_file
 
-        CLEO_RegisterOpcode(0x0AAB, Script_FS_FileExists);
-        CLEO_RegisterOpcode(0x0AE4, Script_FS_DirectoryExists);
-        CLEO_RegisterOpcode(0x0AE5, Script_FS_CreateDirectory);
-        CLEO_RegisterOpcode(0x0AE6, Script_FS_FindFirstFile);
-        CLEO_RegisterOpcode(0x0AE7, Script_FS_FindNextFile);
-        CLEO_RegisterOpcode(0x0AE8, Script_FS_FindClose);
+    CLEO_RegisterOpcode(0x0AAB, Script_FS_FileExists);
+    CLEO_RegisterOpcode(0x0AE4, Script_FS_DirectoryExists);
+    CLEO_RegisterOpcode(0x0AE5, Script_FS_CreateDirectory);
+    CLEO_RegisterOpcode(0x0AE6, Script_FS_FindFirstFile);
+    CLEO_RegisterOpcode(0x0AE7, Script_FS_FindNextFile);
+    CLEO_RegisterOpcode(0x0AE8, Script_FS_FindClose);
 
-        CLEO_RegisterOpcode(0x0AD5, opcode_0AD5); // file_seek
-        CLEO_RegisterOpcode(0x0AD6, opcode_0AD6); // is_end_of_file_reached
-        CLEO_RegisterOpcode(0x0AD7, opcode_0AD7); // read_string_from_file
-        CLEO_RegisterOpcode(0x0AD8, opcode_0AD8); // write_string_to_file
-        CLEO_RegisterOpcode(0x0AD9, opcode_0AD9); // write_formatted_string_to_file
-        CLEO_RegisterOpcode(0x0ADA, opcode_0ADA); // scan_file
+    CLEO_RegisterOpcode(0x0AD5, opcode_0AD5); // file_seek
+    CLEO_RegisterOpcode(0x0AD6, opcode_0AD6); // is_end_of_file_reached
+    CLEO_RegisterOpcode(0x0AD7, opcode_0AD7); // read_string_from_file
+    CLEO_RegisterOpcode(0x0AD8, opcode_0AD8); // write_string_to_file
+    CLEO_RegisterOpcode(0x0AD9, opcode_0AD9); // write_formatted_string_to_file
+    CLEO_RegisterOpcode(0x0ADA, opcode_0ADA); // scan_file
 
-        CLEO_RegisterOpcode(0x0B00, Script_FS_DeleteFile);
-        CLEO_RegisterOpcode(0x0B01, Script_FS_DeleteDirectory);
-        CLEO_RegisterOpcode(0x0B02, Script_FS_MoveFile);
-        CLEO_RegisterOpcode(0x0B03, Script_FS_MoveDir);
-        CLEO_RegisterOpcode(0x0B04, Script_FS_CopyFile);
-        CLEO_RegisterOpcode(0x0B05, Script_FS_CopyDir);
+    CLEO_RegisterOpcode(0x0B00, Script_FS_DeleteFile);
+    CLEO_RegisterOpcode(0x0B01, Script_FS_DeleteDirectory);
+    CLEO_RegisterOpcode(0x0B02, Script_FS_MoveFile);
+    CLEO_RegisterOpcode(0x0B03, Script_FS_MoveDir);
+    CLEO_RegisterOpcode(0x0B04, Script_FS_CopyFile);
+    CLEO_RegisterOpcode(0x0B05, Script_FS_CopyDir);
 
-        CLEO_RegisterOpcode(0x2300, opcode_2300); // get_file_position
-        CLEO_RegisterOpcode(0x2301, opcode_2301); // read_block_from_file
-        CLEO_RegisterOpcode(0x2302, opcode_2302); // write_block_to_file
-        CLEO_RegisterOpcode(0x2303, opcode_2303); // resolve_filepath
-        CLEO_RegisterOpcode(0x2304, opcode_2304); // get_script_filename
-        CLEO_RegisterOpcode(0x2305, opcode_2305); // get_file_write_time
+    CLEO_RegisterOpcode(0x2300, opcode_2300); // get_file_position
+    CLEO_RegisterOpcode(0x2301, opcode_2301); // read_block_from_file
+    CLEO_RegisterOpcode(0x2302, opcode_2302); // write_block_to_file
+    CLEO_RegisterOpcode(0x2303, opcode_2303); // resolve_filepath
+    CLEO_RegisterOpcode(0x2304, opcode_2304); // get_script_filename
+    CLEO_RegisterOpcode(0x2305, opcode_2305); // get_file_write_time
 
-        // register event callbacks
-        CLEO_RegisterCallback(eCallbackId::ScriptsFinalize, OnFinalizeScriptObjects);
-    }
+    // register event callbacks
+    CLEO_RegisterCallback(eCallbackId::ScriptsFinalize,
+                          OnFinalizeScriptObjects);
+  }
 
-    ~FileSystemOperations()
-    {
-        CLEO_UnregisterCallback(eCallbackId::ScriptsFinalize, OnFinalizeScriptObjects);
-    }
+  ~FileSystemOperations() {
+    CLEO_UnregisterCallback(eCallbackId::ScriptsFinalize,
+                            OnFinalizeScriptObjects);
+  }
 
-    //0A99=1,set_current_directory %1b:userdir/rootdir%
-    static OpcodeResult __stdcall opcode_0A99(CRunningScript* thread)
-    {
-        const char* path;
+  // 0A99=1,set_current_directory %1b:userdir/rootdir%
+  static OpcodeResult __stdcall opcode_0A99(CRunningScript *thread) {
+    const char *path;
 
-        auto paramType = thread->PeekDataType();
-        if (IsImmInteger(paramType) || IsVariable(paramType))
-        {
-            // numbered predefined paths
-            auto idx = OPCODE_READ_PARAM_INT();
-            switch (idx)
-            {
-                case 0: path = DIR_GAME; break;
-                case 1: path = DIR_USER; break;
-                case 2: path = DIR_SCRIPT; break;
-                default:
-                    LOG_WARNING(0, "Value (%d) not known by opcode [0A99] in script %s", idx, ScriptInfoStr(thread).c_str());
-                    return OR_CONTINUE;
-            }
-
-            // Hack: restore global workDir if script used some hacky way to set it instead of 0A99 (SkinSelector)
-            if (idx == 0)
-            {
-                FS::current_path(CLEO_GetGameDirectory());
-            }
-        }
-        else
-        {
-            OPCODE_READ_PARAM_STRING(str);
-            path = str;
-        }
-
-        CLEO_SetScriptWorkDir(thread, path);
+    auto paramType = thread->PeekDataType();
+    if (IsImmInteger(paramType) || IsVariable(paramType)) {
+      // numbered predefined paths
+      auto idx = OPCODE_READ_PARAM_INT();
+      switch (idx) {
+      case 0:
+        path = DIR_GAME;
+        break;
+      case 1:
+        path = DIR_USER;
+        break;
+      case 2:
+        path = DIR_SCRIPT;
+        break;
+      default:
+        LOG_WARNING(0, "Value (%d) not known by opcode [0A99] in script %s",
+                    idx, ScriptInfoStr(thread).c_str());
         return OR_CONTINUE;
+      }
+
+      // Hack: restore global workDir if script used some hacky way to set it
+      // instead of 0A99 (SkinSelector)
+      if (idx == 0) {
+        FS::current_path(CLEO_GetGameDirectory());
+      }
+    } else {
+      OPCODE_READ_PARAM_STRING(str);
+      path = str;
     }
 
-    //0A9A=3,%3d% = openfile %1d% mode %2d% // IF and SET
-    static OpcodeResult __stdcall opcode_0A9A(CRunningScript* thread)
+    CLEO_SetScriptWorkDir(thread, path);
+    return OR_CONTINUE;
+  }
+
+  // 0A9A=3,%3d% = openfile %1d% mode %2d% // IF and SET
+  static OpcodeResult __stdcall opcode_0A9A(CRunningScript *thread) {
+    OPCODE_READ_PARAM_FILEPATH(filename);
+
+    char mode[16];
+    auto paramType = thread->PeekDataType();
+    if (IsImmInteger(paramType) || IsVariable(paramType)) {
+      // integer param (for backward compatibility with CLEO 3)
+      union {
+        DWORD uParam;
+        char strParam[4];
+      } param;
+      param.uParam = OPCODE_READ_PARAM_INT();
+      strcpy_s(mode, param.strParam);
+    } else {
+      OPCODE_READ_PARAM_STRING_LEN(
+          strMode, sizeof(mode) - 1); // leave space for terminator char
+      strcpy_s(mode, strMode);
+    }
+
+    // either CLEO 3 or CLEO 4 made a big mistake! (they differ in one major
+    // unapparent preference) lets try to resolve this with a legacy mode
+    bool legacy = CLEO_GetScriptVersion(thread) < CLEO_VER_4_3;
+
+    auto handle = File::open(filename, mode, legacy);
+    if (!File::isOk(handle)) {
+      OPCODE_WRITE_PARAM_INT(0);
+      OPCODE_CONDITION_RESULT(false);
+      return OR_CONTINUE;
+    }
+
+    m_hFiles.insert(handle);
+
+    OPCODE_WRITE_PARAM_INT(handle);
+    OPCODE_CONDITION_RESULT(true);
+    return OR_CONTINUE;
+  }
+
+  // 0A9B=1,closefile %1d%
+  static OpcodeResult __stdcall opcode_0A9B(CRunningScript *thread) {
+    auto handle = OPCODE_READ_PARAM_INT();
+
+    if (m_hFiles.find(handle) != m_hFiles.end()) {
+      File::close(handle);
+      m_hFiles.erase(handle);
+    } else {
+      if (!IsLegacyScript(thread)) {
+        SHOW_ERROR_COMPAT("Invalid or already closed '0x%X' file handle param "
+                          "in script %s \nScript suspended.",
+                          handle, ScriptInfoStr(thread).c_str());
+        return thread->Suspend();
+      }
+    }
+
+    return OR_CONTINUE;
+  }
+
+  // 0A9C=2,get_file_size %1d% store_to %2d%
+  static OpcodeResult __stdcall opcode_0A9C(CRunningScript *thread) {
+    OPCODE_READ_PARAM_FILE_HANDLE(handle);
+
+    auto size = File::getSize(handle);
+
+    OPCODE_WRITE_PARAM_INT(size);
+    return OR_CONTINUE;
+  }
+
+  // 0A9D=3,read_from_file %1d% size %2d% store_to %3d%
+  static OpcodeResult __stdcall opcode_0A9D(CRunningScript *thread) {
+    OPCODE_READ_PARAM_FILE_HANDLE(handle);
+    auto size = OPCODE_READ_PARAM_INT();
+    auto destination = OPCODE_READ_PARAM_OUTPUT_VAR_ANY32();
+
+    if (size < 0) {
+      SHOW_ERROR("Invalid '%d' size argument in script %s\nScript suspended.",
+                 size, ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
+    }
+
+    destination->dwParam = 0; // clear not overwritten bytes -
+                              // https://github.com/cleolibrary/CLEO4/issues/91
+    if (size > 0)
+      File::read(handle, destination, size);
+    return OR_CONTINUE;
+  }
+
+  // 0A9E=3,write_to_file %1d% size %2d% from %3d%
+  static OpcodeResult __stdcall opcode_0A9E(CRunningScript *thread) {
+    OPCODE_READ_PARAM_FILE_HANDLE(handle);
+    auto size = OPCODE_READ_PARAM_INT();
+
+    if (size < 0) {
+      SHOW_ERROR("Invalid '%d' size argument in script %s\nScript suspended.",
+                 size, ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
+    }
+
+    if (size == 0) {
+      OPCODE_SKIP_PARAMS(1); // from
+      return OR_CONTINUE;    // done
+    }
+
+    const void *source;
+    auto paramType = thread->PeekDataType();
+    if (IsVariable(paramType)) {
+      source = CLEO_GetPointerToScriptVariable(thread);
+    } else if (IsImmString(paramType) || IsVarString(paramType)) {
+      static char buffer[MAX_STR_LEN];
+
+      if (size > MAX_STR_LEN) {
+        SHOW_ERROR("Size argument (%d) greater than supported (%d) in script "
+                   "%s\nScript suspended.",
+                   size, MAX_STR_LEN, ScriptInfoStr(thread).c_str());
+        return thread->Suspend();
+      }
+
+      ZeroMemory(buffer, size); // padd with zeros if size > length
+      source = CLEO_ReadStringOpcodeParam(thread, buffer, sizeof(buffer));
+    } else {
+      if (size > sizeof(SCRIPT_VAR)) {
+        SHOW_ERROR("Size argument (%d) greater than supported (%d) in script "
+                   "%s\nScript suspended.",
+                   size, sizeof(SCRIPT_VAR), ScriptInfoStr(thread).c_str());
+        return thread->Suspend();
+      }
+
+      CLEO_RetrieveOpcodeParams(thread, 1);
+      source = CLEO_GetOpcodeParamsArray();
+    }
+
+    File::write(handle, source, size);
+    if (File::isOk(handle))
+      File::flush(handle);
+    return OR_CONTINUE;
+  }
+
+  // 0AAB=1,  does_file_exist %1s%
+  static OpcodeResult __stdcall Script_FS_FileExists(CRunningScript *thread) {
+    OPCODE_READ_PARAM_FILEPATH(filename);
+
+    DWORD fAttr = GetFileAttributes(filename);
+    bool exists = (fAttr != INVALID_FILE_ATTRIBUTES) &&
+                  !(fAttr & FILE_ATTRIBUTE_DIRECTORY);
+
+    OPCODE_CONDITION_RESULT(exists);
+    return OR_CONTINUE;
+  }
+
+  // 0AD5=3,  file_seek %1d% offset %2d% origin %3d% //IF and SET
+  static OpcodeResult __stdcall opcode_0AD5(CRunningScript *thread) {
+    OPCODE_READ_PARAM_FILE_HANDLE(handle);
+    auto offset = OPCODE_READ_PARAM_INT();
+    auto origin = OPCODE_READ_PARAM_UINT();
+
+    auto ok = File::seek(handle, offset, origin);
+
+    OPCODE_CONDITION_RESULT(ok);
+    return OR_CONTINUE;
+  }
+
+  // 0AD6=1,  is_end_of_file_reached %1d%
+  static OpcodeResult __stdcall opcode_0AD6(CRunningScript *thread) {
+    OPCODE_READ_PARAM_FILE_HANDLE(handle);
+
+    bool end = !File::isOk(handle) || File::isEndOfFile(handle);
+
+    OPCODE_CONDITION_RESULT(end);
+    return OR_CONTINUE;
+  }
+
+  // 0AD7=3,  read_string_from_file %1d% to %2d% size %3d% //IF and SET
+  static OpcodeResult __stdcall opcode_0AD7(CRunningScript *thread) {
+    OPCODE_READ_PARAM_FILE_HANDLE(handle);
+    auto result = OPCODE_READ_PARAM_OUTPUT_VAR_STRING();
+    auto size = OPCODE_READ_PARAM_INT();
+
+    if (size < 0) {
+      SHOW_ERROR("Invalid size argument (%d) in script %s\nScript suspended.",
+                 size, ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
+    }
+
+    if (size == 0) {
+      OPCODE_CONDITION_RESULT(true);
+      return OR_CONTINUE;
+    }
+
+    // use caller's size argument, ignoring actual target type size. Intended
+    // for legacy reasons.
+    bool ok = File::readString(handle, result.data, size) != nullptr;
+
+    // remove line ending characters if present
+    if (ok && !IsLegacyScript(thread)) {
+      auto last = (int)strlen(result.data) - 1;
+      while (last >= 0) {
+        if (result.data[last] != '\n' && result.data[last] != '\r') {
+          break;
+        }
+
+        result.data[last] = '\0';
+        last--;
+      }
+    }
+
+    OPCODE_CONDITION_RESULT(ok);
+    return OR_CONTINUE;
+  }
+
+  // 0AD8=2,  write_string_to_file %1d% from %2d% //IF and SET
+  static OpcodeResult __stdcall opcode_0AD8(CRunningScript *thread) {
+    OPCODE_READ_PARAM_FILE_HANDLE(handle);
+    OPCODE_READ_PARAM_STRING(text);
+
+    auto ok = File::writeString(handle, text);
+    if (!ok) {
+      OPCODE_CONDITION_RESULT(false);
+      return OR_CONTINUE;
+    }
+
+    File::flush(handle);
+    OPCODE_CONDITION_RESULT(true);
+    return OR_CONTINUE;
+  }
+
+  // 0AD9=-1,write_formated_text %2d% to_file %1d%
+  static OpcodeResult __stdcall opcode_0AD9(CRunningScript *thread) {
+    OPCODE_READ_PARAM_FILE_HANDLE(handle);
+    OPCODE_READ_PARAM_STRING_FORMATTED(text);
+
+    auto ok = File::writeString(handle, text);
+    if (!ok) {
+      return OR_CONTINUE;
+    }
+
+    File::flush(handle);
+    return OR_CONTINUE;
+  }
+
+  // 0ADA=-1,  %3d% = scan_file %1d% format %2d% //IF and SET
+  static OpcodeResult __stdcall opcode_0ADA(CRunningScript *thread) {
+    OPCODE_READ_PARAM_FILE_HANDLE(handle);
+    OPCODE_READ_PARAM_STRING(format);
+    auto result = OPCODE_READ_PARAM_OUTPUT_VAR_ANY32();
+
+    size_t paramCount = 0;
+    SCRIPT_VAR *outputParams[35];
+    while (thread->PeekDataType() != eDataType::DT_END) {
+      // TODO: if target param is string variable it should be handled correctly
+      outputParams[paramCount++] = CLEO_GetPointerToScriptVariable(thread);
+    }
+    CLEO_SkipUnusedVarArgs(thread); // var arg terminator
+
+    result->dwParam = File::scan(handle, format, (void **)&outputParams);
+
+    // OPCODE_CONDITION_RESULT(paramCount == result->dwParam);
+    OPCODE_CONDITION_RESULT(true);
+    return OR_CONTINUE;
+  }
+
+  // 0AE4=1,  directory_exist %1s%
+  static OpcodeResult __stdcall Script_FS_DirectoryExists(
+      CRunningScript *thread) {
+    OPCODE_READ_PARAM_FILEPATH(filename);
+
+    DWORD fAttr = GetFileAttributes(filename);
+    bool exists = (fAttr != INVALID_FILE_ATTRIBUTES) &&
+                  (fAttr & FILE_ATTRIBUTE_DIRECTORY);
+
+    OPCODE_CONDITION_RESULT(exists);
+    return OR_CONTINUE;
+  }
+
+  // 0AE5=1,  create_directory %1s% //IF and SET
+  static OpcodeResult __stdcall Script_FS_CreateDirectory(
+      CRunningScript *thread) {
+    OPCODE_READ_PARAM_FILEPATH(filename);
+
+    bool result = CreateDirectory(filename, NULL) != 0;
+
+    OPCODE_CONDITION_RESULT(result);
+    return OR_CONTINUE;
+  }
+
+  // 0AE6=3,  %2d% = find_first_file %1s% get_filename_to %3s% //IF and SET
+  static OpcodeResult __stdcall Script_FS_FindFirstFile(
+      CRunningScript *thread) {
+    OPCODE_READ_PARAM_FILEPATH(filename);
+
+    WIN32_FIND_DATA ffd = {0};
+    HANDLE handle = FindFirstFile(filename, &ffd);
+
+    if (handle == INVALID_HANDLE_VALUE) // -1
     {
-        OPCODE_READ_PARAM_FILEPATH(filename);
-
-        char mode[16];
-        auto paramType = thread->PeekDataType();
-        if (IsImmInteger(paramType) || IsVariable(paramType))
-        {
-            // integer param (for backward compatibility with CLEO 3)
-            union
-            {
-                DWORD uParam;
-                char strParam[4];
-            } param;
-            param.uParam = OPCODE_READ_PARAM_INT();
-            strcpy_s(mode, param.strParam);
-        }
-        else
-        {
-            OPCODE_READ_PARAM_STRING_LEN(strMode, sizeof(mode) - 1); // leave space for terminator char
-            strcpy_s(mode, strMode);
-        }
-
-        // either CLEO 3 or CLEO 4 made a big mistake! (they differ in one major unapparent preference)
-        // lets try to resolve this with a legacy mode
-        bool legacy = CLEO_GetScriptVersion(thread) < CLEO_VER_4_3;
-
-        auto handle = File::open(filename, mode, legacy);
-        if (!File::isOk(handle))
-        {
-            OPCODE_WRITE_PARAM_INT(0);
-            OPCODE_CONDITION_RESULT(false);
-            return OR_CONTINUE;
-        }
-
-        m_hFiles.insert(handle);
-
-        OPCODE_WRITE_PARAM_INT(handle);
-        OPCODE_CONDITION_RESULT(true);
-        return OR_CONTINUE;
+      OPCODE_WRITE_PARAM_INT(-1); // invalid handle
+      OPCODE_SKIP_PARAMS(1);      // filename
+      OPCODE_CONDITION_RESULT(false);
+      return OR_CONTINUE;
     }
 
-    //0A9B=1,closefile %1d%
-    static OpcodeResult __stdcall opcode_0A9B(CRunningScript* thread)
+    m_hFileSearches.insert(handle);
+
+    OPCODE_WRITE_PARAM_INT(handle);
+    OPCODE_WRITE_PARAM_STRING(ffd.cFileName);
+    OPCODE_CONDITION_RESULT(true);
+    return OR_CONTINUE;
+  }
+
+  // 0AE7=2,%2s% = find_next_file %1d% //IF and SET
+  static OpcodeResult __stdcall Script_FS_FindNextFile(CRunningScript *thread) {
+    auto handle = (HANDLE)OPCODE_READ_PARAM_INT();
+
+    if (m_hFileSearches.find(handle) == m_hFileSearches.end()) {
+      LOG_WARNING(
+          thread,
+          "Invalid or already closed file search handle (0x%X) in script %s",
+          handle, ScriptInfoStr(thread).c_str());
+      OPCODE_SKIP_PARAMS(1);
+      OPCODE_CONDITION_RESULT(false);
+      return OR_CONTINUE;
+    }
+
+    WIN32_FIND_DATA ffd = {0};
+    if (!FindNextFile(handle, &ffd)) {
+      OPCODE_SKIP_PARAMS(1);
+      OPCODE_CONDITION_RESULT(false);
+      return OR_CONTINUE;
+    }
+
+    OPCODE_WRITE_PARAM_STRING(ffd.cFileName);
+    OPCODE_CONDITION_RESULT(true);
+    return OR_CONTINUE;
+  }
+
+  // 0AE8=1,find_close %1d%
+  static OpcodeResult __stdcall Script_FS_FindClose(CRunningScript *thread) {
+    auto handle = (HANDLE)OPCODE_READ_PARAM_INT();
+
+    if (m_hFileSearches.find(handle) == m_hFileSearches.end()) {
+      LOG_WARNING(
+          thread,
+          "Invalid or already closed file search handle (0x%X) in script %s",
+          handle, ScriptInfoStr(thread).c_str());
+      return OR_CONTINUE;
+    }
+
+    FindClose(handle);
+    m_hFileSearches.erase(handle);
+    return OR_CONTINUE;
+  }
+
+  // 0B00=1,  delete_file %1s% //IF and SET
+  static OpcodeResult __stdcall Script_FS_DeleteFile(CRunningScript *thread) {
+    OPCODE_READ_PARAM_FILEPATH(filename);
+
+    auto success = DeleteFile(filename);
+
+    OPCODE_CONDITION_RESULT(success);
+    return OR_CONTINUE;
+  }
+
+  static BOOL DeleteDir(const char *path) {
+    char mask[MAX_PATH];
+    HANDLE hSearch = NULL;
+    WIN32_FIND_DATA wfd;
+    char subPath[MAX_PATH];
+
+    memset(&wfd, 0, sizeof(wfd));
+    // search mask
+    sprintf_s(mask, "%s\\*", path);
+
+    // try to delete all inside first
+    if ((hSearch = FindFirstFile(mask, &wfd)) != INVALID_HANDLE_VALUE) {
+      do {
+        // recursively delete subdirectories
+        if (wfd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+          if ((strcmp(wfd.cFileName, "..") != 0) &&
+              (strcmp(wfd.cFileName, ".") != 0)) {
+            sprintf_s(subPath, "%s\\%s", path, wfd.cFileName);
+            if (!DeleteDir(subPath))
+              return FALSE;
+          }
+        } else {
+          // remove read-only, system, hidden flags
+          sprintf_s(subPath, "%s\\%s", path, wfd.cFileName);
+          SetFileAttributes(subPath, FILE_ATTRIBUTE_NORMAL);
+          // delete file
+          if (!DeleteFile(subPath))
+            return FALSE;
+        }
+
+      } while (FindNextFile(hSearch, &wfd));
+      FindClose(hSearch);
+    }
+
+    // delete empty directory
+    return RemoveDirectory(path);
+  }
+
+  // 0B01=1, delete_directory %1s% with_all_files_and_subdirectories %2d% //IF
+  // and SET
+  static OpcodeResult __stdcall Script_FS_DeleteDirectory(
+      CRunningScript *thread) {
+    OPCODE_READ_PARAM_FILEPATH(filename);
+    auto deleteContents = OPCODE_READ_PARAM_BOOL();
+
+    BOOL result;
+    if (deleteContents) {
+      // remove directory with all files and subdirectories
+      result = DeleteDir(filename);
+    } else {
+      // try to remove as empty directory
+      result = RemoveDirectory(filename);
+    }
+
+    OPCODE_CONDITION_RESULT(result);
+    return OR_CONTINUE;
+  }
+
+  // 0B02=2, move_file %1s% to %2s% //IF and SET
+  static OpcodeResult __stdcall Script_FS_MoveFile(CRunningScript *thread) {
+    OPCODE_READ_PARAM_FILEPATH(filepath);
+    OPCODE_READ_PARAM_FILEPATH(newFilepath);
+
+    bool result = false;
+
+    auto fsPath = FS::path(filepath);
+    if (FS::is_regular_file(fsPath)) {
+      std::error_code err;
+      FS::rename(fsPath, newFilepath, err);
+      result = !err;
+    }
+
+    OPCODE_CONDITION_RESULT(result);
+    return OR_CONTINUE;
+  }
+
+  // 0B03=2, move_directory %1s% to %2s% //IF and SET
+  static OpcodeResult __stdcall Script_FS_MoveDir(CRunningScript *thread) {
+    OPCODE_READ_PARAM_FILEPATH(filepath);
+    OPCODE_READ_PARAM_FILEPATH(newFilepath);
+
+    bool result = false;
+
+    auto fsPath = FS::path(filepath);
+    if (FS::is_directory(fsPath)) {
+      std::error_code err;
+      FS::rename(fsPath, newFilepath, err);
+      result = !err;
+    }
+
+    OPCODE_CONDITION_RESULT(result);
+    return OR_CONTINUE;
+  }
+
+  // 0B04=2, copy_file %1s% to %2s% //IF and SET
+  static OpcodeResult __stdcall Script_FS_CopyFile(CRunningScript *thread) {
+    OPCODE_READ_PARAM_FILEPATH(filepath);
+    OPCODE_READ_PARAM_FILEPATH(newFilepath);
+
+    BOOL result = CopyFile(filepath, newFilepath, FALSE);
+    if (result) {
+      // copy file attributes
+      DWORD fattr = GetFileAttributes(filepath);
+      SetFileAttributes(newFilepath, fattr);
+    }
+
+    OPCODE_CONDITION_RESULT(result);
+    return OR_CONTINUE;
+  }
+
+  // 0B05=2,  copy_directory %1d% to %2d% //IF and SET
+  static OpcodeResult __stdcall Script_FS_CopyDir(CRunningScript *thread) {
+    OPCODE_READ_PARAM_FILEPATH(filepath);
+    OPCODE_READ_PARAM_FILEPATH(newFilepath);
+
+    auto path = FS::path(filepath);
+    if (!FS::is_directory(path)) {
+      OPCODE_CONDITION_RESULT(false);
+      return OR_CONTINUE;
+    }
+
+    std::error_code err;
+    FS::copy(filepath, newFilepath,
+             FS::copy_options::update_existing | FS::copy_options::recursive,
+             err);
+
+    OPCODE_CONDITION_RESULT(!err);
+    return OR_CONTINUE;
+  }
+
+  // 2300=2,get_file_position %1d% store_to %2d%
+  static OpcodeResult __stdcall opcode_2300(CRunningScript *thread) {
+    OPCODE_READ_PARAM_FILE_HANDLE(handle);
+
+    auto pos = File::getPos(handle);
+
+    OPCODE_WRITE_PARAM_INT(pos);
+    return OR_CONTINUE;
+  }
+
+  // 2301=3,read_block_from_file %1d% size %2d% buffer %3d% // IF and SET
+  static OpcodeResult __stdcall opcode_2301(CRunningScript *thread) {
+    OPCODE_READ_PARAM_FILE_HANDLE(handle);
+    auto size = OPCODE_READ_PARAM_INT();
+    auto destination = OPCODE_READ_PARAM_PTR();
+
+    if (size < 0) {
+      SHOW_ERROR("Invalid size argument (%d) in script %s\nScript suspended.",
+                 size, ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
+    }
+
+    if (size == 0) {
+      OPCODE_CONDITION_RESULT(true); // done
+      return OR_CONTINUE;
+    }
+
+    auto readCount = File::read(handle, destination, size);
+    if (readCount != size) {
+      OPCODE_CONDITION_RESULT(false);
+      return OR_CONTINUE;
+    }
+
+    OPCODE_CONDITION_RESULT(true);
+    return OR_CONTINUE;
+  }
+
+  // 2302=3,  write_block_to_file %1d% size %2d% address %3d% // IF and SET
+  static OpcodeResult __stdcall opcode_2302(CRunningScript *thread) {
+    OPCODE_READ_PARAM_FILE_HANDLE(handle);
+    auto size = OPCODE_READ_PARAM_INT();
+    auto source = OPCODE_READ_PARAM_PTR();
+
+    if (size < 0) {
+      SHOW_ERROR("Invalid size argument (%d) in script %s\nScript suspended.",
+                 size, ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
+    }
+
+    if (size == 0) {
+      OPCODE_CONDITION_RESULT(true);
+      return OR_CONTINUE;
+    }
+
+    auto readCount = File::write(handle, source, size);
+
+    OPCODE_CONDITION_RESULT(readCount == size);
+    return OR_CONTINUE;
+  }
+
+  // 2303=2,%2s% = resolve_filepath %1s%
+  static OpcodeResult __stdcall opcode_2303(CRunningScript *thread) {
+    OPCODE_READ_PARAM_FILEPATH(
+        path); // it also resolves the path to absolute form
+
+    OPCODE_WRITE_PARAM_STRING(path);
+    return OR_CONTINUE;
+  }
+
+  // 2304=3,%3s% = get_script_filename %1d% full_path %2d% // IF and SET
+  static OpcodeResult __stdcall opcode_2304(CRunningScript *thread) {
+    auto script = OPCODE_READ_PARAM_INT();
+    auto fullPath = OPCODE_READ_PARAM_BOOL();
+
+    if (script == -1) // special case: current script
     {
-        auto handle = OPCODE_READ_PARAM_INT();
-
-        if (m_hFiles.find(handle) != m_hFiles.end())
-        {
-            File::close(handle);
-            m_hFiles.erase(handle);
-        }
-        else
-        {
-            if (!IsLegacyScript(thread))
-            {
-                SHOW_ERROR_COMPAT("Invalid or already closed '0x%X' file handle param in script %s \nScript suspended.", handle, ScriptInfoStr(thread).c_str());
-                return thread->Suspend();
-            }
-        }
-
-        return OR_CONTINUE;
+      script = (int)thread;
+    } else {
+      OPCODE_VALIDATE_POINTER(script);
     }
 
-    //0A9C=2,get_file_size %1d% store_to %2d%
-    static OpcodeResult __stdcall opcode_0A9C(CRunningScript* thread)
-    {
-        OPCODE_READ_PARAM_FILE_HANDLE(handle);
-
-        auto size = File::getSize(handle);
-
-        OPCODE_WRITE_PARAM_INT(size);
-        return OR_CONTINUE;
+    const char *filename = CLEO_GetScriptFilename((CRunningScript *)script);
+    if (filename == nullptr) {
+      OPCODE_SKIP_PARAMS(1);
+      OPCODE_CONDITION_RESULT(false);
+      return OR_CONTINUE;
     }
 
-    //0A9D=3,read_from_file %1d% size %2d% store_to %3d%
-    static OpcodeResult __stdcall opcode_0A9D(CRunningScript* thread)
-    {
-        OPCODE_READ_PARAM_FILE_HANDLE(handle);
-        auto size = OPCODE_READ_PARAM_INT();
-        auto destination = OPCODE_READ_PARAM_OUTPUT_VAR_ANY32();
-
-        if (size < 0)
-        {
-            SHOW_ERROR("Invalid '%d' size argument in script %s\nScript suspended.", size, ScriptInfoStr(thread).c_str());
-            return thread->Suspend();
-        }
-
-        destination->dwParam = 0; // clear not overwritten bytes - https://github.com/cleolibrary/CLEO4/issues/91
-        if (size > 0) File::read(handle, destination, size);
-        return OR_CONTINUE;
+    if (!fullPath) {
+      OPCODE_WRITE_PARAM_STRING(filename);
+    } else {
+      std::string absolute = ".\\";
+      absolute += filename;
+      absolute.resize(MAX_STR_LEN);
+      CLEO_ResolvePath((CRunningScript *)script, absolute.data(), MAX_STR_LEN);
+      OPCODE_WRITE_PARAM_STRING(absolute.c_str());
     }
 
-    //0A9E=3,write_to_file %1d% size %2d% from %3d%
-    static OpcodeResult __stdcall opcode_0A9E(CRunningScript* thread)
-    {
-        OPCODE_READ_PARAM_FILE_HANDLE(handle);
-        auto size = OPCODE_READ_PARAM_INT();
+    OPCODE_CONDITION_RESULT(true);
+    return OR_CONTINUE;
+  }
 
-        if (size < 0)
-        {
-            SHOW_ERROR("Invalid '%d' size argument in script %s\nScript suspended.", size, ScriptInfoStr(thread).c_str());
-            return thread->Suspend();
-        }
+  // 2305=8,  get_file_write_time %1s% year %2d% month %3d% day %3d% hour %4d%
+  // minute %5d% second %6d% milisecond %7d% // IF and SET
+  static OpcodeResult __stdcall opcode_2305(CRunningScript *thread) {
+    OPCODE_READ_PARAM_FILEPATH(path);
 
-        if (size == 0)
-        {
-            OPCODE_SKIP_PARAMS(1); // from
-            return OR_CONTINUE; // done
-        }
-
-        const void* source;
-        auto paramType = thread->PeekDataType();
-        if (IsVariable(paramType))
-        {
-            source = CLEO_GetPointerToScriptVariable(thread);
-        }
-        else if(IsImmString(paramType) || IsVarString(paramType))
-        {
-            static char buffer[MAX_STR_LEN];
-
-            if (size > MAX_STR_LEN)
-            {
-                SHOW_ERROR("Size argument (%d) greater than supported (%d) in script %s\nScript suspended.", size, MAX_STR_LEN, ScriptInfoStr(thread).c_str());
-                return thread->Suspend();
-            }
-
-            ZeroMemory(buffer, size); // padd with zeros if size > length
-            source = CLEO_ReadStringOpcodeParam(thread, buffer, sizeof(buffer));
-        }
-        else
-        {
-            if (size > sizeof(SCRIPT_VAR))
-            {
-                SHOW_ERROR("Size argument (%d) greater than supported (%d) in script %s\nScript suspended.", size, sizeof(SCRIPT_VAR), ScriptInfoStr(thread).c_str());
-                return thread->Suspend();
-            }
-
-            CLEO_RetrieveOpcodeParams(thread, 1);
-            source = CLEO_GetOpcodeParamsArray();
-        }
-
-        File::write(handle, source, size);
-        if (File::isOk(handle)) File::flush(handle);
-        return OR_CONTINUE;
+    HANDLE file = CreateFile(path, GENERIC_READ, FILE_SHARE_READ, NULL,
+                             OPEN_EXISTING, 0, NULL);
+    if (file == INVALID_HANDLE_VALUE) {
+      OPCODE_SKIP_PARAMS(7);
+      OPCODE_CONDITION_RESULT(false);
+      return OR_CONTINUE;
     }
 
-    // 0AAB=1,  does_file_exist %1s%
-    static OpcodeResult __stdcall Script_FS_FileExists(CRunningScript* thread)
-    {
-        OPCODE_READ_PARAM_FILEPATH(filename);
-
-        DWORD fAttr = GetFileAttributes(filename);
-        bool exists = (fAttr != INVALID_FILE_ATTRIBUTES) && !(fAttr & FILE_ATTRIBUTE_DIRECTORY);
-
-        OPCODE_CONDITION_RESULT(exists);
-        return OR_CONTINUE;
+    FILETIME writeTime;
+    if (!GetFileTime(file, nullptr, nullptr, &writeTime)) {
+      CloseHandle(file);
+      OPCODE_SKIP_PARAMS(7);
+      OPCODE_CONDITION_RESULT(false);
+      return OR_CONTINUE;
     }
-
-    //0AD5=3,  file_seek %1d% offset %2d% origin %3d% //IF and SET
-    static OpcodeResult __stdcall opcode_0AD5(CRunningScript* thread)
-    {
-        OPCODE_READ_PARAM_FILE_HANDLE(handle);
-        auto offset = OPCODE_READ_PARAM_INT();
-        auto origin = OPCODE_READ_PARAM_UINT();
-
-        auto ok = File::seek(handle, offset, origin);
-
-        OPCODE_CONDITION_RESULT(ok);
-        return OR_CONTINUE;
-    }
-
-    //0AD6=1,  is_end_of_file_reached %1d%
-    static OpcodeResult __stdcall opcode_0AD6(CRunningScript* thread)
-    {
-        OPCODE_READ_PARAM_FILE_HANDLE(handle);
-
-        bool end = !File::isOk(handle) || File::isEndOfFile(handle);
-
-        OPCODE_CONDITION_RESULT(end);
-        return OR_CONTINUE;
-    }
-
-    //0AD7=3,  read_string_from_file %1d% to %2d% size %3d% //IF and SET
-    static OpcodeResult __stdcall opcode_0AD7(CRunningScript* thread)
-    {
-        OPCODE_READ_PARAM_FILE_HANDLE(handle);
-        auto result = OPCODE_READ_PARAM_OUTPUT_VAR_STRING();
-        auto size = OPCODE_READ_PARAM_INT();
-
-        if (size < 0)
-        {
-            SHOW_ERROR("Invalid size argument (%d) in script %s\nScript suspended.", size, ScriptInfoStr(thread).c_str());
-            return thread->Suspend();
-        }
-
-        if (size == 0)
-        {
-            OPCODE_CONDITION_RESULT(true);
-            return OR_CONTINUE;
-        }
-
-        // use caller's size argument, ignoring actual target type size. Intended for legacy reasons.
-        bool ok = File::readString(handle, result.data, size) != nullptr;
-
-        // remove line ending characters if present
-        if (ok && !IsLegacyScript(thread))
-        {
-            auto last = (int)strlen(result.data) - 1;
-            while (last >= 0)
-            {
-                if (result.data[last] != '\n' && result.data[last] != '\r')
-                {
-                    break;
-                }
-
-                result.data[last] = '\0';
-                last--;
-            }
-        }
-
-        OPCODE_CONDITION_RESULT(ok);
-        return OR_CONTINUE;
-    }
-
-    //0AD8=2,  write_string_to_file %1d% from %2d% //IF and SET
-    static OpcodeResult __stdcall opcode_0AD8(CRunningScript* thread)
-    {
-        OPCODE_READ_PARAM_FILE_HANDLE(handle);
-        OPCODE_READ_PARAM_STRING(text);
-
-        auto ok = File::writeString(handle, text);
-        if (!ok)
-        {
-            OPCODE_CONDITION_RESULT(false);
-            return OR_CONTINUE;
-        }
-
-        File::flush(handle);
-        OPCODE_CONDITION_RESULT(true);
-        return OR_CONTINUE;
-    }
-
-    //0AD9=-1,write_formated_text %2d% to_file %1d%
-    static OpcodeResult __stdcall opcode_0AD9(CRunningScript* thread)
-    {
-        OPCODE_READ_PARAM_FILE_HANDLE(handle);
-        OPCODE_READ_PARAM_STRING_FORMATTED(text);
-        
-        auto ok = File::writeString(handle, text);
-        if (!ok)
-        {
-            return OR_CONTINUE;
-        }
-
-        File::flush(handle);
-        return OR_CONTINUE;
-    }
-
-    //0ADA=-1,  %3d% = scan_file %1d% format %2d% //IF and SET
-    static OpcodeResult __stdcall opcode_0ADA(CRunningScript* thread)
-    {
-        OPCODE_READ_PARAM_FILE_HANDLE(handle);
-        OPCODE_READ_PARAM_STRING(format);
-        auto result = OPCODE_READ_PARAM_OUTPUT_VAR_ANY32();
-
-        size_t paramCount = 0;
-        SCRIPT_VAR* outputParams[35];
-        while (thread->PeekDataType() != eDataType::DT_END)
-        {
-            // TODO: if target param is string variable it should be handled correctly
-            outputParams[paramCount++] = CLEO_GetPointerToScriptVariable(thread);
-        }
-        CLEO_SkipUnusedVarArgs(thread); // var arg terminator
-
-        result->dwParam = File::scan(handle, format, (void**)&outputParams);
-
-        //OPCODE_CONDITION_RESULT(paramCount == result->dwParam);
-        OPCODE_CONDITION_RESULT(true);
-        return OR_CONTINUE;
-    }
-
-    // 0AE4=1,  directory_exist %1s%
-    static OpcodeResult __stdcall Script_FS_DirectoryExists(CRunningScript* thread)
-    {
-        OPCODE_READ_PARAM_FILEPATH(filename);
-
-        DWORD fAttr = GetFileAttributes(filename);
-        bool exists = (fAttr != INVALID_FILE_ATTRIBUTES) && (fAttr & FILE_ATTRIBUTE_DIRECTORY);
-
-        OPCODE_CONDITION_RESULT(exists);
-        return OR_CONTINUE;
-    }
-
-    // 0AE5=1,  create_directory %1s% //IF and SET
-    static OpcodeResult __stdcall Script_FS_CreateDirectory(CRunningScript* thread)
-    {
-        OPCODE_READ_PARAM_FILEPATH(filename);
-
-        bool result = CreateDirectory(filename, NULL) != 0;
-
-        OPCODE_CONDITION_RESULT(result);
-        return OR_CONTINUE;
-    }
-
-    // 0AE6=3,  %2d% = find_first_file %1s% get_filename_to %3s% //IF and SET
-    static OpcodeResult __stdcall Script_FS_FindFirstFile(CRunningScript* thread)
-    {
-        OPCODE_READ_PARAM_FILEPATH(filename);
-
-        WIN32_FIND_DATA ffd = { 0 };
-        HANDLE handle = FindFirstFile(filename, &ffd);
-
-        if (handle == INVALID_HANDLE_VALUE) // -1
-        {
-            OPCODE_WRITE_PARAM_INT(-1); // invalid handle
-            OPCODE_SKIP_PARAMS(1); // filename
-            OPCODE_CONDITION_RESULT(false);
-            return OR_CONTINUE;
-        }
-
-        m_hFileSearches.insert(handle);
-
-        OPCODE_WRITE_PARAM_INT(handle);
-        OPCODE_WRITE_PARAM_STRING(ffd.cFileName);
-        OPCODE_CONDITION_RESULT(true);
-        return OR_CONTINUE;
-    }
-
-    // 0AE7=2,%2s% = find_next_file %1d% //IF and SET
-    static OpcodeResult __stdcall Script_FS_FindNextFile(CRunningScript* thread)
-    {
-        auto handle = (HANDLE)OPCODE_READ_PARAM_INT();
-
-        if (m_hFileSearches.find(handle) == m_hFileSearches.end())
-        {
-            LOG_WARNING(thread, "Invalid or already closed file search handle (0x%X) in script %s", handle, ScriptInfoStr(thread).c_str());
-            OPCODE_SKIP_PARAMS(1);
-            OPCODE_CONDITION_RESULT(false);
-            return OR_CONTINUE;
-        }
-
-        WIN32_FIND_DATA ffd = { 0 };
-        if (!FindNextFile(handle, &ffd))
-        {
-            OPCODE_SKIP_PARAMS(1);
-            OPCODE_CONDITION_RESULT(false);
-            return OR_CONTINUE;
-        }
-
-        OPCODE_WRITE_PARAM_STRING(ffd.cFileName);
-        OPCODE_CONDITION_RESULT(true);
-        return OR_CONTINUE;
-    }
-
-    // 0AE8=1,find_close %1d%
-    static OpcodeResult __stdcall Script_FS_FindClose(CRunningScript* thread)
-    {
-        auto handle = (HANDLE)OPCODE_READ_PARAM_INT();
-
-        if (m_hFileSearches.find(handle) == m_hFileSearches.end())
-        {
-            LOG_WARNING(thread, "Invalid or already closed file search handle (0x%X) in script %s", handle, ScriptInfoStr(thread).c_str());
-            return OR_CONTINUE;
-        }
-
-        FindClose(handle);
-        m_hFileSearches.erase(handle);
-        return OR_CONTINUE;
-    }
-
-    // 0B00=1,  delete_file %1s% //IF and SET
-    static OpcodeResult __stdcall Script_FS_DeleteFile(CRunningScript* thread)
-    {
-        OPCODE_READ_PARAM_FILEPATH(filename);
-
-        auto success = DeleteFile(filename);
-
-        OPCODE_CONDITION_RESULT(success);
-        return OR_CONTINUE;
-    }
-
-    static BOOL DeleteDir(const char *path)
-    {
-        char mask[MAX_PATH];
-        HANDLE hSearch = NULL;
-        WIN32_FIND_DATA wfd;
-        char subPath[MAX_PATH];
-
-        memset(&wfd, 0, sizeof(wfd));
-        //search mask
-        sprintf_s(mask, "%s\\*", path);
-
-        //try to delete all inside first
-        if ((hSearch = FindFirstFile(mask, &wfd)) != INVALID_HANDLE_VALUE)
-        {
-            do
-            {
-                //recursively delete subdirectories
-                if (wfd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
-                {
-                    if ((strcmp(wfd.cFileName, "..") != 0) && (strcmp(wfd.cFileName, ".") != 0))
-                    {
-                        sprintf_s(subPath, "%s\\%s", path, wfd.cFileName);
-                        if (!DeleteDir(subPath))
-                            return FALSE;
-                    }
-                }
-                else
-                {
-                    //remove read-only, system, hidden flags
-                    sprintf_s(subPath, "%s\\%s", path, wfd.cFileName);
-                    SetFileAttributes(subPath, FILE_ATTRIBUTE_NORMAL);
-                    //delete file
-                    if (!DeleteFile(subPath))
-                        return FALSE;
-                }
-
-
-            } while (FindNextFile(hSearch, &wfd));
-            FindClose(hSearch);
-        }
-
-        //delete empty directory
-        return RemoveDirectory(path);
-    }
-
-    // 0B01=1, delete_directory %1s% with_all_files_and_subdirectories %2d% //IF and SET
-    static OpcodeResult __stdcall Script_FS_DeleteDirectory(CRunningScript* thread)
-    {
-        OPCODE_READ_PARAM_FILEPATH(filename);
-        auto deleteContents = OPCODE_READ_PARAM_BOOL();
-
-        BOOL result;
-        if (deleteContents)
-        {
-            // remove directory with all files and subdirectories
-            result = DeleteDir(filename);
-        }
-        else
-        {
-            // try to remove as empty directory
-            result = RemoveDirectory(filename);
-        }
-
-        OPCODE_CONDITION_RESULT(result);
-        return OR_CONTINUE;
-    }
-
-    // 0B02=2, move_file %1s% to %2s% //IF and SET
-    static OpcodeResult __stdcall Script_FS_MoveFile(CRunningScript* thread)
-    {
-        OPCODE_READ_PARAM_FILEPATH(filepath);
-        OPCODE_READ_PARAM_FILEPATH(newFilepath);
-
-        bool result = false;
-
-        auto fsPath = FS::path(filepath);
-        if (FS::is_regular_file(fsPath))
-        {
-            std::error_code err;
-            FS::rename(fsPath, newFilepath, err);
-            result = !err;
-        }
-
-        OPCODE_CONDITION_RESULT(result);
-        return OR_CONTINUE;
-    }
-
-    // 0B03=2, move_directory %1s% to %2s% //IF and SET
-    static OpcodeResult __stdcall Script_FS_MoveDir(CRunningScript* thread)
-    {
-        OPCODE_READ_PARAM_FILEPATH(filepath);
-        OPCODE_READ_PARAM_FILEPATH(newFilepath);
-
-        bool result = false;
-
-        auto fsPath = FS::path(filepath);
-        if (FS::is_directory(fsPath))
-        {
-            std::error_code err;
-            FS::rename(fsPath, newFilepath, err);
-            result = !err;
-        }
-
-        OPCODE_CONDITION_RESULT(result);
-        return OR_CONTINUE;
-    }
-
-    // 0B04=2, copy_file %1s% to %2s% //IF and SET
-    static OpcodeResult __stdcall Script_FS_CopyFile(CRunningScript* thread)
-    {
-        OPCODE_READ_PARAM_FILEPATH(filepath);
-        OPCODE_READ_PARAM_FILEPATH(newFilepath);
-
-        BOOL result = CopyFile(filepath, newFilepath, FALSE);
-        if (result)
-        {
-            // copy file attributes
-            DWORD fattr = GetFileAttributes(filepath);
-            SetFileAttributes(newFilepath, fattr);
-        }
-
-        OPCODE_CONDITION_RESULT(result);
-        return OR_CONTINUE;
-    }
-
-    // 0B05=2,  copy_directory %1d% to %2d% //IF and SET
-    static OpcodeResult __stdcall Script_FS_CopyDir(CRunningScript* thread)
-    {
-        OPCODE_READ_PARAM_FILEPATH(filepath);
-        OPCODE_READ_PARAM_FILEPATH(newFilepath);
-
-        auto path = FS::path(filepath);
-        if (!FS::is_directory(path))
-        {
-            OPCODE_CONDITION_RESULT(false);
-            return OR_CONTINUE;
-        }
-
-        std::error_code err;
-        FS::copy(filepath, newFilepath, FS::copy_options::update_existing | FS::copy_options::recursive, err);
-
-        OPCODE_CONDITION_RESULT(!err);
-        return OR_CONTINUE;
-    }
-
-    //2300=2,get_file_position %1d% store_to %2d%
-    static OpcodeResult __stdcall opcode_2300(CRunningScript* thread)
-    {
-        OPCODE_READ_PARAM_FILE_HANDLE(handle);
-
-        auto pos = File::getPos(handle);
-
-        OPCODE_WRITE_PARAM_INT(pos);
-        return OR_CONTINUE;
-    }
-
-    //2301=3,read_block_from_file %1d% size %2d% buffer %3d% // IF and SET
-    static OpcodeResult __stdcall opcode_2301(CRunningScript* thread)
-    {
-        OPCODE_READ_PARAM_FILE_HANDLE(handle);
-        auto size = OPCODE_READ_PARAM_INT();
-        auto destination = OPCODE_READ_PARAM_PTR();
-
-        if (size < 0)
-        {
-            SHOW_ERROR("Invalid size argument (%d) in script %s\nScript suspended.", size, ScriptInfoStr(thread).c_str());
-            return thread->Suspend();
-        }
-
-        if (size == 0)
-        {
-            OPCODE_CONDITION_RESULT(true); // done
-            return OR_CONTINUE;
-        }
-
-        auto readCount = File::read(handle, destination, size);
-        if (readCount != size)
-        {
-            OPCODE_CONDITION_RESULT(false);
-            return OR_CONTINUE;
-        }
-
-        OPCODE_CONDITION_RESULT(true);
-        return OR_CONTINUE;
-    }
-
-    //2302=3,  write_block_to_file %1d% size %2d% address %3d% // IF and SET
-    static OpcodeResult __stdcall opcode_2302(CRunningScript* thread)
-    {
-        OPCODE_READ_PARAM_FILE_HANDLE(handle);
-        auto size = OPCODE_READ_PARAM_INT();
-        auto source = OPCODE_READ_PARAM_PTR();
-
-        if (size < 0)
-        {
-            SHOW_ERROR("Invalid size argument (%d) in script %s\nScript suspended.", size, ScriptInfoStr(thread).c_str());
-            return thread->Suspend();
-        }
-
-        if (size == 0)
-        {
-            OPCODE_CONDITION_RESULT(true);
-            return OR_CONTINUE;
-        }
-
-        auto readCount = File::write(handle, source, size);
-
-        OPCODE_CONDITION_RESULT(readCount == size);
-        return OR_CONTINUE;
-    }
-
-    //2303=2,%2s% = resolve_filepath %1s%
-    static OpcodeResult __stdcall opcode_2303(CRunningScript* thread)
-    {
-        OPCODE_READ_PARAM_FILEPATH(path); // it also resolves the path to absolute form
-
-        OPCODE_WRITE_PARAM_STRING(path);
-        return OR_CONTINUE;
-    }
-
-    //2304=3,%3s% = get_script_filename %1d% full_path %2d% // IF and SET
-    static OpcodeResult __stdcall opcode_2304(CRunningScript* thread)
-    {
-        auto script = OPCODE_READ_PARAM_INT();
-        auto fullPath = OPCODE_READ_PARAM_BOOL();
-
-        if (script == -1) // special case: current script
-        {
-            script = (int)thread;
-        }
-        else
-        {
-            OPCODE_VALIDATE_POINTER(script);
-        }
-
-        const char* filename = CLEO_GetScriptFilename((CRunningScript*)script);
-        if (filename == nullptr)
-        {
-            OPCODE_SKIP_PARAMS(1);
-            OPCODE_CONDITION_RESULT(false);
-            return OR_CONTINUE;
-        }
-
-        if (!fullPath)
-        {
-            OPCODE_WRITE_PARAM_STRING(filename);
-        }
-        else
-        {
-            std::string absolute = ".\\";
-            absolute += filename;
-            absolute.resize(MAX_STR_LEN);
-            CLEO_ResolvePath((CRunningScript*)script, absolute.data(), MAX_STR_LEN);
-            OPCODE_WRITE_PARAM_STRING(absolute.c_str());
-        }
-
-        OPCODE_CONDITION_RESULT(true);
-        return OR_CONTINUE;
-    }
-
-    //2305=8,  get_file_write_time %1s% year %2d% month %3d% day %3d% hour %4d% minute %5d% second %6d% milisecond %7d% // IF and SET
-    static OpcodeResult __stdcall opcode_2305(CRunningScript* thread)
-    {
-        OPCODE_READ_PARAM_FILEPATH(path);
-
-        HANDLE file = CreateFile(path, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, 0, NULL);
-        if (file == INVALID_HANDLE_VALUE)
-        {
-            OPCODE_SKIP_PARAMS(7);
-            OPCODE_CONDITION_RESULT(false);
-            return OR_CONTINUE;
-        }
-
-        FILETIME writeTime;
-        if (!GetFileTime(file, nullptr, nullptr, &writeTime))
-        {
-            CloseHandle(file);
-            OPCODE_SKIP_PARAMS(7);
-            OPCODE_CONDITION_RESULT(false);
-            return OR_CONTINUE;
-        }
-        CloseHandle(file);
-
-        // convert to local time
-        SYSTEMTIME timeUTC, timeLocal;
-        FileTimeToSystemTime(&writeTime, &timeUTC);
-        SystemTimeToTzSpecificLocalTime(NULL, &timeUTC, &timeLocal);
-
-        OPCODE_WRITE_PARAM_INT(timeLocal.wYear);
-        OPCODE_WRITE_PARAM_INT(timeLocal.wMonth);
-        OPCODE_WRITE_PARAM_INT(timeLocal.wDay);
-        OPCODE_WRITE_PARAM_INT(timeLocal.wHour);
-        OPCODE_WRITE_PARAM_INT(timeLocal.wMinute);
-        OPCODE_WRITE_PARAM_INT(timeLocal.wSecond);
-        OPCODE_WRITE_PARAM_INT(timeLocal.wMilliseconds);
-        OPCODE_CONDITION_RESULT(true);
-        return OR_CONTINUE;
-    }
+    CloseHandle(file);
+
+    // convert to local time
+    SYSTEMTIME timeUTC, timeLocal;
+    FileTimeToSystemTime(&writeTime, &timeUTC);
+    SystemTimeToTzSpecificLocalTime(NULL, &timeUTC, &timeLocal);
+
+    OPCODE_WRITE_PARAM_INT(timeLocal.wYear);
+    OPCODE_WRITE_PARAM_INT(timeLocal.wMonth);
+    OPCODE_WRITE_PARAM_INT(timeLocal.wDay);
+    OPCODE_WRITE_PARAM_INT(timeLocal.wHour);
+    OPCODE_WRITE_PARAM_INT(timeLocal.wMinute);
+    OPCODE_WRITE_PARAM_INT(timeLocal.wSecond);
+    OPCODE_WRITE_PARAM_INT(timeLocal.wMilliseconds);
+    OPCODE_CONDITION_RESULT(true);
+    return OR_CONTINUE;
+  }
 } fileSystemOperations;
 
 std::set<DWORD> FileSystemOperations::m_hFiles;

--- a/cleo_plugins/FileSystemOperations/FileUtils.cpp
+++ b/cleo_plugins/FileSystemOperations/FileUtils.cpp
@@ -16,275 +16,275 @@ DWORD File::FUNC_fflush = 0;
 DWORD File::FUNC_feof = 0;
 DWORD File::FUNC_ferror = 0;
 
-void File::initialize(CLEO::eGameVersion version)
-{
-	// GV_US10, GV_US11, GV_EU10, GV_EU11, GV_STEAM
-	const DWORD MA_FOPEN_FUNCTION[] =	{ 0x008232D8, 0, 0x00823318, 0x00824098, 0x0085C75E };
-	const DWORD MA_FCLOSE_FUNCTION[] =	{ 0x0082318B, 0, 0x008231CB, 0x00823F4B, 0x0085C396 };
-	const DWORD MA_FGETC_FUNCTION[] =	{ 0x008231DC, 0, 0x0082321C, 0x00823F9C, 0x0085C680 };
-	const DWORD MA_FGETS_FUNCTION[] =	{ 0x00823798, 0, 0x008237D8, 0x00824558, 0x0085D00C };
-	const DWORD MA_FPUTS_FUNCTION[] =	{ 0x008262B8, 0, 0x008262F8, 0x00826BA8, 0x008621F1 };
-	const DWORD MA_FREAD_FUNCTION[] =	{ 0x00823521, 0, 0x00823561, 0x008242E1, 0x0085CD04 };
-	const DWORD MA_FWRITE_FUNCTION[] =	{ 0x00823674, 0, 0x008236B4, 0x00824434, 0x0085CE7E };
-	const DWORD MA_FSEEK_FUNCTION[] =	{ 0x0082374F, 0, 0x0082378F, 0x0082450F, 0x0085CF87 };
-	const DWORD MA_FPRINTF_FUNCTION[] = { 0x00823A30, 0, 0x00823A70, 0x008247F0, 0x0085D464 };
-	const DWORD MA_FTELL_FUNCTION[] =	{ 0x00826261, 0, 0x008262A1, 0x00826B51, 0x00862183 };
-	const DWORD MA_FFLUSH_FUNCTION[] =	{ 0x00823E86, 0, 0x00823EC6, 0x00824C46, 0x0085DDDD };
-	const DWORD MA_FEOF_FUNCTION[] =	{ 0x008262A2, 0, 0x008262E2, 0x00826B92, 0x0085D193 };
-	const DWORD MA_FERROR_FUNCTION[] =	{ 0x008262AD, 0, 0x008262ED, 0x00826B9D, 0x0085D1C2 };
+void File::initialize(CLEO::eGameVersion version) {
+  // GV_US10, GV_US11, GV_EU10, GV_EU11, GV_STEAM
+  const DWORD MA_FOPEN_FUNCTION[] = {0x008232D8, 0, 0x00823318, 0x00824098,
+                                     0x0085C75E};
+  const DWORD MA_FCLOSE_FUNCTION[] = {0x0082318B, 0, 0x008231CB, 0x00823F4B,
+                                      0x0085C396};
+  const DWORD MA_FGETC_FUNCTION[] = {0x008231DC, 0, 0x0082321C, 0x00823F9C,
+                                     0x0085C680};
+  const DWORD MA_FGETS_FUNCTION[] = {0x00823798, 0, 0x008237D8, 0x00824558,
+                                     0x0085D00C};
+  const DWORD MA_FPUTS_FUNCTION[] = {0x008262B8, 0, 0x008262F8, 0x00826BA8,
+                                     0x008621F1};
+  const DWORD MA_FREAD_FUNCTION[] = {0x00823521, 0, 0x00823561, 0x008242E1,
+                                     0x0085CD04};
+  const DWORD MA_FWRITE_FUNCTION[] = {0x00823674, 0, 0x008236B4, 0x00824434,
+                                      0x0085CE7E};
+  const DWORD MA_FSEEK_FUNCTION[] = {0x0082374F, 0, 0x0082378F, 0x0082450F,
+                                     0x0085CF87};
+  const DWORD MA_FPRINTF_FUNCTION[] = {0x00823A30, 0, 0x00823A70, 0x008247F0,
+                                       0x0085D464};
+  const DWORD MA_FTELL_FUNCTION[] = {0x00826261, 0, 0x008262A1, 0x00826B51,
+                                     0x00862183};
+  const DWORD MA_FFLUSH_FUNCTION[] = {0x00823E86, 0, 0x00823EC6, 0x00824C46,
+                                      0x0085DDDD};
+  const DWORD MA_FEOF_FUNCTION[] = {0x008262A2, 0, 0x008262E2, 0x00826B92,
+                                    0x0085D193};
+  const DWORD MA_FERROR_FUNCTION[] = {0x008262AD, 0, 0x008262ED, 0x00826B9D,
+                                      0x0085D1C2};
 
-	FUNC_fopen = MA_FOPEN_FUNCTION[version];
-	FUNC_fclose = MA_FCLOSE_FUNCTION[version];
-	FUNC_fread = MA_FREAD_FUNCTION[version];
-	FUNC_fwrite = MA_FWRITE_FUNCTION[version];
-	FUNC_fgetc = MA_FGETC_FUNCTION[version];
-	FUNC_fgets = MA_FGETS_FUNCTION[version];
-	FUNC_fputs = MA_FPUTS_FUNCTION[version];
-	FUNC_fseek = MA_FSEEK_FUNCTION[version];
-	FUNC_fprintf = MA_FPRINTF_FUNCTION[version];
-	FUNC_ftell = MA_FTELL_FUNCTION[version];
-	FUNC_fflush = MA_FFLUSH_FUNCTION[version];
-	FUNC_feof = MA_FEOF_FUNCTION[version];
-	FUNC_ferror = MA_FERROR_FUNCTION[version];;
+  FUNC_fopen = MA_FOPEN_FUNCTION[version];
+  FUNC_fclose = MA_FCLOSE_FUNCTION[version];
+  FUNC_fread = MA_FREAD_FUNCTION[version];
+  FUNC_fwrite = MA_FWRITE_FUNCTION[version];
+  FUNC_fgetc = MA_FGETC_FUNCTION[version];
+  FUNC_fgets = MA_FGETS_FUNCTION[version];
+  FUNC_fputs = MA_FPUTS_FUNCTION[version];
+  FUNC_fseek = MA_FSEEK_FUNCTION[version];
+  FUNC_fprintf = MA_FPRINTF_FUNCTION[version];
+  FUNC_ftell = MA_FTELL_FUNCTION[version];
+  FUNC_fflush = MA_FFLUSH_FUNCTION[version];
+  FUNC_feof = MA_FEOF_FUNCTION[version];
+  FUNC_ferror = MA_FERROR_FUNCTION[version];
+  ;
 }
 
 bool File::isLegacy(DWORD handle) { return (handle & 0x1) == 0; }
 
-FILE* File::handleToFile(DWORD handle) { return (FILE*)(handle & ~0x1); }
+FILE *File::handleToFile(DWORD handle) { return (FILE *)(handle & ~0x1); }
 
-DWORD File::fileToHandle(FILE* file, bool legacy)
-{
-	if (file == nullptr) return 0;
+DWORD File::fileToHandle(FILE *file, bool legacy) {
+  if (file == nullptr)
+    return 0;
 
-	auto handle = (DWORD)file;
-	if (!legacy) handle |= 0x1;
-	return handle;
+  auto handle = (DWORD)file;
+  if (!legacy)
+    handle |= 0x1;
+  return handle;
 }
 
-void File::updateState(DWORD handle)
-{
-	// RW streams needs synchronization of read and write positions (https://en.wikibooks.org/wiki/C_Programming/stdio.h/fopen)
-	if (isOk(handle) && !isEndOfFile(handle))
-	{
-		seek(handle, 0, SEEK_CUR);
-	}
+void File::updateState(DWORD handle) {
+  // RW streams needs synchronization of read and write positions
+  // (https://en.wikibooks.org/wiki/C_Programming/stdio.h/fopen)
+  if (isOk(handle) && !isEndOfFile(handle)) {
+    seek(handle, 0, SEEK_CUR);
+  }
 }
 
-bool File::flush(DWORD handle)
-{
-	FILE* file = handleToFile(handle);
-	if (file == nullptr) return false;
+bool File::flush(DWORD handle) {
+  FILE *file = handleToFile(handle);
+  if (file == nullptr)
+    return false;
 
-	int result = 0;
-	if (isLegacy(handle))
-	{
-		_asm
-		{
+  int result = 0;
+  if (isLegacy(handle)) {
+    _asm
+    {
 			push file
 			call FUNC_fflush
 			add esp, 0x4
 			mov result, eax
-		}
-	}
-	else
-		result = fflush(file);
+    }
+  } else
+    result = fflush(file);
 
-	return result == 0;
+  return result == 0;
 }
 
-DWORD File::open(const char* filename, const char* mode, bool legacy)
-{
-	// validate the mode argument
-	if (!legacy)
-	{
-		static char modeUpdated[12];
-		const std::string allowed = "+abcnrtwxDRST"; // https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/fopen-wfopen?view=msvc-170
+DWORD File::open(const char *filename, const char *mode, bool legacy) {
+  // validate the mode argument
+  if (!legacy) {
+    static char modeUpdated[12];
+    const std::string allowed =
+        "+abcnrtwxDRST"; // https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/fopen-wfopen?view=msvc-170
 
-		bool valid = false;
-		bool binary = false;
-		bool text = false;
-		auto modeLen = mode != nullptr ? strlen(mode) : 0;
-		if (modeLen > 0 && modeLen < (sizeof(modeUpdated) - 1)) // keep space for extra binary mode char
-		{
-			valid = true;
+    bool valid = false;
+    bool binary = false;
+    bool text = false;
+    auto modeLen = mode != nullptr ? strlen(mode) : 0;
+    if (modeLen > 0 && modeLen < (sizeof(modeUpdated) -
+                                  1)) // keep space for extra binary mode char
+    {
+      valid = true;
 
-			for (auto ch : std::string_view(mode))
-			{
-				if (allowed.find(ch) == std::string_view::npos)
-				{
-					valid = false;
-					break; // invalid character
-				}
+      for (auto ch : std::string_view(mode)) {
+        if (allowed.find(ch) == std::string_view::npos) {
+          valid = false;
+          break; // invalid character
+        }
 
-				if (ch == 'b') binary = true;
-				if (ch == 't') text = true;
-			}
+        if (ch == 'b')
+          binary = true;
+        if (ch == 't')
+          text = true;
+      }
 
-			if (binary && text) valid = false;
+      if (binary && text)
+        valid = false;
 
-			// By default open as binary mode.
-			// Generally text mode is not well documented in C and many file related functions has undefined behavior. For example 'ftell' returns invalid values.
-			if (valid && (!binary && !text))
-			{
-				strcpy_s(modeUpdated, mode);
-				strcat_s(modeUpdated, "b");
-				mode = modeUpdated;
-			}
-		}
+      // By default open as binary mode.
+      // Generally text mode is not well documented in C and many file related
+      // functions has undefined behavior. For example 'ftell' returns invalid
+      // values.
+      if (valid && (!binary && !text)) {
+        strcpy_s(modeUpdated, mode);
+        strcat_s(modeUpdated, "b");
+        mode = modeUpdated;
+      }
+    }
 
-		if (!valid)
-		{
-			LOG_WARNING(0, "Invalid mode argument '%s' while opening file \"%s\" stream!", mode, filename);
-			return 0; // invalid handle
-		}
-	}
+    if (!valid) {
+      LOG_WARNING(
+          0, "Invalid mode argument '%s' while opening file \"%s\" stream!",
+          mode, filename);
+      return 0; // invalid handle
+    }
+  }
 
-	FILE* file = nullptr;
-	if (legacy)
-	{
-		_asm
-		{
+  FILE *file = nullptr;
+  if (legacy) {
+    _asm
+    {
 			push mode
 			push filename
 			call FUNC_fopen
 			add esp, 8
 			mov file, eax
-		}
-	}
-	else
-		fopen_s(&file, filename, mode);
+    }
+  } else
+    fopen_s(&file, filename, mode);
 
-	return fileToHandle(file, legacy);
+  return fileToHandle(file, legacy);
 }
 
-void File::close(DWORD handle)
-{
-	FILE* file = handleToFile(handle);
-	if (file == nullptr) return;
+void File::close(DWORD handle) {
+  FILE *file = handleToFile(handle);
+  if (file == nullptr)
+    return;
 
-	if (isLegacy(handle))
-	{
-		_asm
-		{
+  if (isLegacy(handle)) {
+    _asm
+        {
 			push file
 			call FUNC_fclose
 			add esp, 4
-		}
-	}
-	else
-		fclose(file);
+        }
+  } else
+    fclose(file);
 }
 
-bool File::isOk(DWORD handle)
-{
-	FILE* file = handleToFile(handle);
-	if (file == nullptr) return false;
+bool File::isOk(DWORD handle) {
+  FILE *file = handleToFile(handle);
+  if (file == nullptr)
+    return false;
 
-	int result = 0;
-	if (isLegacy(handle))
-	{
-		_asm
-		{
+  int result = 0;
+  if (isLegacy(handle)) {
+    _asm
+        {
 			push file
 			call FUNC_ferror
 			add esp, 0x4
-		}
-	}
-	else
-		result = ferror(file);
+        }
+  } else
+    result = ferror(file);
 
-	return result == 0;
+  return result == 0;
 }
 
-DWORD File::getSize(DWORD handle)
-{
-	auto pos = getPos(handle);
-	seek(handle, 0, SEEK_END);
-	DWORD size = getPos(handle);
-	seek(handle, pos, SEEK_SET);
-	return size;
+DWORD File::getSize(DWORD handle) {
+  auto pos = getPos(handle);
+  seek(handle, 0, SEEK_END);
+  DWORD size = getPos(handle);
+  seek(handle, pos, SEEK_SET);
+  return size;
 }
 
-bool File::seek(DWORD handle, int offset, DWORD orign)
-{
-	FILE* file = handleToFile(handle);
-	if (file == nullptr) return false;
+bool File::seek(DWORD handle, int offset, DWORD orign) {
+  FILE *file = handleToFile(handle);
+  if (file == nullptr)
+    return false;
 
-	int result = 0;
-	if (isLegacy(handle))
-	{
-		auto off = offset; // 'offset' is keyword in asm
-		_asm
-		{
+  int result = 0;
+  if (isLegacy(handle)) {
+    auto off = offset; // 'offset' is keyword in asm
+    _asm
+    {
 			push orign
 			push off
 			push file
 			call FUNC_fseek
 			add esp, 0xC
 			mov result, eax
-		}
-	}
-	else
-		result = fseek(file, offset, orign);
+    }
+  } else
+    result = fseek(file, offset, orign);
 
-	return result == 0;
+  return result == 0;
 }
 
-DWORD File::getPos(DWORD handle)
-{
-	FILE* file = handleToFile(handle);
-	if (file == nullptr) return 0;
+DWORD File::getPos(DWORD handle) {
+  FILE *file = handleToFile(handle);
+  if (file == nullptr)
+    return 0;
 
-	DWORD pos = 0;
-	if (isLegacy(handle))
-	{
-		_asm
-		{
+  DWORD pos = 0;
+  if (isLegacy(handle)) {
+    _asm
+    {
 			push file
 			call FUNC_ftell
 			add esp, 0x4
 			mov pos, eax
-		}
-	}
-	else
-		pos = (DWORD)ftell(file);
+    }
+  } else
+    pos = (DWORD)ftell(file);
 
-	return pos;
+  return pos;
 }
 
-bool File::isEndOfFile(DWORD handle)
-{
-	FILE* file = handleToFile(handle);
-	if (file == nullptr) return true;
+bool File::isEndOfFile(DWORD handle) {
+  FILE *file = handleToFile(handle);
+  if (file == nullptr)
+    return true;
 
-	int result = 0;
-	if (isLegacy(handle))
-	{
-		_asm
-		{
+  int result = 0;
+  if (isLegacy(handle)) {
+    _asm
+    {
 			push file
 			call FUNC_feof
 			add esp, 0x4
 			mov result, eax
-		}
-	}
-	else
-		result = feof(file);
+    }
+  } else
+    result = feof(file);
 
-	return result != 0;
+  return result != 0;
 }
 
-DWORD File::read(DWORD handle, void* buffer, DWORD size)
-{
-	FILE* file = handleToFile(handle);
-	if (file == nullptr) return 0;
+DWORD File::read(DWORD handle, void *buffer, DWORD size) {
+  FILE *file = handleToFile(handle);
+  if (file == nullptr)
+    return 0;
 
-	DWORD read = 0;
-	if (isLegacy(handle))
-	{
-		auto siz = size; // 'size' is keyword in asm
-		_asm
-		{
+  DWORD read = 0;
+  if (isLegacy(handle)) {
+    auto siz = size; // 'size' is keyword in asm
+    _asm
+    {
 			push file
 			push siz
 			push 1
@@ -292,77 +292,71 @@ DWORD File::read(DWORD handle, void* buffer, DWORD size)
 			call FUNC_fread
 			add esp, 0x10
 			mov read, eax
-		}
-	}
-	else
-		read = fread(buffer, 1, size, file);
+    }
+  } else
+    read = fread(buffer, 1, size, file);
 
-	updateState(handle);
+  updateState(handle);
 
-	return read;
+  return read;
 }
 
-char File::readChar(DWORD handle)
-{
-	FILE* file = handleToFile(handle);
-	if (file == nullptr) return 0;
+char File::readChar(DWORD handle) {
+  FILE *file = handleToFile(handle);
+  if (file == nullptr)
+    return 0;
 
-	char result = '_';
-	if (isLegacy(handle))
-	{
-		_asm
-		{
+  char result = '_';
+  if (isLegacy(handle)) {
+    _asm
+    {
 			push file
 			call FUNC_fgetc
 			add esp, 0x4
 			mov result, al
-		}
-	}
-	else
-		result = fgetc(file);
+    }
+  } else
+    result = fgetc(file);
 
-	updateState(handle);
+  updateState(handle);
 
-	return result;
+  return result;
 }
 
-char* File::readString(DWORD handle, char* buffer, DWORD bufferSize)
-{
-	FILE* file = handleToFile(handle);
-	if (file == nullptr) return nullptr;
+char *File::readString(DWORD handle, char *buffer, DWORD bufferSize) {
+  FILE *file = handleToFile(handle);
+  if (file == nullptr)
+    return nullptr;
 
-	char* result = nullptr;
-	if (isLegacy(handle))
-	{
-		_asm
-		{
+  char *result = nullptr;
+  if (isLegacy(handle)) {
+    _asm
+    {
 			push file
 			push bufferSize
 			push buffer
 			call FUNC_fgets
 			add esp, 0xC
 			mov result, eax
-		}
-	}
-	else
-		result = fgets(buffer, bufferSize, file);
+    }
+  } else
+    result = fgets(buffer, bufferSize, file);
 
-	updateState(handle);
+  updateState(handle);
 
-	return result;
+  return result;
 }
 
-DWORD File::write(DWORD handle, const void* buffer, DWORD size)
-{
-	FILE* file = handleToFile(handle);
-	if (file == nullptr) return 0;
+DWORD File::write(DWORD handle, const void *buffer, DWORD size) {
+  FILE *file = handleToFile(handle);
+  if (file == nullptr)
+    return 0;
 
-	DWORD writen = 0;
-	if (isLegacy(handle))
-	{
-		auto siz = size; // 'size' is keyword in asm
-		_asm
-		{
+  DWORD writen = 0;
+  if (isLegacy(handle)) {
+    auto siz = size; // 'size' is keyword in asm
+    _asm
+    {
 			push file
 			push siz
 			push 1
@@ -370,113 +364,111 @@ DWORD File::write(DWORD handle, const void* buffer, DWORD size)
 			call FUNC_fwrite
 			add esp, 0x10
 			mov writen, eax
-		}
-	}
-	else
-		writen = (DWORD)fwrite(buffer, 1, size, file);
+    }
+  } else
+    writen = (DWORD)fwrite(buffer, 1, size, file);
 
-	updateState(handle);
+  updateState(handle);
 
-	return writen;
+  return writen;
 }
 
-bool File::writeString(DWORD handle, const char* text)
-{
-	FILE* file = handleToFile(handle);
-	if (file == nullptr) return 0;
+bool File::writeString(DWORD handle, const char *text) {
+  FILE *file = handleToFile(handle);
+  if (file == nullptr)
+    return 0;
 
-	int result = 0;
-	if (isLegacy(handle))
-	{
-		_asm
-		{
+  int result = 0;
+  if (isLegacy(handle)) {
+    _asm
+    {
 			push file
 			push text
 			call FUNC_fputs
 			add esp, 0x8
 			mov result, eax
-		}
-	}
-	else
-		result = (DWORD)fputs(text, file);
+    }
+  } else
+    result = (DWORD)fputs(text, file);
 
-	updateState(handle);
+  updateState(handle);
 
-	return result >= 0;
+  return result >= 0;
 }
 
-DWORD File::scan(DWORD handle, const char* format, void** outputParams)
-{
-	FILE* file = handleToFile(handle);
-	if (file == nullptr) return 0;
+DWORD File::scan(DWORD handle, const char *format, void **outputParams) {
+  FILE *file = handleToFile(handle);
+  if (file == nullptr)
+    return 0;
 
-	int read = 0;
-	if (isLegacy(handle))
-	{
-		// fscanf for game file streams not existent in game's code. Emulate it
+  int read = 0;
+  if (isLegacy(handle)) {
+    // fscanf for game file streams not existent in game's code. Emulate it
 
-		size_t paramCount = 0;
-		const char* f = format;
-		while(*f != '\0')
-		{
-			if (*f == '%')
-			{
-				if (*(f + 1) != '%') // not escaped %
-					paramCount++;
-				else
-					f++; // skip escaped
-			}
-			f++;
-		}
+    size_t paramCount = 0;
+    const char *f = format;
+    while (*f != '\0') {
+      if (*f == '%') {
+        if (*(f + 1) != '%') // not escaped %
+          paramCount++;
+        else
+          f++; // skip escaped
+      }
+      f++;
+    }
 
-		auto newFormat = std::string(format) + "%n"; // %n returns characters processed by
-		DWORD charRead = 0;
-		outputParams[paramCount] = &charRead;
+    auto newFormat =
+        std::string(format) + "%n"; // %n returns characters processed by
+    DWORD charRead = 0;
+    outputParams[paramCount] = &charRead;
 
-		DWORD prevCharRead = 0;
-		std::string readText;
-		while(true)
-		{
-			readText += readChar(handle);
+    DWORD prevCharRead = 0;
+    std::string readText;
+    while (true) {
+      readText += readChar(handle);
 
-			prevCharRead = charRead;
-			auto p = outputParams;
-			#pragma warning(suppress: 4996) // sscanf_s would expect additional arg after each %s arg
-			read = sscanf(readText.c_str(), newFormat.c_str(),
-				p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8], p[9], // 10
-				p[10], p[11], p[12], p[13], p[14], p[15], p[16], p[17], p[18], p[19], // 20
-				p[20], p[21], p[22], p[23], p[24], p[25], p[26], p[27], p[28], p[29], // 30
-				p[30], p[31], p[32], p[33], p[34]); // 35
+      prevCharRead = charRead;
+      auto p = outputParams;
+#pragma warning(                                                               \
+    suppress : 4996) // sscanf_s would expect additional arg after each %s arg
+      read = sscanf(readText.c_str(), newFormat.c_str(), p[0], p[1], p[2], p[3],
+                    p[4], p[5], p[6], p[7], p[8], p[9], // 10
+                    p[10], p[11], p[12], p[13], p[14], p[15], p[16], p[17],
+                    p[18], p[19], // 20
+                    p[20], p[21], p[22], p[23], p[24], p[25], p[26], p[27],
+                    p[28], p[29],                       // 30
+                    p[30], p[31], p[32], p[33], p[34]); // 35
 
-			if (!isOk(handle)) break;
+      if (!isOk(handle))
+        break;
 
-			if (read == paramCount)
-			{
-				if (charRead == prevCharRead) // all params collected and scan doesn't consume input text anymore
-				{
-					seek(handle, -1, SEEK_CUR); // return the character not used by scan
-					break;
-				}
+      if (read == paramCount) {
+        if (charRead == prevCharRead) // all params collected and scan doesn't
+                                      // consume input text anymore
+        {
+          seek(handle, -1, SEEK_CUR); // return the character not used by scan
+          break;
+        }
 
-				if (isEndOfFile(handle))
-				{
-					break;
-				}
-			}
-		}
-	}
-	else
-	{
-		auto p = outputParams;
-		#pragma warning(suppress: 4996) // fscanf_s would expect additional arg after each %s arg
-		read = 	fscanf(file, format, 
-			p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8], p[9], // 10
-			p[10], p[11], p[12], p[13], p[14], p[15], p[16], p[17], p[18], p[19], // 20
-			p[20], p[21], p[22], p[23], p[24], p[25], p[26], p[27], p[28], p[29], // 30
-			p[30], p[31], p[32], p[33], p[34]); // 35
-	}
+        if (isEndOfFile(handle)) {
+          break;
+        }
+      }
+    }
+  } else {
+    auto p = outputParams;
+#pragma warning(                                                               \
+    suppress : 4996) // fscanf_s would expect additional arg after each %s arg
+    read = fscanf(file, format, p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7],
+                  p[8], p[9], // 10
+                  p[10], p[11], p[12], p[13], p[14], p[15], p[16], p[17], p[18],
+                  p[19], // 20
+                  p[20], p[21], p[22], p[23], p[24], p[25], p[26], p[27], p[28],
+                  p[29],                              // 30
+                  p[30], p[31], p[32], p[33], p[34]); // 35
+  }
 
-	updateState(handle);
+  updateState(handle);
 
-	return read;
+  return read;
 }

--- a/cleo_plugins/FileSystemOperations/FileUtils.h
+++ b/cleo_plugins/FileSystemOperations/FileUtils.h
@@ -3,48 +3,47 @@
 #include <stdio.h>
 #include <wtypes.h>
 
-class File
-{
+class File {
 public:
-	static void initialize(CLEO::eGameVersion version);
+  static void initialize(CLEO::eGameVersion version);
 
-	static DWORD open(const char* filename, const char* mode, bool legacy);
-	static void close(DWORD handle);
+  static DWORD open(const char *filename, const char *mode, bool legacy);
+  static void close(DWORD handle);
 
-	static bool isOk(DWORD handle);
+  static bool isOk(DWORD handle);
 
-	static DWORD getSize(DWORD handle);
-	static bool seek(DWORD handle, int offset, DWORD orign);
-	static DWORD getPos(DWORD handle);
-	static bool isEndOfFile(DWORD handle);
+  static DWORD getSize(DWORD handle);
+  static bool seek(DWORD handle, int offset, DWORD orign);
+  static DWORD getPos(DWORD handle);
+  static bool isEndOfFile(DWORD handle);
 
-	static DWORD read(DWORD handle, void* buffer, DWORD size);
-	static char readChar(DWORD handle);
-	static char* readString(DWORD handle, char* buffer, DWORD bufferSize);
+  static DWORD read(DWORD handle, void *buffer, DWORD size);
+  static char readChar(DWORD handle);
+  static char *readString(DWORD handle, char *buffer, DWORD bufferSize);
 
-	static DWORD write(DWORD handle, const void* buffer, DWORD size);
-	static bool writeString(DWORD handle, const char* text);
-	static DWORD scan(DWORD handle, const char* format, void** outputParams);
-	static bool flush(DWORD handle);
+  static DWORD write(DWORD handle, const void *buffer, DWORD size);
+  static bool writeString(DWORD handle, const char *text);
+  static DWORD scan(DWORD handle, const char *format, void **outputParams);
+  static bool flush(DWORD handle);
 
-	static bool isLegacy(DWORD handle); // Legacy modes for CLEO 3
-	static FILE* handleToFile(DWORD handle);
-	
+  static bool isLegacy(DWORD handle); // Legacy modes for CLEO 3
+  static FILE *handleToFile(DWORD handle);
+
 private:
-	static DWORD FUNC_fopen;
-	static DWORD FUNC_fclose;
-	static DWORD FUNC_fread;
-	static DWORD FUNC_fwrite;
-	static DWORD FUNC_fgetc;
-	static DWORD FUNC_fgets;
-	static DWORD FUNC_fputs;
-	static DWORD FUNC_fseek;
-	static DWORD FUNC_fprintf;
-	static DWORD FUNC_ftell;
-	static DWORD FUNC_fflush;
-	static DWORD FUNC_feof;
-	static DWORD FUNC_ferror;
+  static DWORD FUNC_fopen;
+  static DWORD FUNC_fclose;
+  static DWORD FUNC_fread;
+  static DWORD FUNC_fwrite;
+  static DWORD FUNC_fgetc;
+  static DWORD FUNC_fgets;
+  static DWORD FUNC_fputs;
+  static DWORD FUNC_fseek;
+  static DWORD FUNC_fprintf;
+  static DWORD FUNC_ftell;
+  static DWORD FUNC_fflush;
+  static DWORD FUNC_feof;
+  static DWORD FUNC_ferror;
 
-	static DWORD fileToHandle(FILE* file, bool legacy);
-	static void updateState(DWORD handle);
+  static DWORD fileToHandle(FILE *file, bool legacy);
+  static void updateState(DWORD handle);
 };

--- a/cleo_plugins/GameEntities/GameEntities.cpp
+++ b/cleo_plugins/GameEntities/GameEntities.cpp
@@ -1,6 +1,6 @@
-#include "plugin.h"
 #include "CLEO.h"
 #include "CLEO_Utils.h"
+#include "plugin.h"
 #include <CCheat.h>
 #include <CMenuManager.h>
 #include <CModelInfo.h>
@@ -12,428 +12,402 @@ using namespace CLEO;
 using namespace plugin;
 using namespace std;
 
-class GameEntities
-{
+class GameEntities {
 public:
-	std::map<CRunningScript*, int> charSearchState; // for get_random_char_in_sphere_no_save_recursive
-	std::map<CRunningScript*, int> carSearchState; // for get_random_car_in_sphere_no_save_recursive
-	std::map<CRunningScript*, int> objectSearchState; // for get_random_object_in_sphere_no_save_recursive
-
-	GameEntities()
-	{
-		if (!PluginCheckCleoVersion()) return;
-
-		// register opcodes
-		CLEO_RegisterOpcode(0x0AB5, opcode_0AB5); // store_closest_entities
-		CLEO_RegisterOpcode(0x0AB6, opcode_0AB6); // get_target_blip_coords
-		CLEO_RegisterOpcode(0x0AB7, opcode_0AB7); // get_car_number_of_gears
-		CLEO_RegisterOpcode(0x0AB8, opcode_0AB8); // get_car_current_gear
-		CLEO_RegisterOpcode(0x0ABD, opcode_0ABD); // is_car_siren_on
-		CLEO_RegisterOpcode(0x0ABE, opcode_0ABE); // is_car_engine_on
-		CLEO_RegisterOpcode(0x0ABF, opcode_0ABF); // cleo_set_car_engine_on
-		CLEO_RegisterOpcode(0x0AD2, opcode_0AD2); // get_char_player_is_targeting
-		CLEO_RegisterOpcode(0x0ADD, opcode_0ADD); // spawn_vehicle_by_cheating
-		CLEO_RegisterOpcode(0x0AE1, opcode_0AE1); // get_random_char_in_sphere_no_save_recursive
-		CLEO_RegisterOpcode(0x0AE2, opcode_0AE2); // get_random_car_in_sphere_no_save_recursive
-		CLEO_RegisterOpcode(0x0AE3, opcode_0AE3); // get_random_object_in_sphere_no_save_recursive
-
-		// register event callbacks
-		CLEO_RegisterCallback(eCallbackId::ScriptsFinalize, OnScriptsFinalize);
-	}
-
-	~GameEntities()
-	{
-		CLEO_UnregisterCallback(eCallbackId::ScriptsFinalize, OnScriptsFinalize);
-	}
-
-	static void __stdcall OnScriptsFinalize()
-	{
-		Instance.charSearchState.clear();
-		Instance.carSearchState.clear();
-		Instance.objectSearchState.clear();
-	}
-
-	// store_closest_entities
-	// [var carHandle: Car], [var charHandle: Char] = store_closest_entities [Char]
-	static OpcodeResult __stdcall opcode_0AB5(CRunningScript* thread)
-	{
-		auto pedHandle = OPCODE_READ_PARAM_PED_HANDLE();
-
-		auto ped = CPools::GetPed(pedHandle);
-		if (ped == nullptr || ped->m_pIntelligence == nullptr)
-		{
-			OPCODE_WRITE_PARAM_INT(-1);
-			OPCODE_WRITE_PARAM_INT(-1);
-			return OR_CONTINUE;
-		}
-
-		DWORD foundCar = -1;
-		const auto& cars = ped->m_pIntelligence->m_vehicleScanner.m_apEntities;
-		for (size_t i = 0; i < std::size(cars); i++)
-		{
-			auto car = (CVehicle*)cars[i];
-			if (car != nullptr &&
-				car->m_nCreatedBy != eVehicleCreatedBy::MISSION_VEHICLE &&
-				!car->bFadeOut)
-			{
-				foundCar = CPools::GetVehicleRef(car); // get handle
-				break;
-			}
-		}
-
-		DWORD foundPed = -1;
-		const auto& peds = ped->m_pIntelligence->m_pedScanner.m_apEntities;
-		for (size_t i = 0; i < std::size(peds); i++)
-		{
-			auto ped = (CPed*)peds[i];
-			if (ped != nullptr &&
-				ped->m_nCreatedBy == 1 && // random pedestrian
-				!ped->bFadeOut)
-			{
-				foundPed = CPools::GetPedRef(ped); // get handle
-				break;
-			}
-		}
-
-		OPCODE_WRITE_PARAM_INT(foundCar);
-		OPCODE_WRITE_PARAM_INT(foundPed);
-		return OR_CONTINUE;
-	}
-
-	// get_target_blip_coords
-	// [var x: float], [var y: float], [var z: float] = get_target_blip_coords (logical)
-	static OpcodeResult __stdcall opcode_0AB6(CRunningScript* thread)
-	{
-		auto blipIdx = CRadar::GetActualBlipArrayIndex(FrontEndMenuManager.m_nTargetBlipIndex);
-		if (blipIdx == -1)
-		{
-			OPCODE_SKIP_PARAMS(3); // x, y, z
-			OPCODE_CONDITION_RESULT(false); // no target marker placed
-			return OR_CONTINUE;
-		}
-
-		CVector pos = CRadar::ms_RadarTrace[blipIdx].m_vecPos; // TODO: support for Fastman92's Limit Adjuster
-
-		// TODO: load world collisions for the coords
-		pos.z = CWorld::FindGroundZForCoord(pos.x, pos.y);
-
-		OPCODE_WRITE_PARAM_FLOAT(pos.x);
-		OPCODE_WRITE_PARAM_FLOAT(pos.y);
-		OPCODE_WRITE_PARAM_FLOAT(pos.z);
-		OPCODE_CONDITION_RESULT(true);
-		return OR_CONTINUE;
-	}
-
-	// get_car_number_of_gears
-	// [var numGear: int] = get_car_number_of_gears [Car]
-	static OpcodeResult __stdcall opcode_0AB7(CRunningScript* thread)
-	{
-		auto handle = OPCODE_READ_PARAM_VEHICLE_HANDLE();
-
-		auto vehicle = CPools::GetVehicle(handle);
-		auto gears = vehicle->m_pHandlingData->m_transmissionData.m_nNumberOfGears;
-
-		OPCODE_WRITE_PARAM_INT(gears);
-		return OR_CONTINUE;
-	}
-
-	// get_car_current_gear
-	// [var gear: int] = get_car_current_gear [Car]
-	static OpcodeResult __stdcall opcode_0AB8(CRunningScript* thread)
-	{
-		auto handle = OPCODE_READ_PARAM_VEHICLE_HANDLE();
-
-		auto vehicle = CPools::GetVehicle(handle);
-		auto gear = vehicle->m_nCurrentGear;
-
-		OPCODE_WRITE_PARAM_INT(gear);
-		return OR_CONTINUE;
-	}
-
-	// is_car_siren_on
-	// is_car_siren_on [Car] (logical)
-	static OpcodeResult __stdcall opcode_0ABD(CRunningScript* thread)
-	{
-		auto handle = OPCODE_READ_PARAM_VEHICLE_HANDLE();
-
-		auto vehicle = CPools::GetVehicle(handle);
-		auto state = vehicle->bSirenOrAlarm;
-
-		OPCODE_CONDITION_RESULT(state);
-		return OR_CONTINUE;
-	}
-
-	// is_car_engine_on
-	// is_car_engine_on [Car] (logical)
-	static OpcodeResult __stdcall opcode_0ABE(CRunningScript* thread)
-	{
-		auto handle = OPCODE_READ_PARAM_VEHICLE_HANDLE();
-
-		auto vehicle = CPools::GetVehicle(handle);
-		auto state = vehicle->bEngineOn;
-
-		OPCODE_CONDITION_RESULT(state);
-		return OR_CONTINUE;
-	}
-
-	// cleo_set_car_engine_on
-	// cleo_set_car_engine_on [Car] {state} [bool]
-	static OpcodeResult __stdcall opcode_0ABF(CRunningScript* thread)
-	{
-		auto handle = OPCODE_READ_PARAM_VEHICLE_HANDLE();
-		auto state = OPCODE_READ_PARAM_BOOL();
-
-		auto vehicle = CPools::GetVehicle(handle);
-
-		vehicle->bEngineOn = (state != false);
-		return OR_CONTINUE;
-	}
-
-	// get_char_player_is_targeting
-	// [var handle: Char] = get_char_player_is_targeting [Player] (logical)
-	static OpcodeResult __stdcall opcode_0AD2(CRunningScript* thread)
-	{
-		auto playerId = OPCODE_READ_PARAM_PLAYER_ID();
-
-		auto ped = FindPlayerPed(playerId);
-
-		auto target = ped->m_pPlayerTargettedPed;
-		if (target == nullptr) target = (CPed*)ped->m_pTargetedObject;
-		
-		if (target == nullptr || target->m_nType != ENTITY_TYPE_PED)
-		{
-			OPCODE_WRITE_PARAM_INT(-1);
-			OPCODE_CONDITION_RESULT(false);
-			return OR_CONTINUE;
-		}
-
-		auto handle = CPools::GetPedRef(target);
-
-		OPCODE_WRITE_PARAM_INT(handle);
-		OPCODE_CONDITION_RESULT(true);
-		return OR_CONTINUE;
-	}
-
-	// spawn_vehicle_by_cheating
-	// spawn_vehicle_by_cheating {modelId} [model_vehicle]
-	static OpcodeResult __stdcall opcode_0ADD(CRunningScript* thread)
-	{
-		auto modelIndex = OPCODE_READ_PARAM_INT();
-
-		auto model = CModelInfo::GetModelInfo(modelIndex);
-		if (model == nullptr || model->GetModelType() != MODEL_INFO_VEHICLE)
-		{
-			return OR_CONTINUE; // modelIndex is not vehicle
-		}
-
-		auto veh = (CVehicleModelInfo*)model;
-		switch (veh->m_nVehicleType)
-		{
-			case VEHICLE_AUTOMOBILE:
-			case VEHICLE_MTRUCK:
-			case VEHICLE_QUAD:
-			case VEHICLE_HELI:
-			case VEHICLE_PLANE:
-			case VEHICLE_BOAT:
-			//case VEHICLE_TRAIN:
-			//case VEHICLE_FHELI:
-			//case VEHICLE_FPLANE:
-			case VEHICLE_BIKE:
-			case VEHICLE_BMX:
-			case VEHICLE_TRAILER:
-				break;
-
-			default:
-				return OR_CONTINUE; // unsupported vehicle type
-		}
-
-		CCheat::VehicleCheat(modelIndex);
-
-		return OR_CONTINUE;
-	}
-
-	// get_random_char_in_sphere_no_save_recursive
-	// [var handle: Char] = get_random_char_in_sphere_no_save_recursive {x} [float] {y} [float] {z} [float] {radius} [float] {findNext} [bool] {filter} [int] (logical)
-	static OpcodeResult __stdcall opcode_0AE1(CRunningScript* thread)
-	{
-		CVector center = {};
-		center.x = OPCODE_READ_PARAM_FLOAT();
-		center.y = OPCODE_READ_PARAM_FLOAT();
-		center.z = OPCODE_READ_PARAM_FLOAT();
-		auto radius = OPCODE_READ_PARAM_FLOAT();
-		auto findNext = OPCODE_READ_PARAM_BOOL();
-		auto filter = OPCODE_READ_PARAM_INT();
-
-		bool skipDead = (filter == 1);
-		bool skipPlayer = (filter != -1);
-
-		int& searchIdx = Instance.charSearchState[thread];
-		if (!findNext) searchIdx = 0;
-
-		CPed* found = nullptr;
-		for (int index = searchIdx; index < CPools::ms_pPedPool->m_nSize; index++)
-		{
-			auto ped = CPools::ms_pPedPool->GetAt(index);
-
-			if (ped == nullptr || ped->bFadeOut)
-			{
-				continue; // invalid or about to be deleted
-			}
-
-			if (skipPlayer && ped->IsPlayer())
-			{
-				continue; // player
-			}
-
-			if (skipDead)
-			{
-				if (ped->m_ePedState == PEDSTATE_DIE || ped->m_ePedState == PEDSTATE_DEAD)
-				{
-					continue; // dead
-				}
-			}
-
-			if (radius < 1000.0f)
-			{
-				if((ped->GetPosition() - center).Magnitude() > radius)
-				{
-					continue; // out of search radius
-				}
-			}
-
-			found = ped;
-			searchIdx = index + 1; // next search start index
-			break;
-		}
-
-		DWORD handle;
-		if (found != nullptr)
-		{
-			handle = CPools::ms_pPedPool->GetRef(found);
-		}
-		else
-		{
-			handle = -1;
-			searchIdx = 0;
-		}
-
-		OPCODE_WRITE_PARAM_INT(handle);
-		OPCODE_CONDITION_RESULT(handle != -1);
-		return OR_CONTINUE;
-	}
-
-	// get_random_car_in_sphere_no_save_recursive
-	// [var handle: Car] = get_random_car_in_sphere_no_save_recursive {x} [float] {y} [float] {z} [float] {radius} [float] {findNext} [bool] {skipWrecked} [bool] (logical)
-	static OpcodeResult __stdcall opcode_0AE2(CRunningScript* thread)
-	{
-		CVector center = {};
-		center.x = OPCODE_READ_PARAM_FLOAT();
-		center.y = OPCODE_READ_PARAM_FLOAT();
-		center.z = OPCODE_READ_PARAM_FLOAT();
-		auto radius = OPCODE_READ_PARAM_FLOAT();
-		auto findNext = OPCODE_READ_PARAM_BOOL();
-		auto skipWrecked = OPCODE_READ_PARAM_BOOL();
-
-		int& searchIdx = Instance.carSearchState[thread];
-		if (!findNext) searchIdx = 0;
-
-		CVehicle* found = nullptr;
-		for (int index = searchIdx; index < CPools::ms_pVehiclePool->m_nSize; index++)
-		{
-			auto car = CPools::ms_pVehiclePool->GetAt(index);
-
-			if (car == nullptr || car->bFadeOut)
-			{
-				continue; // invalid or about to be deleted
-			}
-
-			if (skipWrecked)
-			{
-				if (car->m_nStatus == STATUS_WRECKED || car->bIsDrowning)
-				{
-					continue; // wrecked
-				}
-			}
-
-			if (radius < 1000.0f)
-			{
-				if ((car->GetPosition() - center).Magnitude() > radius)
-				{
-					continue; // out of search radius
-				}
-			}
-
-			found = car;
-			searchIdx = index + 1; // next search start index
-			break;
-		}
-
-		DWORD handle;
-		if (found != nullptr)
-		{
-			handle = CPools::ms_pVehiclePool->GetRef(found);
-		}
-		else
-		{
-			handle = -1;
-			searchIdx = 0;
-		}
-
-		OPCODE_WRITE_PARAM_INT(handle);
-		OPCODE_CONDITION_RESULT(handle != -1);
-		return OR_CONTINUE;
-	}
-
-	// get_random_object_in_sphere_no_save_recursive
-	// [var handle: Object] = get_random_object_in_sphere_no_save_recursive {x} [float] {y} [float] {z} [float] {radius} [float] {findNext} [bool] (logical)
-	static OpcodeResult __stdcall opcode_0AE3(CRunningScript* thread)
-	{
-		CVector center = {};
-		center.x = OPCODE_READ_PARAM_FLOAT();
-		center.y = OPCODE_READ_PARAM_FLOAT();
-		center.z = OPCODE_READ_PARAM_FLOAT();
-		auto radius = OPCODE_READ_PARAM_FLOAT();
-		auto findNext = OPCODE_READ_PARAM_BOOL();
-
-		int& searchIdx = Instance.objectSearchState[thread];
-		if (!findNext) searchIdx = 0;
-
-		CObject* found = nullptr;
-		for (int index = searchIdx; index < CPools::ms_pObjectPool->m_nSize; index++)
-		{
-			auto object = CPools::ms_pObjectPool->GetAt(index);
-
-			if (object == nullptr || object->m_nObjectFlags.bFadingIn) // this is actually .bFadingOut
-			{
-				continue; // invalid
-			}
-
-			if (radius < 1000.0f)
-			{
-				if ((object->GetPosition() - center).Magnitude() > radius)
-				{
-					continue; // out of search radius
-				}
-			}
-
-			found = object;
-			searchIdx = index + 1; // next search start index
-			break;
-		}
-
-		DWORD handle;
-		if (found != nullptr)
-		{
-			handle = CPools::ms_pObjectPool->GetRef(found);
-		}
-		else
-		{
-			handle = -1;
-			searchIdx = 0;
-		}
-
-		OPCODE_WRITE_PARAM_INT(handle);
-		OPCODE_CONDITION_RESULT(handle != -1);
-		return OR_CONTINUE;
-	}
+  std::map<CRunningScript *, int>
+      charSearchState; // for get_random_char_in_sphere_no_save_recursive
+  std::map<CRunningScript *, int>
+      carSearchState; // for get_random_car_in_sphere_no_save_recursive
+  std::map<CRunningScript *, int>
+      objectSearchState; // for get_random_object_in_sphere_no_save_recursive
+
+  GameEntities() {
+    if (!PluginCheckCleoVersion())
+      return;
+
+    // register opcodes
+    CLEO_RegisterOpcode(0x0AB5, opcode_0AB5); // store_closest_entities
+    CLEO_RegisterOpcode(0x0AB6, opcode_0AB6); // get_target_blip_coords
+    CLEO_RegisterOpcode(0x0AB7, opcode_0AB7); // get_car_number_of_gears
+    CLEO_RegisterOpcode(0x0AB8, opcode_0AB8); // get_car_current_gear
+    CLEO_RegisterOpcode(0x0ABD, opcode_0ABD); // is_car_siren_on
+    CLEO_RegisterOpcode(0x0ABE, opcode_0ABE); // is_car_engine_on
+    CLEO_RegisterOpcode(0x0ABF, opcode_0ABF); // cleo_set_car_engine_on
+    CLEO_RegisterOpcode(0x0AD2, opcode_0AD2); // get_char_player_is_targeting
+    CLEO_RegisterOpcode(0x0ADD, opcode_0ADD); // spawn_vehicle_by_cheating
+    CLEO_RegisterOpcode(
+        0x0AE1, opcode_0AE1); // get_random_char_in_sphere_no_save_recursive
+    CLEO_RegisterOpcode(
+        0x0AE2, opcode_0AE2); // get_random_car_in_sphere_no_save_recursive
+    CLEO_RegisterOpcode(
+        0x0AE3, opcode_0AE3); // get_random_object_in_sphere_no_save_recursive
+
+    // register event callbacks
+    CLEO_RegisterCallback(eCallbackId::ScriptsFinalize, OnScriptsFinalize);
+  }
+
+  ~GameEntities() {
+    CLEO_UnregisterCallback(eCallbackId::ScriptsFinalize, OnScriptsFinalize);
+  }
+
+  static void __stdcall OnScriptsFinalize() {
+    Instance.charSearchState.clear();
+    Instance.carSearchState.clear();
+    Instance.objectSearchState.clear();
+  }
+
+  // store_closest_entities
+  // [var carHandle: Car], [var charHandle: Char] = store_closest_entities
+  // [Char]
+  static OpcodeResult __stdcall opcode_0AB5(CRunningScript *thread) {
+    auto pedHandle = OPCODE_READ_PARAM_PED_HANDLE();
+
+    auto ped = CPools::GetPed(pedHandle);
+    if (ped == nullptr || ped->m_pIntelligence == nullptr) {
+      OPCODE_WRITE_PARAM_INT(-1);
+      OPCODE_WRITE_PARAM_INT(-1);
+      return OR_CONTINUE;
+    }
+
+    DWORD foundCar = -1;
+    const auto &cars = ped->m_pIntelligence->m_vehicleScanner.m_apEntities;
+    for (size_t i = 0; i < std::size(cars); i++) {
+      auto car = (CVehicle *)cars[i];
+      if (car != nullptr &&
+          car->m_nCreatedBy != eVehicleCreatedBy::MISSION_VEHICLE &&
+          !car->bFadeOut) {
+        foundCar = CPools::GetVehicleRef(car); // get handle
+        break;
+      }
+    }
+
+    DWORD foundPed = -1;
+    const auto &peds = ped->m_pIntelligence->m_pedScanner.m_apEntities;
+    for (size_t i = 0; i < std::size(peds); i++) {
+      auto ped = (CPed *)peds[i];
+      if (ped != nullptr && ped->m_nCreatedBy == 1 && // random pedestrian
+          !ped->bFadeOut) {
+        foundPed = CPools::GetPedRef(ped); // get handle
+        break;
+      }
+    }
+
+    OPCODE_WRITE_PARAM_INT(foundCar);
+    OPCODE_WRITE_PARAM_INT(foundPed);
+    return OR_CONTINUE;
+  }
+
+  // get_target_blip_coords
+  // [var x: float], [var y: float], [var z: float] = get_target_blip_coords
+  // (logical)
+  static OpcodeResult __stdcall opcode_0AB6(CRunningScript *thread) {
+    auto blipIdx =
+        CRadar::GetActualBlipArrayIndex(FrontEndMenuManager.m_nTargetBlipIndex);
+    if (blipIdx == -1) {
+      OPCODE_SKIP_PARAMS(3);          // x, y, z
+      OPCODE_CONDITION_RESULT(false); // no target marker placed
+      return OR_CONTINUE;
+    }
+
+    CVector pos = CRadar::ms_RadarTrace[blipIdx]
+                      .m_vecPos; // TODO: support for Fastman92's Limit Adjuster
+
+    // TODO: load world collisions for the coords
+    pos.z = CWorld::FindGroundZForCoord(pos.x, pos.y);
+
+    OPCODE_WRITE_PARAM_FLOAT(pos.x);
+    OPCODE_WRITE_PARAM_FLOAT(pos.y);
+    OPCODE_WRITE_PARAM_FLOAT(pos.z);
+    OPCODE_CONDITION_RESULT(true);
+    return OR_CONTINUE;
+  }
+
+  // get_car_number_of_gears
+  // [var numGear: int] = get_car_number_of_gears [Car]
+  static OpcodeResult __stdcall opcode_0AB7(CRunningScript *thread) {
+    auto handle = OPCODE_READ_PARAM_VEHICLE_HANDLE();
+
+    auto vehicle = CPools::GetVehicle(handle);
+    auto gears = vehicle->m_pHandlingData->m_transmissionData.m_nNumberOfGears;
+
+    OPCODE_WRITE_PARAM_INT(gears);
+    return OR_CONTINUE;
+  }
+
+  // get_car_current_gear
+  // [var gear: int] = get_car_current_gear [Car]
+  static OpcodeResult __stdcall opcode_0AB8(CRunningScript *thread) {
+    auto handle = OPCODE_READ_PARAM_VEHICLE_HANDLE();
+
+    auto vehicle = CPools::GetVehicle(handle);
+    auto gear = vehicle->m_nCurrentGear;
+
+    OPCODE_WRITE_PARAM_INT(gear);
+    return OR_CONTINUE;
+  }
+
+  // is_car_siren_on
+  // is_car_siren_on [Car] (logical)
+  static OpcodeResult __stdcall opcode_0ABD(CRunningScript *thread) {
+    auto handle = OPCODE_READ_PARAM_VEHICLE_HANDLE();
+
+    auto vehicle = CPools::GetVehicle(handle);
+    auto state = vehicle->bSirenOrAlarm;
+
+    OPCODE_CONDITION_RESULT(state);
+    return OR_CONTINUE;
+  }
+
+  // is_car_engine_on
+  // is_car_engine_on [Car] (logical)
+  static OpcodeResult __stdcall opcode_0ABE(CRunningScript *thread) {
+    auto handle = OPCODE_READ_PARAM_VEHICLE_HANDLE();
+
+    auto vehicle = CPools::GetVehicle(handle);
+    auto state = vehicle->bEngineOn;
+
+    OPCODE_CONDITION_RESULT(state);
+    return OR_CONTINUE;
+  }
+
+  // cleo_set_car_engine_on
+  // cleo_set_car_engine_on [Car] {state} [bool]
+  static OpcodeResult __stdcall opcode_0ABF(CRunningScript *thread) {
+    auto handle = OPCODE_READ_PARAM_VEHICLE_HANDLE();
+    auto state = OPCODE_READ_PARAM_BOOL();
+
+    auto vehicle = CPools::GetVehicle(handle);
+
+    vehicle->bEngineOn = (state != false);
+    return OR_CONTINUE;
+  }
+
+  // get_char_player_is_targeting
+  // [var handle: Char] = get_char_player_is_targeting [Player] (logical)
+  static OpcodeResult __stdcall opcode_0AD2(CRunningScript *thread) {
+    auto playerId = OPCODE_READ_PARAM_PLAYER_ID();
+
+    auto ped = FindPlayerPed(playerId);
+
+    auto target = ped->m_pPlayerTargettedPed;
+    if (target == nullptr)
+      target = (CPed *)ped->m_pTargetedObject;
+
+    if (target == nullptr || target->m_nType != ENTITY_TYPE_PED) {
+      OPCODE_WRITE_PARAM_INT(-1);
+      OPCODE_CONDITION_RESULT(false);
+      return OR_CONTINUE;
+    }
+
+    auto handle = CPools::GetPedRef(target);
+
+    OPCODE_WRITE_PARAM_INT(handle);
+    OPCODE_CONDITION_RESULT(true);
+    return OR_CONTINUE;
+  }
+
+  // spawn_vehicle_by_cheating
+  // spawn_vehicle_by_cheating {modelId} [model_vehicle]
+  static OpcodeResult __stdcall opcode_0ADD(CRunningScript *thread) {
+    auto modelIndex = OPCODE_READ_PARAM_INT();
+
+    auto model = CModelInfo::GetModelInfo(modelIndex);
+    if (model == nullptr || model->GetModelType() != MODEL_INFO_VEHICLE) {
+      return OR_CONTINUE; // modelIndex is not vehicle
+    }
+
+    auto veh = (CVehicleModelInfo *)model;
+    switch (veh->m_nVehicleType) {
+    case VEHICLE_AUTOMOBILE:
+    case VEHICLE_MTRUCK:
+    case VEHICLE_QUAD:
+    case VEHICLE_HELI:
+    case VEHICLE_PLANE:
+    case VEHICLE_BOAT:
+    // case VEHICLE_TRAIN:
+    // case VEHICLE_FHELI:
+    // case VEHICLE_FPLANE:
+    case VEHICLE_BIKE:
+    case VEHICLE_BMX:
+    case VEHICLE_TRAILER:
+      break;
+
+    default:
+      return OR_CONTINUE; // unsupported vehicle type
+    }
+
+    CCheat::VehicleCheat(modelIndex);
+
+    return OR_CONTINUE;
+  }
+
+  // get_random_char_in_sphere_no_save_recursive
+  // [var handle: Char] = get_random_char_in_sphere_no_save_recursive {x}
+  // [float] {y} [float] {z} [float] {radius} [float] {findNext} [bool] {filter}
+  // [int] (logical)
+  static OpcodeResult __stdcall opcode_0AE1(CRunningScript *thread) {
+    CVector center = {};
+    center.x = OPCODE_READ_PARAM_FLOAT();
+    center.y = OPCODE_READ_PARAM_FLOAT();
+    center.z = OPCODE_READ_PARAM_FLOAT();
+    auto radius = OPCODE_READ_PARAM_FLOAT();
+    auto findNext = OPCODE_READ_PARAM_BOOL();
+    auto filter = OPCODE_READ_PARAM_INT();
+
+    bool skipDead = (filter == 1);
+    bool skipPlayer = (filter != -1);
+
+    int &searchIdx = Instance.charSearchState[thread];
+    if (!findNext)
+      searchIdx = 0;
+
+    CPed *found = nullptr;
+    for (int index = searchIdx; index < CPools::ms_pPedPool->m_nSize; index++) {
+      auto ped = CPools::ms_pPedPool->GetAt(index);
+
+      if (ped == nullptr || ped->bFadeOut) {
+        continue; // invalid or about to be deleted
+      }
+
+      if (skipPlayer && ped->IsPlayer()) {
+        continue; // player
+      }
+
+      if (skipDead) {
+        if (ped->m_ePedState == PEDSTATE_DIE ||
+            ped->m_ePedState == PEDSTATE_DEAD) {
+          continue; // dead
+        }
+      }
+
+      if (radius < 1000.0f) {
+        if ((ped->GetPosition() - center).Magnitude() > radius) {
+          continue; // out of search radius
+        }
+      }
+
+      found = ped;
+      searchIdx = index + 1; // next search start index
+      break;
+    }
+
+    DWORD handle;
+    if (found != nullptr) {
+      handle = CPools::ms_pPedPool->GetRef(found);
+    } else {
+      handle = -1;
+      searchIdx = 0;
+    }
+
+    OPCODE_WRITE_PARAM_INT(handle);
+    OPCODE_CONDITION_RESULT(handle != -1);
+    return OR_CONTINUE;
+  }
+
+  // get_random_car_in_sphere_no_save_recursive
+  // [var handle: Car] = get_random_car_in_sphere_no_save_recursive {x} [float]
+  // {y} [float] {z} [float] {radius} [float] {findNext} [bool] {skipWrecked}
+  // [bool] (logical)
+  static OpcodeResult __stdcall opcode_0AE2(CRunningScript *thread) {
+    CVector center = {};
+    center.x = OPCODE_READ_PARAM_FLOAT();
+    center.y = OPCODE_READ_PARAM_FLOAT();
+    center.z = OPCODE_READ_PARAM_FLOAT();
+    auto radius = OPCODE_READ_PARAM_FLOAT();
+    auto findNext = OPCODE_READ_PARAM_BOOL();
+    auto skipWrecked = OPCODE_READ_PARAM_BOOL();
+
+    int &searchIdx = Instance.carSearchState[thread];
+    if (!findNext)
+      searchIdx = 0;
+
+    CVehicle *found = nullptr;
+    for (int index = searchIdx; index < CPools::ms_pVehiclePool->m_nSize;
+         index++) {
+      auto car = CPools::ms_pVehiclePool->GetAt(index);
+
+      if (car == nullptr || car->bFadeOut) {
+        continue; // invalid or about to be deleted
+      }
+
+      if (skipWrecked) {
+        if (car->m_nStatus == STATUS_WRECKED || car->bIsDrowning) {
+          continue; // wrecked
+        }
+      }
+
+      if (radius < 1000.0f) {
+        if ((car->GetPosition() - center).Magnitude() > radius) {
+          continue; // out of search radius
+        }
+      }
+
+      found = car;
+      searchIdx = index + 1; // next search start index
+      break;
+    }
+
+    DWORD handle;
+    if (found != nullptr) {
+      handle = CPools::ms_pVehiclePool->GetRef(found);
+    } else {
+      handle = -1;
+      searchIdx = 0;
+    }
+
+    OPCODE_WRITE_PARAM_INT(handle);
+    OPCODE_CONDITION_RESULT(handle != -1);
+    return OR_CONTINUE;
+  }
+
+  // get_random_object_in_sphere_no_save_recursive
+  // [var handle: Object] = get_random_object_in_sphere_no_save_recursive {x}
+  // [float] {y} [float] {z} [float] {radius} [float] {findNext} [bool]
+  // (logical)
+  static OpcodeResult __stdcall opcode_0AE3(CRunningScript *thread) {
+    CVector center = {};
+    center.x = OPCODE_READ_PARAM_FLOAT();
+    center.y = OPCODE_READ_PARAM_FLOAT();
+    center.z = OPCODE_READ_PARAM_FLOAT();
+    auto radius = OPCODE_READ_PARAM_FLOAT();
+    auto findNext = OPCODE_READ_PARAM_BOOL();
+
+    int &searchIdx = Instance.objectSearchState[thread];
+    if (!findNext)
+      searchIdx = 0;
+
+    CObject *found = nullptr;
+    for (int index = searchIdx; index < CPools::ms_pObjectPool->m_nSize;
+         index++) {
+      auto object = CPools::ms_pObjectPool->GetAt(index);
+
+      if (object == nullptr ||
+          object->m_nObjectFlags.bFadingIn) // this is actually .bFadingOut
+      {
+        continue; // invalid
+      }
+
+      if (radius < 1000.0f) {
+        if ((object->GetPosition() - center).Magnitude() > radius) {
+          continue; // out of search radius
+        }
+      }
+
+      found = object;
+      searchIdx = index + 1; // next search start index
+      break;
+    }
+
+    DWORD handle;
+    if (found != nullptr) {
+      handle = CPools::ms_pObjectPool->GetRef(found);
+    } else {
+      handle = -1;
+      searchIdx = 0;
+    }
+
+    OPCODE_WRITE_PARAM_INT(handle);
+    OPCODE_CONDITION_RESULT(handle != -1);
+    return OR_CONTINUE;
+  }
 } Instance;

--- a/cleo_plugins/IniFiles/IniFiles.cpp
+++ b/cleo_plugins/IniFiles/IniFiles.cpp
@@ -1,255 +1,250 @@
-#include <cstdio>
 #include "CLEO.h"
 #include "CLEO_Utils.h"
+#include <cstdio>
 #include <string>
 
 using namespace CLEO;
 
-// In case of naked file names without parent path INI file APIs searchs in Windows directory. Add leading ".\" to prevent that.
-static void fixIniFilepath(char* buff)
-{
-	if (!std::filesystem::path(buff).has_parent_path())
-	{
-		std::string filename = buff;
-		strcpy_s(buff, 512, ".\\");
-		strcat_s(buff, 512, filename.c_str());
-	}
+// In case of naked file names without parent path INI file APIs searchs in
+// Windows directory. Add leading ".\" to prevent that.
+static void fixIniFilepath(char *buff) {
+  if (!std::filesystem::path(buff).has_parent_path()) {
+    std::string filename = buff;
+    strcpy_s(buff, 512, ".\\");
+    strcat_s(buff, 512, filename.c_str());
+  }
 }
 
-#define OPCODE_READ_PARAM_FILEPATH_INI(_varName) OPCODE_READ_PARAM_FILEPATH(_varName); fixIniFilepath(_buff_##_varName)
+#define OPCODE_READ_PARAM_FILEPATH_INI(_varName)                               \
+  OPCODE_READ_PARAM_FILEPATH(_varName);                                        \
+  fixIniFilepath(_buff_##_varName)
 
-#define OPCODE_READ_PARAM_STRING_OR_ZERO(_varName) const char* ##_varName; \
-if (IsLegacyScript(thread) && IsImmInteger(thread->PeekDataType()) && CLEO_PeekIntOpcodeParam(thread) == 0) \
-{ \
-	CLEO_SkipOpcodeParams(thread, 1); \
-	##_varName = nullptr; \
-} \
-else \
-{ \
-	char _buff_##_varName[MAX_STR_LEN + 1]; \
-	##_varName = _readParamText(thread, _buff_##_varName, MAX_STR_LEN + 1); \
-	if (!_paramWasString()) { return OpcodeResult::OR_INTERRUPT; } \
-};
+#define OPCODE_READ_PARAM_STRING_OR_ZERO(_varName)                             \
+  const char *##_varName;                                                      \
+  if (IsLegacyScript(thread) && IsImmInteger(thread->PeekDataType()) &&        \
+      CLEO_PeekIntOpcodeParam(thread) == 0) {                                  \
+    CLEO_SkipOpcodeParams(thread, 1);                                          \
+    ##_varName = nullptr;                                                      \
+  } else {                                                                     \
+    char _buff_##_varName[MAX_STR_LEN + 1];                                    \
+    ##_varName = _readParamText(thread, _buff_##_varName, MAX_STR_LEN + 1);    \
+    if (!_paramWasString()) {                                                  \
+      return OpcodeResult::OR_INTERRUPT;                                       \
+    }                                                                          \
+  };
 
-class IniFiles
-{
+class IniFiles {
 public:
-	IniFiles()
-	{
-		if (!PluginCheckCleoVersion()) return;
+  IniFiles() {
+    if (!PluginCheckCleoVersion())
+      return;
 
-		// register opcodes
-		CLEO_RegisterOpcode(0x0AF0, Script_InifileGetInt);
-		CLEO_RegisterOpcode(0x0AF1, Script_InifileWriteInt);
-		CLEO_RegisterOpcode(0x0AF2, Script_InifileGetFloat);
-		CLEO_RegisterOpcode(0x0AF3, Script_InifileWriteFloat);
-		CLEO_RegisterOpcode(0x0AF4, Script_InifileReadString);
-		CLEO_RegisterOpcode(0x0AF5, Script_InifileWriteString);
-		CLEO_RegisterOpcode(0x2800, Script_InifileDeleteSection);
-		CLEO_RegisterOpcode(0x2801, Script_InifileDeleteKey);
-	}
+    // register opcodes
+    CLEO_RegisterOpcode(0x0AF0, Script_InifileGetInt);
+    CLEO_RegisterOpcode(0x0AF1, Script_InifileWriteInt);
+    CLEO_RegisterOpcode(0x0AF2, Script_InifileGetFloat);
+    CLEO_RegisterOpcode(0x0AF3, Script_InifileWriteFloat);
+    CLEO_RegisterOpcode(0x0AF4, Script_InifileReadString);
+    CLEO_RegisterOpcode(0x0AF5, Script_InifileWriteString);
+    CLEO_RegisterOpcode(0x2800, Script_InifileDeleteSection);
+    CLEO_RegisterOpcode(0x2801, Script_InifileDeleteKey);
+  }
 
-	static OpcodeResult __stdcall Script_InifileGetInt(CRunningScript* thread)
-		/****************************************************************
-		Opcode Format
-		0AF0=4,%4d% = get_int_from_ini_file %1s% section %2s% key %3s%
-		****************************************************************/
-	{
-		OPCODE_READ_PARAM_FILEPATH_INI(path);
-		OPCODE_READ_PARAM_STRING(section);
-		OPCODE_READ_PARAM_STRING(key);
+  static OpcodeResult __stdcall Script_InifileGetInt(CRunningScript *thread)
+  /****************************************************************
+  Opcode Format
+  0AF0=4,%4d% = get_int_from_ini_file %1s% section %2s% key %3s%
+  ****************************************************************/
+  {
+    OPCODE_READ_PARAM_FILEPATH_INI(path);
+    OPCODE_READ_PARAM_STRING(section);
+    OPCODE_READ_PARAM_STRING(key);
 
-		char buff[32];
-		if (GetPrivateProfileString(section, key, NULL, buff, sizeof(buff), path))
-		{
-			char* str;
-			int base;
-			if (StringStartsWith(buff, "0x", false)) // hex int
-			{
-				str = buff + 2;
-				base = 16;
-			}
-			else // decimal int
-			{
-				str = buff;
-				base = 10;
-			}
+    char buff[32];
+    if (GetPrivateProfileString(section, key, NULL, buff, sizeof(buff), path)) {
+      char *str;
+      int base;
+      if (StringStartsWith(buff, "0x", false)) // hex int
+      {
+        str = buff + 2;
+        base = 16;
+      } else // decimal int
+      {
+        str = buff;
+        base = 10;
+      }
 
-			// parse
-			char* end;
-			int value = strtol(str, &end, base);
-			if (end != str || // at least one number character consumed
-				IsLegacyScript(thread)) // old CLEO reported success anyway with value 0
-			{
-				OPCODE_WRITE_PARAM_INT(value);
-				OPCODE_CONDITION_RESULT(true);
-				return OR_CONTINUE;
-			}
-		}
+      // parse
+      char *end;
+      int value = strtol(str, &end, base);
+      if (end != str || // at least one number character consumed
+          IsLegacyScript(
+              thread)) // old CLEO reported success anyway with value 0
+      {
+        OPCODE_WRITE_PARAM_INT(value);
+        OPCODE_CONDITION_RESULT(true);
+        return OR_CONTINUE;
+      }
+    }
 
-		// failed
-		if (IsLegacyScript(thread))
-		{
-			OPCODE_WRITE_PARAM_INT(0x80000000); // CLEO4 behavior
-		}
-		else
-		{
-			OPCODE_SKIP_PARAMS(1);
-		}
+    // failed
+    if (IsLegacyScript(thread)) {
+      OPCODE_WRITE_PARAM_INT(0x80000000); // CLEO4 behavior
+    } else {
+      OPCODE_SKIP_PARAMS(1);
+    }
 
-		OPCODE_CONDITION_RESULT(false);
-		return OR_CONTINUE;
-	}
+    OPCODE_CONDITION_RESULT(false);
+    return OR_CONTINUE;
+  }
 
-	static OpcodeResult __stdcall Script_InifileWriteInt(CRunningScript* thread)
-		/****************************************************************
-		Opcode Format
-		0AF1=4,write_int %1d% to_ini_file %2s% section %3s% key %4s%
-		****************************************************************/
-	{
-		auto value = OPCODE_READ_PARAM_INT();
-		OPCODE_READ_PARAM_FILEPATH_INI(path);
-		OPCODE_READ_PARAM_STRING(section);
-		OPCODE_READ_PARAM_STRING_OR_ZERO(key);	// 0 deletes the whole section
+  static OpcodeResult __stdcall Script_InifileWriteInt(CRunningScript *thread)
+  /****************************************************************
+  Opcode Format
+  0AF1=4,write_int %1d% to_ini_file %2s% section %3s% key %4s%
+  ****************************************************************/
+  {
+    auto value = OPCODE_READ_PARAM_INT();
+    OPCODE_READ_PARAM_FILEPATH_INI(path);
+    OPCODE_READ_PARAM_STRING(section);
+    OPCODE_READ_PARAM_STRING_OR_ZERO(key); // 0 deletes the whole section
 
-		char strValue[32];
-		_itoa_s(value, strValue, 10);
-		auto result = WritePrivateProfileString(section, key, strValue, path);
-		
-		OPCODE_CONDITION_RESULT(result);
-		return OR_CONTINUE;
-	}
+    char strValue[32];
+    _itoa_s(value, strValue, 10);
+    auto result = WritePrivateProfileString(section, key, strValue, path);
 
-	static OpcodeResult __stdcall Script_InifileGetFloat(CRunningScript* thread)
-		/****************************************************************
-		Opcode Format
-		0AF2=4,%4d% = get_float_from_ini_file %1s% section %2s% key %3s%
-		****************************************************************/
-	{
-		OPCODE_READ_PARAM_FILEPATH_INI(path);
-		OPCODE_READ_PARAM_STRING(section);
-		OPCODE_READ_PARAM_STRING(key);
+    OPCODE_CONDITION_RESULT(result);
+    return OR_CONTINUE;
+  }
 
-		char buff[32];
-		if (GetPrivateProfileString(section, key, NULL, buff, sizeof(buff), path))
-		{
-			char *str, *end;
-			float value;
-			if (StringStartsWith(buff, "0x", false)) // hex int
-			{
-				str = buff + 2;
-				value = (float)strtol(str, &end, 16);
-			}
-			else // float
-			{
-				str = buff;
-				value = strtof(str, &end);
-			}
+  static OpcodeResult __stdcall Script_InifileGetFloat(CRunningScript *thread)
+  /****************************************************************
+  Opcode Format
+  0AF2=4,%4d% = get_float_from_ini_file %1s% section %2s% key %3s%
+  ****************************************************************/
+  {
+    OPCODE_READ_PARAM_FILEPATH_INI(path);
+    OPCODE_READ_PARAM_STRING(section);
+    OPCODE_READ_PARAM_STRING(key);
 
-			if (end != str || // at least one number character consumed
-				IsLegacyScript(thread)) // old CLEO reported success anyway with value 0
-			{
-				OPCODE_WRITE_PARAM_FLOAT(value);
-				OPCODE_CONDITION_RESULT(true);
-				return OR_CONTINUE;
-			}
-		}
+    char buff[32];
+    if (GetPrivateProfileString(section, key, NULL, buff, sizeof(buff), path)) {
+      char *str, *end;
+      float value;
+      if (StringStartsWith(buff, "0x", false)) // hex int
+      {
+        str = buff + 2;
+        value = (float)strtol(str, &end, 16);
+      } else // float
+      {
+        str = buff;
+        value = strtof(str, &end);
+      }
 
-		// failed
-		OPCODE_SKIP_PARAMS(1);
-		OPCODE_CONDITION_RESULT(false);
-		return OR_CONTINUE;
-	}
+      if (end != str || // at least one number character consumed
+          IsLegacyScript(
+              thread)) // old CLEO reported success anyway with value 0
+      {
+        OPCODE_WRITE_PARAM_FLOAT(value);
+        OPCODE_CONDITION_RESULT(true);
+        return OR_CONTINUE;
+      }
+    }
 
-	static OpcodeResult __stdcall Script_InifileWriteFloat(CRunningScript* thread)
-		/****************************************************************
-		Opcode Format
-		0AF3=4,write_float %1d% to_ini_file %2s% section %3s% key %4s%
-		****************************************************************/
-	{
-		auto value = OPCODE_READ_PARAM_FLOAT();
-		OPCODE_READ_PARAM_FILEPATH_INI(path);
-		OPCODE_READ_PARAM_STRING(section);
-		OPCODE_READ_PARAM_STRING_OR_ZERO(key); // 0 deletes the whole section
+    // failed
+    OPCODE_SKIP_PARAMS(1);
+    OPCODE_CONDITION_RESULT(false);
+    return OR_CONTINUE;
+  }
 
-		char strValue[32];
-		sprintf_s(strValue, "%g", value);
-		auto result = WritePrivateProfileString(section, key, strValue, path);
-		
-		OPCODE_CONDITION_RESULT(result);
-		return OR_CONTINUE;
-	}
+  static OpcodeResult __stdcall Script_InifileWriteFloat(CRunningScript *thread)
+  /****************************************************************
+  Opcode Format
+  0AF3=4,write_float %1d% to_ini_file %2s% section %3s% key %4s%
+  ****************************************************************/
+  {
+    auto value = OPCODE_READ_PARAM_FLOAT();
+    OPCODE_READ_PARAM_FILEPATH_INI(path);
+    OPCODE_READ_PARAM_STRING(section);
+    OPCODE_READ_PARAM_STRING_OR_ZERO(key); // 0 deletes the whole section
 
-	static OpcodeResult __stdcall Script_InifileReadString(CRunningScript* thread)
-		/****************************************************************
-		Opcode Format
-		0AF4=4,%4d% = read_string_from_ini_file %1s% section %2s% key %3s%
-		****************************************************************/
-	{
-		OPCODE_READ_PARAM_FILEPATH_INI(path);
-		OPCODE_READ_PARAM_STRING(section);
-		OPCODE_READ_PARAM_STRING(key);
+    char strValue[32];
+    sprintf_s(strValue, "%g", value);
+    auto result = WritePrivateProfileString(section, key, strValue, path);
 
-		char strValue[MAX_STR_LEN];
-		auto result = GetPrivateProfileString(section, key, NULL, strValue, sizeof(strValue), path);
-		if (result)
-		{
-			OPCODE_WRITE_PARAM_STRING(strValue);
-		}
-		else
-		{
-			OPCODE_SKIP_PARAMS(1);
-		}
-		OPCODE_CONDITION_RESULT(result);
-		return OR_CONTINUE;
-	}
+    OPCODE_CONDITION_RESULT(result);
+    return OR_CONTINUE;
+  }
 
-	static OpcodeResult __stdcall Script_InifileWriteString(CRunningScript* thread)
-		/****************************************************************
-		Opcode Format
-		0AF5=4,write_string %1s% to_ini_file %2s% section %3s% key %4s%
-		****************************************************************/
-	{
-		OPCODE_READ_PARAM_STRING_OR_ZERO(strValue); // 0 deletes the key
-		OPCODE_READ_PARAM_FILEPATH_INI(path);
-		OPCODE_READ_PARAM_STRING(section);
-		OPCODE_READ_PARAM_STRING_OR_ZERO(key);		// 0 deletes the whole section
+  static OpcodeResult __stdcall Script_InifileReadString(CRunningScript *thread)
+  /****************************************************************
+  Opcode Format
+  0AF4=4,%4d% = read_string_from_ini_file %1s% section %2s% key %3s%
+  ****************************************************************/
+  {
+    OPCODE_READ_PARAM_FILEPATH_INI(path);
+    OPCODE_READ_PARAM_STRING(section);
+    OPCODE_READ_PARAM_STRING(key);
 
-		auto result = WritePrivateProfileString(section, key, strValue, path);
+    char strValue[MAX_STR_LEN];
+    auto result = GetPrivateProfileString(section, key, NULL, strValue,
+                                          sizeof(strValue), path);
+    if (result) {
+      OPCODE_WRITE_PARAM_STRING(strValue);
+    } else {
+      OPCODE_SKIP_PARAMS(1);
+    }
+    OPCODE_CONDITION_RESULT(result);
+    return OR_CONTINUE;
+  }
 
-		OPCODE_CONDITION_RESULT(result);
-		return OR_CONTINUE;
-	}
+  static OpcodeResult __stdcall Script_InifileWriteString(
+      CRunningScript *thread)
+  /****************************************************************
+  Opcode Format
+  0AF5=4,write_string %1s% to_ini_file %2s% section %3s% key %4s%
+  ****************************************************************/
+  {
+    OPCODE_READ_PARAM_STRING_OR_ZERO(strValue); // 0 deletes the key
+    OPCODE_READ_PARAM_FILEPATH_INI(path);
+    OPCODE_READ_PARAM_STRING(section);
+    OPCODE_READ_PARAM_STRING_OR_ZERO(key); // 0 deletes the whole section
 
-	static OpcodeResult __stdcall Script_InifileDeleteSection(CRunningScript* thread)
-		/****************************************************************
-		Opcode Format
-		2800=2,delete_section_from_ini_file %1s% section %2s%
-		****************************************************************/
-	{
-		OPCODE_READ_PARAM_FILEPATH_INI(path);
-		OPCODE_READ_PARAM_STRING(section);
+    auto result = WritePrivateProfileString(section, key, strValue, path);
 
-		auto result = WritePrivateProfileString(section, nullptr, nullptr, path);
+    OPCODE_CONDITION_RESULT(result);
+    return OR_CONTINUE;
+  }
 
-		OPCODE_CONDITION_RESULT(result);
-		return OR_CONTINUE;
-	}
+  static OpcodeResult __stdcall Script_InifileDeleteSection(
+      CRunningScript *thread)
+  /****************************************************************
+  Opcode Format
+  2800=2,delete_section_from_ini_file %1s% section %2s%
+  ****************************************************************/
+  {
+    OPCODE_READ_PARAM_FILEPATH_INI(path);
+    OPCODE_READ_PARAM_STRING(section);
 
-	static OpcodeResult __stdcall Script_InifileDeleteKey(CRunningScript* thread)
-		/****************************************************************
-		Opcode Format
-		2801=3,delete_key_from_ini_file %1s% section %2s%
-		****************************************************************/
-	{
-		OPCODE_READ_PARAM_FILEPATH_INI(path);
-		OPCODE_READ_PARAM_STRING(section);
-		OPCODE_READ_PARAM_STRING(key);
+    auto result = WritePrivateProfileString(section, nullptr, nullptr, path);
 
-		auto result = WritePrivateProfileString(section, key, nullptr, path);
+    OPCODE_CONDITION_RESULT(result);
+    return OR_CONTINUE;
+  }
 
-		OPCODE_CONDITION_RESULT(result);
-		return OR_CONTINUE;
-	}
+  static OpcodeResult __stdcall Script_InifileDeleteKey(CRunningScript *thread)
+  /****************************************************************
+  Opcode Format
+  2801=3,delete_key_from_ini_file %1s% section %2s%
+  ****************************************************************/
+  {
+    OPCODE_READ_PARAM_FILEPATH_INI(path);
+    OPCODE_READ_PARAM_STRING(section);
+    OPCODE_READ_PARAM_STRING(key);
+
+    auto result = WritePrivateProfileString(section, key, nullptr, path);
+
+    OPCODE_CONDITION_RESULT(result);
+    return OR_CONTINUE;
+  }
 } iniFiles;
-

--- a/cleo_plugins/Input/main.cpp
+++ b/cleo_plugins/Input/main.cpp
@@ -9,639 +9,857 @@
 
 using namespace CLEO;
 
-
-class Input
-{
-	static constexpr int Key_Code_None = -1;
-	static constexpr size_t Key_Code_Max = 0xFF;
-	static constexpr BYTE Key_Flag_Down = 0x80; // top bit
+class Input {
+  static constexpr int Key_Code_None = -1;
+  static constexpr size_t Key_Code_Max = 0xFF;
+  static constexpr BYTE Key_Flag_Down = 0x80; // top bit
 
 public:
-	std::array<BYTE, Key_Code_Max + 1>* keyStatesCurr, *keyStatesPrev;
-
-	Input()
-	{
-		keyStatesCurr = new std::array<BYTE, Key_Code_Max + 1>();
-		keyStatesPrev = new std::array<BYTE, Key_Code_Max + 1>();
-
-		if (!PluginCheckCleoVersion()) return;
-
-		// register opcodes
-		CLEO_RegisterOpcode(0x0AB0, opcode_0AB0); // is_key_pressed
-		CLEO_RegisterOpcode(0x0ADC, opcode_0ADC); // test_cheat
-		CLEO_RegisterOpcode(0x2080, opcode_2080); // is_key_just_pressed
-		CLEO_RegisterOpcode(0x2081, opcode_2081); // get_key_pressed_in_range
-		CLEO_RegisterOpcode(0x2082, opcode_2082); // get_key_just_pressed_in_range
-		CLEO_RegisterOpcode(0x2083, opcode_2083); // emulate_key_press
-		CLEO_RegisterOpcode(0x2084, opcode_2084); // emulate_key_release
-		CLEO_RegisterOpcode(0x2085, opcode_2085); // get_controller_key
-		CLEO_RegisterOpcode(0x2086, opcode_2086); // get_key_name
-
-		// register event callbacks
-		CLEO_RegisterCallback(eCallbackId::GameProcessBefore, OnGameProcessBefore);
-		CLEO_RegisterCallback(eCallbackId::DrawingFinished, OnDrawingFinished);
-	}
-
-	~Input()
-	{
-		delete keyStatesCurr;
-		delete keyStatesPrev;
-
-		CLEO_UnregisterCallback(eCallbackId::GameProcessBefore, OnGameProcessBefore);
-		CLEO_UnregisterCallback(eCallbackId::DrawingFinished, OnDrawingFinished);
-	}
-
-	// refresh keys info
-	void CheckKeyboard()
-	{
-		std::swap(keyStatesCurr, keyStatesPrev);
-		GetKeyboardState(keyStatesCurr->data());
-	}
-
-	static void SendKeyEvent(BYTE vKey, bool down)
-	{
-		INPUT input = { 0 };
-		if (vKey >= VK_LBUTTON && vKey <= VK_XBUTTON2) // mouse keys
-		{
-			input.type = INPUT_MOUSE;
-			switch (vKey)
-			{
-				case VK_LBUTTON: input.mi.dwFlags = down ? MOUSEEVENTF_LEFTDOWN : MOUSEEVENTF_LEFTUP; break;
-				case VK_MBUTTON: input.mi.dwFlags = down ? MOUSEEVENTF_MIDDLEDOWN : MOUSEEVENTF_MIDDLEUP; break;
-				case VK_RBUTTON: input.mi.dwFlags = down ? MOUSEEVENTF_RIGHTDOWN : MOUSEEVENTF_RIGHTUP; break;
-
-				case VK_XBUTTON1:
-					input.mi.dwFlags = down ? MOUSEEVENTF_XDOWN : MOUSEEVENTF_XUP;
-					input.mi.mouseData = XBUTTON1;
-					break;
-
-				case VK_XBUTTON2:
-					input.mi.dwFlags = down ? MOUSEEVENTF_XDOWN : MOUSEEVENTF_XUP;
-					input.mi.mouseData = XBUTTON2;
-					break;
-			}
-		}
-		else // keyboard
-		{
-			input.type = INPUT_KEYBOARD;
-			input.ki.wVk = vKey;
-			input.ki.dwFlags = down ? 0 : KEYEVENTF_KEYUP;
-
-			switch(vKey)
-			{
-				case VK_RETURN: // would be mapped to numpad's enter
-				case VK_LSHIFT: // maps to VK_SHIFT
-				case VK_LCONTROL: // maps to VK_CONTROL
-				case VK_LMENU: // maps to VK_MENU
-					break; // do not use scan code
-
-				default:
-					input.ki.wScan = MapVirtualKey(vKey, MAPVK_VK_TO_VSC_EX);
-					input.ki.dwFlags |= KEYEVENTF_EXTENDEDKEY;
-			}
-		}
-
-		SendInput(1, &input, sizeof(input));
-	}
-
-	static void __stdcall OnGameProcessBefore()
-	{
-		g_instance.CheckKeyboard();
-	}
-
-	static void __stdcall OnDrawingFinished()
-	{
-		if (CTimer::m_UserPause) // main menu visible
-		{
-			g_instance.CheckKeyboard(); // update for ambient scripts running in menu
-		}
-	}
-
-	// is_key_pressed
-	// is_key_pressed {keyCode} [KeyCode] (logical)
-	static OpcodeResult __stdcall opcode_0AB0(CRunningScript* thread)
-	{
-		auto key = OPCODE_READ_PARAM_INT();
-
-		if (key == Key_Code_None)
-		{
-			OPCODE_CONDITION_RESULT(false);
-			return OR_CONTINUE;
-		}
-		if (key < 0 || key > Key_Code_Max)
-		{
-			LOG_WARNING(thread, "Invalid key code (%d) used in script %s", key, ScriptInfoStr(thread).c_str()); // legacy opcode, just warning
-			OPCODE_CONDITION_RESULT(false);
-			return OR_CONTINUE;
-		}
-
-		bool isDown = g_instance.keyStatesCurr->at(key) & Key_Flag_Down;
-
-		thread->SetConditionResult(isDown);
-		return OR_CONTINUE;
-	}
-
-	// test_cheat
-	// test_cheat {input} [string] (logical)
-	static OpcodeResult __stdcall opcode_0ADC(CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING_LEN(text, sizeof(CCheat::m_CheatString));
-
-		auto len = strlen(_buff_text);
-		if (len == 0)
-		{
-			OPCODE_CONDITION_RESULT(false);
-			return OR_CONTINUE;
-		}
-
-		_strrev(_buff_text); // reverse
-		if (_strnicmp(_buff_text, CCheat::m_CheatString, len) != 0)
-		{
-			OPCODE_CONDITION_RESULT(false);
-			return OR_CONTINUE;
-		}
-
-		CCheat::m_CheatString[0] = '\0'; // consume the cheat
-		OPCODE_CONDITION_RESULT(true);
-		return OR_CONTINUE;
-	}
-
-	// is_key_just_pressed
-	// is_key_just_pressed {keyCode} [KeyCode] (logical)
-	static OpcodeResult __stdcall opcode_2080(CRunningScript* thread)
-	{
-		auto key = OPCODE_READ_PARAM_INT();
-
-		if (key == Key_Code_None)
-		{
-			OPCODE_CONDITION_RESULT(false);
-			return OR_CONTINUE;
-		}
-		if (key < 0 || key > Key_Code_Max)
-		{
-			SHOW_ERROR("Invalid key code (%d) used in script %s\nScript suspended.", key, ScriptInfoStr(thread).c_str());
-			return thread->Suspend();
-		}
-
-		bool wasDown = g_instance.keyStatesPrev->at(key) & Key_Flag_Down;
-		bool isDown = g_instance.keyStatesCurr->at(key) & Key_Flag_Down;
-
-		OPCODE_CONDITION_RESULT(!wasDown && isDown);
-		return OR_CONTINUE;
-	}
-
-	// get_key_pressed_in_range
-	// [var keyCode: KeyCode] = get_key_pressed_in_range {minKeyCode} [KeyCode] {maxKeyCode} [KeyCode] (logical)
-	static OpcodeResult __stdcall opcode_2081(CRunningScript* thread)
-	{
-		auto keyMin = OPCODE_READ_PARAM_INT();
-		auto keyMax = OPCODE_READ_PARAM_INT();
-
-		if (keyMin < 0 || keyMin > Key_Code_Max)
-		{
-			SHOW_ERROR("Invalid value (%d) of 'minKeyCode' argument in script %s\nScript suspended.", keyMin, ScriptInfoStr(thread).c_str());
-			return thread->Suspend();
-		}
-		if (keyMax < 0 || keyMax > Key_Code_Max || keyMax < keyMin)
-		{
-			SHOW_ERROR("Invalid value (%d) of 'maxKeyCode' argument in script %s\nScript suspended.", keyMin, ScriptInfoStr(thread).c_str());
-			return thread->Suspend();
-		}
-
-		for (auto key = keyMin; key <= keyMax; key++)
-		{
-			bool isDown = g_instance.keyStatesCurr->at(key) & Key_Flag_Down;
-
-			if (isDown)
-			{
-				OPCODE_WRITE_PARAM_INT(key);
-				OPCODE_CONDITION_RESULT(true);
-				return OR_CONTINUE;
-			}
-		}
-
-		OPCODE_SKIP_PARAMS(1); // no result
-		OPCODE_CONDITION_RESULT(false);
-		return OR_CONTINUE;
-	}
-
-	// get_key_just_pressed_in_range
-	// [var keyCode: KeyCode] = get_key_just_pressed_in_range {minKeyCode} [KeyCode] {maxKeyCode} [KeyCode] (logical)
-	static OpcodeResult __stdcall opcode_2082(CRunningScript* thread)
-	{
-		auto keyMin = OPCODE_READ_PARAM_INT();
-		auto keyMax = OPCODE_READ_PARAM_INT();
-
-		if (keyMin < 0 || keyMin > Key_Code_Max)
-		{
-			SHOW_ERROR("Invalid value (%d) of 'minKeyCode' argument in script %s\nScript suspended.", keyMin, ScriptInfoStr(thread).c_str());
-			return thread->Suspend();
-		}
-		if (keyMax < 0 || keyMax > Key_Code_Max || keyMax < keyMin)
-		{
-			SHOW_ERROR("Invalid value (%d) of 'maxKeyCode' argument in script %s\nScript suspended.", keyMin, ScriptInfoStr(thread).c_str());
-			return thread->Suspend();
-		}
-
-		for (auto key = keyMin; key <= keyMax; key++)
-		{
-			bool wasDown = g_instance.keyStatesPrev->at(key) & Key_Flag_Down;
-			bool isDown = g_instance.keyStatesCurr->at(key) & Key_Flag_Down;
-
-			if (!wasDown && isDown)
-			{
-				OPCODE_WRITE_PARAM_INT(key);
-				OPCODE_CONDITION_RESULT(true);
-				return OR_CONTINUE;
-			}
-		}
-
-		OPCODE_SKIP_PARAMS(1); // no result
-		OPCODE_CONDITION_RESULT(false);
-		return OR_CONTINUE;
-	}
-
-	// emulate_key_press
-	// emulate_key_press {keyCode} [KeyCode]
-	static OpcodeResult __stdcall opcode_2083(CRunningScript* thread)
-	{
-		auto key = OPCODE_READ_PARAM_INT();
-
-		if (key == Key_Code_None)
-		{
-			return OR_CONTINUE;
-		}
-		if (key < 0 || key > Key_Code_Max)
-		{
-			SHOW_ERROR("Invalid key code (%d) used in script %s\nScript suspended.", key, ScriptInfoStr(thread).c_str());
-			return thread->Suspend();
-		}
-
-		SendKeyEvent(key, true);
-
-		return OR_CONTINUE;
-	}
-
-	// emulate_key_release
-	// emulate_key_release {keyCode} [KeyCode]
-	static OpcodeResult __stdcall opcode_2084(CRunningScript* thread)
-	{
-		auto key = OPCODE_READ_PARAM_INT();
-
-		if (key == Key_Code_None)
-		{
-			return OR_CONTINUE;
-		}
-		if (key < 0 || key > Key_Code_Max)
-		{
-			SHOW_ERROR("Invalid key code (%d) used in script %s\nScript suspended.", key, ScriptInfoStr(thread).c_str());
-			return thread->Suspend();
-		}
-
-		SendKeyEvent(key, false);
-
-		return OR_CONTINUE;
-	}
-
-	// get_controller_key
-	// [var keyCode: KeyCode] = get_controller_key {action} [ControllerAction] {altKeyIdx} [int] (logical)
-	static OpcodeResult __stdcall opcode_2085(CRunningScript* thread)
-	{
-		auto actionId = OPCODE_READ_PARAM_INT();
-		auto altKeyIdx = OPCODE_READ_PARAM_INT();
-
-		if (actionId < 0 || actionId >= _countof(ControlsManager.m_actions))
-		{
-			SHOW_ERROR("Invalid value (%d) of 'action' argument in script %s\nScript suspended.", actionId, ScriptInfoStr(thread).c_str());
-			return thread->Suspend();
-		}
-		if (altKeyIdx < 0 || altKeyIdx >= _countof(CControllerAction::keys))
-		{
-			SHOW_ERROR("Invalid value (%d) of 'altKeyIdx' argument in script %s\nScript suspended.", actionId, ScriptInfoStr(thread).c_str());
-			return thread->Suspend();
-		}
-
-		auto& action = ControlsManager.m_actions[actionId];
-
-		// sort associated keys by priority
-		std::map<unsigned int, DWORD> mapping;
-		for (size_t i = 0; i < _countof(action.keys); i++)
-		{
-			auto& k = action.keys[i];
-
-			if (k.keyCode == 0 || k.priority == 0) // key not assigned
-				continue;
-
-			if (k.keyCode == rsMOUSEWHEELUPBUTTON || k.keyCode == rsMOUSEWHEELDOWNBUTTON)
-				continue; // there is no VK codes for mouse wheel rolling
-
-			mapping[k.priority] = k.keyCode;
-		}
-
-		if (mapping.size() <= (size_t)altKeyIdx)
-		{
-			OPCODE_SKIP_PARAMS(1); // no key assigned
-			OPCODE_CONDITION_RESULT(false);
-			return OR_CONTINUE;
-		}
-
-		// get the alt key code
-		auto it = std::next(mapping.begin(), altKeyIdx);
-		auto keyCode = it->second;
-
-		// translate RsKeyCode to VirtualKey
-		switch(keyCode)
-		{
-			case rsMOUSELEFTBUTTON: keyCode = VK_LBUTTON; break;
-			case rsMOUSEMIDDLEBUTTON: keyCode = VK_MBUTTON; break;
-			case rsMOUSERIGHTBUTTON: keyCode = VK_RBUTTON; break;
-			//case rsMOUSEWHEELUPBUTTON:
-			//case rsMOUSEWHEELDOWNBUTTON:
-			case rsMOUSEX1BUTTON: keyCode = VK_XBUTTON1; break;
-			case rsMOUSEX2BUTTON: keyCode = VK_XBUTTON2; break;
-
-			case rsESC: keyCode = VK_ESCAPE; break;
-
-			case rsF1: keyCode = VK_F1; break;
-			case rsF2: keyCode = VK_F2; break;
-			case rsF3: keyCode = VK_F3; break;
-			case rsF4: keyCode = VK_F4; break;
-			case rsF5: keyCode = VK_F5; break;
-			case rsF6: keyCode = VK_F6; break;
-			case rsF7: keyCode = VK_F7; break;
-			case rsF8: keyCode = VK_F8; break;
-			case rsF9: keyCode = VK_F9; break;
-			case rsF10: keyCode = VK_F10; break;
-			case rsF11: keyCode = VK_F11; break;
-			case rsF12: keyCode = VK_F12; break;
-
-			case rsINS: keyCode = VK_INSERT; break;
-			case rsDEL: keyCode = VK_DELETE; break;
-			case rsHOME: keyCode = VK_HOME; break;
-			case rsEND: keyCode = VK_END; break;
-			case rsPGUP: keyCode = VK_PRIOR; break;
-			case rsPGDN: keyCode = VK_NEXT; break;
-
-			case rsUP: keyCode = VK_UP; break;
-			case rsDOWN: keyCode = VK_DOWN; break;
-			case rsLEFT: keyCode = VK_LEFT; break;
-			case rsRIGHT: keyCode = VK_RIGHT; break;
-
-			case rsDIVIDE: keyCode = VK_DIVIDE; break;
-			case rsTIMES: keyCode = VK_MULTIPLY; break;
-			case rsPLUS: keyCode = VK_ADD; break;
-			case rsMINUS: keyCode = VK_SUBTRACT; break;
-			case rsPADDEL: keyCode = VK_DECIMAL; break;
-			case rsPADEND: keyCode = VK_NUMPAD1; break;
-			case rsPADDOWN: keyCode = VK_NUMPAD2; break;
-			case rsPADPGDN: keyCode = VK_NUMPAD3; break;
-			case rsPADLEFT: keyCode = VK_NUMPAD4; break;
-			case rsPAD5: keyCode = VK_NUMPAD5; break;
-			case rsNUMLOCK: keyCode = VK_NUMLOCK; break;
-			case rsPADRIGHT: keyCode = VK_NUMPAD6; break;
-			case rsPADHOME: keyCode = VK_NUMPAD7; break;
-			case rsPADUP: keyCode = VK_NUMPAD8; break;
-			case rsPADPGUP: keyCode = VK_NUMPAD9; break;
-			case rsPADINS: keyCode = VK_NUMPAD0; break;
-			case rsPADENTER: keyCode = VK_RETURN; break; // not quite same
-
-			case rsSCROLL: keyCode = VK_SCROLL; break;
-			case rsPAUSE: keyCode = VK_PAUSE; break;
-
-			case rsBACKSP: keyCode = VK_BACK; break;
-			case rsTAB: keyCode = VK_TAB; break;
-			case rsCAPSLK: keyCode = VK_CAPITAL; break;
-			case rsENTER: keyCode = VK_RETURN; break;
-			case rsLSHIFT: keyCode = VK_LSHIFT; break;
-			case rsRSHIFT: keyCode = VK_RSHIFT; break;
-			case rsSHIFT: keyCode = VK_SHIFT; break;
-			case rsLCTRL: keyCode = VK_LCONTROL; break;
-			case rsRCTRL: keyCode = VK_RCONTROL; break;
-			case rsLALT: keyCode = VK_LMENU; break;
-			case rsRALT: keyCode = VK_RMENU; break;
-			case rsLWIN: keyCode = VK_LWIN; break;
-			case rsRWIN: keyCode = VK_RWIN; break;
-			case rsAPPS: keyCode = VK_APPS; break;
-		}
-		
-		OPCODE_WRITE_PARAM_INT(keyCode);
-		OPCODE_CONDITION_RESULT(true);
-		return OR_CONTINUE;
-	}
-
-	// get_key_name
-	// [var name: string] = get_key_name {keyCode} [KeyCode] (logical)
-	static OpcodeResult __stdcall opcode_2086(CRunningScript* thread)
-	{
-		auto key = OPCODE_READ_PARAM_INT();
-		
-		static char buff[32];
-		const char* name = nullptr;
-
-		if ((key >= '0' && key <= '9') ||
-			(key >= 'A' && key <= 'Z'))
-		{
-			// direct ASCII equivalent
-			buff[0] = (char)key;
-			buff[1] = '\0';
-			name = buff;
-		}
-		else if (key >= VK_F1 && key <= VK_F24)
-		{
-			CMessages::InsertNumberInString(TheText.Get("FEC_FNC"), key - VK_F1 + 1, 0, 0, 0, 0, 0, buff);
-			name = buff;
-		}
-		else if (key >= VK_NUMPAD0 && key <= VK_NUMPAD9)
-		{
-			CMessages::InsertNumberInString(TheText.Get("FEC_NMN"), key - VK_NUMPAD0, 0, 0, 0, 0, 0, buff);
-			name = buff;
-		}
-		else
-		{
-			// based on CInputEvents::getEventKeyName
-			switch(key)
-			{
-				case Key_Code_None: name = TheText.Get("FEC_UNB"); break;
-
-				case VK_LBUTTON: name = TheText.Get("FEC_MSL"); break;
-				case VK_RBUTTON: name = TheText.Get("FEC_MSR"); break; 
-				//case VK_CANCEL
-				case VK_MBUTTON: name = TheText.Get("FEC_MSM"); break;
-				case VK_XBUTTON1: name = TheText.Get("FEC_MXO"); break;
-				case VK_XBUTTON2: name = TheText.Get("FEC_MXT"); break;
-
-				case VK_BACK: name = TheText.Get("FEC_BSP"); break;
-				case VK_TAB: name = TheText.Get("FEC_TAB"); break;
-				case VK_CLEAR: name = "CLEAR"; break;
-				case VK_RETURN: name = TheText.Get("FEC_RTN"); break;
-				case VK_SHIFT: name = TheText.Get("FEC_SFT"); break;
-				case VK_CONTROL: name = "CTRL"; break;
-				case VK_MENU: name = "ALT"; break;
-				case VK_PAUSE: name = TheText.Get("FEC_PSB"); break; // FEC_PAS
-				case VK_CAPITAL: name = TheText.Get("FEC_CLK"); break;
-				//case VK_KANA
-				//case VK_IME_ON
-				//case VK_JUNJA
-				//case VK_FINAL
-				//case VK_HANJA
-				//case VK_IME_OFF
-				case VK_ESCAPE: name = "ESC"; break;
-				//case VK_CONVERT
-				//case VK_NONCONVERT
-				//case VK_ACCEPT
-				//case VK_MODECHANGE
-				case VK_SPACE: name = TheText.Get("FEC_SPC"); break;
-				case VK_PRIOR: name = TheText.Get("FEC_PGU"); break;
-				case VK_NEXT: name = TheText.Get("FEC_PGD"); break;
-				case VK_END: name = TheText.Get("FEC_END"); break;
-				case VK_HOME: name = TheText.Get("FEC_HME"); break;
-				case VK_LEFT: name = TheText.Get("FEC_LFA"); break;
-				case VK_UP: name = TheText.Get("FEC_UPA"); break;
-				case VK_RIGHT: name = TheText.Get("FEC_RFA"); break;
-				case VK_DOWN: name = TheText.Get("FEC_DWA"); break;
-				case VK_SELECT: name = "SELECT"; break;
-				case VK_PRINT: name = "PRINT"; break;
-				case VK_EXECUTE: name = "EXECUTE"; break;
-				case VK_SNAPSHOT: name = "PRTSCR"; break;
-				case VK_INSERT: name = TheText.Get("FEC_IRT"); break;
-				case VK_DELETE: name = TheText.Get("FEC_DLL"); break;
-				case VK_HELP: name = "HELP"; break;
-				case VK_LWIN: name = TheText.Get("FEC_LWD"); break;
-				case VK_RWIN: name = TheText.Get("FEC_RWD"); break;
-				case VK_APPS: name = TheText.Get("FEC_WRC"); break;
-
-				case '^': // German "double s" letter
-					buff[0] = '|';
-					buff[1] = '\0';
-					name = buff;
-				break;
-
-				case VK_SLEEP: name = "SLEEP"; break;
-				case VK_MULTIPLY: name = TheText.Get("FECSTAR"); break;
-				case VK_ADD: name = TheText.Get("FEC_PLS"); break;
-				//case VK_SEPARATOR ???
-				case VK_SUBTRACT: name = TheText.Get("FEC_MIN"); break;
-				case VK_DECIMAL: name = TheText.Get("FEC_DOT"); break;
-				case VK_DIVIDE: name = TheText.Get("FEC_FWS"); break;
-				//case VK_NAVIGATION_VIEW
-				//case VK_NAVIGATION_MENU
-				//case VK_NAVIGATION_UP
-				//case VK_NAVIGATION_DOWN
-				//case VK_NAVIGATION_LEFT
-				//case VK_NAVIGATION_RIGHT
-				//case VK_NAVIGATION_ACCEPT
-				//case VK_NAVIGATION_CANCEL
-				case VK_NUMLOCK: name = TheText.Get("FEC_NLK"); break;
-				case VK_SCROLL: name = TheText.Get("FEC_SLK"); break;
-				case VK_OEM_NEC_EQUAL: name = TheText.Get("FEC_ETR"); break;
-				//case VK_OEM_FJ_JISHO
-				//case VK_OEM_FJ_MASSHOU
-				//case VK_OEM_FJ_TOUROKU
-				//case VK_OEM_FJ_LOYA
-				//case VK_OEM_FJ_ROYA
-				case VK_LSHIFT: name = TheText.Get("FEC_LSF"); break;
-				case VK_RSHIFT: name = TheText.Get("FEC_RSF"); break;
-				case VK_LCONTROL: name = TheText.Get("FEC_LCT"); break;
-				case VK_RCONTROL: name = TheText.Get("FEC_RCT"); break;
-				case VK_LMENU:name = TheText.Get("FEC_LAL"); break;
-				case VK_RMENU:name = TheText.Get("FEC_RAL"); break;
-				//case VK_BROWSER_BACK
-				//case VK_BROWSER_FORWARD
-				//case VK_BROWSER_REFRESH
-				//case VK_BROWSER_STOP
-				//case VK_BROWSER_SEARCH
-				//case VK_BROWSER_FAVORITES
-				//case VK_BROWSER_HOME
-				//case VK_VOLUME_MUTE
-				//case VK_VOLUME_DOWN
-				//case VK_VOLUME_UP
-				//case VK_MEDIA_NEXT_TRACK
-				//case VK_MEDIA_PREV_TRACK
-				//case VK_MEDIA_STOP: in GTA some French letter?
-				//case VK_MEDIA_PLAY_PAUSE
-				//case VK_LAUNCH_MAIL
-				//case VK_LAUNCH_MEDIA_SELECT
-				//case VK_LAUNCH_APP1
-				//case VK_LAUNCH_APP2
-				case VK_OEM_1: name = ","; break;
-				case VK_OEM_PLUS: name = "="; break;
-				case VK_OEM_COMMA: name = ","; break;
-				case VK_OEM_MINUS: name = "-"; break;
-				case VK_OEM_PERIOD: name = "."; break;
-				case VK_OEM_2: name = "/"; break;
-				case VK_OEM_3: name = "`"; break;
-				//case VK_GAMEPAD_A
-				//case VK_GAMEPAD_B
-				//case VK_GAMEPAD_X
-				//case VK_GAMEPAD_Y
-				//case VK_GAMEPAD_RIGHT_SHOULDER
-				//case VK_GAMEPAD_LEFT_SHOULDER
-				//case VK_GAMEPAD_LEFT_TRIGGER
-				//case VK_GAMEPAD_RIGHT_TRIGGER
-				//case VK_GAMEPAD_DPAD_UP
-				//case VK_GAMEPAD_DPAD_DOWN
-				//case VK_GAMEPAD_DPAD_LEFT
-				//case VK_GAMEPAD_DPAD_RIGHT
-				//case VK_GAMEPAD_MENU
-				//case VK_GAMEPAD_VIEW
-				//case VK_GAMEPAD_LEFT_THUMBSTICK_BUTTON
-				//case VK_GAMEPAD_RIGHT_THUMBSTICK_BUTTON
-				//case VK_GAMEPAD_LEFT_THUMBSTICK_UP
-				//case VK_GAMEPAD_LEFT_THUMBSTICK_DOWN
-				//case VK_GAMEPAD_LEFT_THUMBSTICK_RIGHT
-				//case VK_GAMEPAD_LEFT_THUMBSTICK_LEFT
-				//case VK_GAMEPAD_RIGHT_THUMBSTICK_UP
-				//case VK_GAMEPAD_RIGHT_THUMBSTICK_DOWN
-				//case VK_GAMEPAD_RIGHT_THUMBSTICK_RIGHT
-				//case VK_GAMEPAD_RIGHT_THUMBSTICK_LEFT
-				case VK_OEM_4: name = "["; break;
-				case VK_OEM_5: name = "\\"; break;
-				case VK_OEM_6: name = "]"; break;
-				case VK_OEM_7: name = "'"; break;
-				//case VK_OEM_8
-				//case VK_OEM_AX
-				//case VK_OEM_102
-				//case VK_ICO_HELP
-				//case VK_ICO_00
-				//case VK_ICO_CLEAR
-				//case VK_PACKET
-				//case VK_OEM_RESET
-				//case VK_OEM_JUMP
-				//case VK_OEM_PA1
-				//case VK_OEM_PA2
-				//case VK_OEM_PA3
-				//case VK_OEM_WSCTRL
-				//case VK_OEM_CUSEL
-				//case VK_OEM_ATTN
-				//case VK_OEM_FINISH
-				//case VK_OEM_COPY
-				//case VK_OEM_AUTO
-				//case VK_OEM_ENLW
-				//case VK_OEM_BACKTAB
-				//case VK_OEM_BACKTAB
-				//case VK_ATTN
-				//case VK_CRSEL
-				//case VK_EXSEL
-				//case VK_EREOF
-				//case VK_PLAY
-				//case VK_ZOOM
-				//case VK_NONAME
-				//case VK_PA1
-				//case VK_OEM_CLEAR
-			}
-		}
-
-		if (name == nullptr)
-		{
-			OPCODE_SKIP_PARAMS(1);
-			OPCODE_CONDITION_RESULT(false);
-			return OR_CONTINUE;
-		}
-
-		OPCODE_WRITE_PARAM_STRING(name);
-		OPCODE_CONDITION_RESULT(true);
-		return OR_CONTINUE;
-	}
+  std::array<BYTE, Key_Code_Max + 1> *keyStatesCurr, *keyStatesPrev;
+
+  Input() {
+    keyStatesCurr = new std::array<BYTE, Key_Code_Max + 1>();
+    keyStatesPrev = new std::array<BYTE, Key_Code_Max + 1>();
+
+    if (!PluginCheckCleoVersion())
+      return;
+
+    // register opcodes
+    CLEO_RegisterOpcode(0x0AB0, opcode_0AB0); // is_key_pressed
+    CLEO_RegisterOpcode(0x0ADC, opcode_0ADC); // test_cheat
+    CLEO_RegisterOpcode(0x2080, opcode_2080); // is_key_just_pressed
+    CLEO_RegisterOpcode(0x2081, opcode_2081); // get_key_pressed_in_range
+    CLEO_RegisterOpcode(0x2082, opcode_2082); // get_key_just_pressed_in_range
+    CLEO_RegisterOpcode(0x2083, opcode_2083); // emulate_key_press
+    CLEO_RegisterOpcode(0x2084, opcode_2084); // emulate_key_release
+    CLEO_RegisterOpcode(0x2085, opcode_2085); // get_controller_key
+    CLEO_RegisterOpcode(0x2086, opcode_2086); // get_key_name
+
+    // register event callbacks
+    CLEO_RegisterCallback(eCallbackId::GameProcessBefore, OnGameProcessBefore);
+    CLEO_RegisterCallback(eCallbackId::DrawingFinished, OnDrawingFinished);
+  }
+
+  ~Input() {
+    delete keyStatesCurr;
+    delete keyStatesPrev;
+
+    CLEO_UnregisterCallback(eCallbackId::GameProcessBefore,
+                            OnGameProcessBefore);
+    CLEO_UnregisterCallback(eCallbackId::DrawingFinished, OnDrawingFinished);
+  }
+
+  // refresh keys info
+  void CheckKeyboard() {
+    std::swap(keyStatesCurr, keyStatesPrev);
+    GetKeyboardState(keyStatesCurr->data());
+  }
+
+  static void SendKeyEvent(BYTE vKey, bool down) {
+    INPUT input = {0};
+    if (vKey >= VK_LBUTTON && vKey <= VK_XBUTTON2) // mouse keys
+    {
+      input.type = INPUT_MOUSE;
+      switch (vKey) {
+      case VK_LBUTTON:
+        input.mi.dwFlags = down ? MOUSEEVENTF_LEFTDOWN : MOUSEEVENTF_LEFTUP;
+        break;
+      case VK_MBUTTON:
+        input.mi.dwFlags = down ? MOUSEEVENTF_MIDDLEDOWN : MOUSEEVENTF_MIDDLEUP;
+        break;
+      case VK_RBUTTON:
+        input.mi.dwFlags = down ? MOUSEEVENTF_RIGHTDOWN : MOUSEEVENTF_RIGHTUP;
+        break;
+
+      case VK_XBUTTON1:
+        input.mi.dwFlags = down ? MOUSEEVENTF_XDOWN : MOUSEEVENTF_XUP;
+        input.mi.mouseData = XBUTTON1;
+        break;
+
+      case VK_XBUTTON2:
+        input.mi.dwFlags = down ? MOUSEEVENTF_XDOWN : MOUSEEVENTF_XUP;
+        input.mi.mouseData = XBUTTON2;
+        break;
+      }
+    } else // keyboard
+    {
+      input.type = INPUT_KEYBOARD;
+      input.ki.wVk = vKey;
+      input.ki.dwFlags = down ? 0 : KEYEVENTF_KEYUP;
+
+      switch (vKey) {
+      case VK_RETURN:   // would be mapped to numpad's enter
+      case VK_LSHIFT:   // maps to VK_SHIFT
+      case VK_LCONTROL: // maps to VK_CONTROL
+      case VK_LMENU:    // maps to VK_MENU
+        break;          // do not use scan code
+
+      default:
+        input.ki.wScan = MapVirtualKey(vKey, MAPVK_VK_TO_VSC_EX);
+        input.ki.dwFlags |= KEYEVENTF_EXTENDEDKEY;
+      }
+    }
+
+    SendInput(1, &input, sizeof(input));
+  }
+
+  static void __stdcall OnGameProcessBefore() { g_instance.CheckKeyboard(); }
+
+  static void __stdcall OnDrawingFinished() {
+    if (CTimer::m_UserPause) // main menu visible
+    {
+      g_instance.CheckKeyboard(); // update for ambient scripts running in menu
+    }
+  }
+
+  // is_key_pressed
+  // is_key_pressed {keyCode} [KeyCode] (logical)
+  static OpcodeResult __stdcall opcode_0AB0(CRunningScript *thread) {
+    auto key = OPCODE_READ_PARAM_INT();
+
+    if (key == Key_Code_None) {
+      OPCODE_CONDITION_RESULT(false);
+      return OR_CONTINUE;
+    }
+    if (key < 0 || key > Key_Code_Max) {
+      LOG_WARNING(thread, "Invalid key code (%d) used in script %s", key,
+                  ScriptInfoStr(thread).c_str()); // legacy opcode, just warning
+      OPCODE_CONDITION_RESULT(false);
+      return OR_CONTINUE;
+    }
+
+    bool isDown = g_instance.keyStatesCurr->at(key) & Key_Flag_Down;
+
+    thread->SetConditionResult(isDown);
+    return OR_CONTINUE;
+  }
+
+  // test_cheat
+  // test_cheat {input} [string] (logical)
+  static OpcodeResult __stdcall opcode_0ADC(CRunningScript *thread) {
+    OPCODE_READ_PARAM_STRING_LEN(text, sizeof(CCheat::m_CheatString));
+
+    auto len = strlen(_buff_text);
+    if (len == 0) {
+      OPCODE_CONDITION_RESULT(false);
+      return OR_CONTINUE;
+    }
+
+    _strrev(_buff_text); // reverse
+    if (_strnicmp(_buff_text, CCheat::m_CheatString, len) != 0) {
+      OPCODE_CONDITION_RESULT(false);
+      return OR_CONTINUE;
+    }
+
+    CCheat::m_CheatString[0] = '\0'; // consume the cheat
+    OPCODE_CONDITION_RESULT(true);
+    return OR_CONTINUE;
+  }
+
+  // is_key_just_pressed
+  // is_key_just_pressed {keyCode} [KeyCode] (logical)
+  static OpcodeResult __stdcall opcode_2080(CRunningScript *thread) {
+    auto key = OPCODE_READ_PARAM_INT();
+
+    if (key == Key_Code_None) {
+      OPCODE_CONDITION_RESULT(false);
+      return OR_CONTINUE;
+    }
+    if (key < 0 || key > Key_Code_Max) {
+      SHOW_ERROR("Invalid key code (%d) used in script %s\nScript suspended.",
+                 key, ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
+    }
+
+    bool wasDown = g_instance.keyStatesPrev->at(key) & Key_Flag_Down;
+    bool isDown = g_instance.keyStatesCurr->at(key) & Key_Flag_Down;
+
+    OPCODE_CONDITION_RESULT(!wasDown && isDown);
+    return OR_CONTINUE;
+  }
+
+  // get_key_pressed_in_range
+  // [var keyCode: KeyCode] = get_key_pressed_in_range {minKeyCode} [KeyCode]
+  // {maxKeyCode} [KeyCode] (logical)
+  static OpcodeResult __stdcall opcode_2081(CRunningScript *thread) {
+    auto keyMin = OPCODE_READ_PARAM_INT();
+    auto keyMax = OPCODE_READ_PARAM_INT();
+
+    if (keyMin < 0 || keyMin > Key_Code_Max) {
+      SHOW_ERROR("Invalid value (%d) of 'minKeyCode' argument in script "
+                 "%s\nScript suspended.",
+                 keyMin, ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
+    }
+    if (keyMax < 0 || keyMax > Key_Code_Max || keyMax < keyMin) {
+      SHOW_ERROR("Invalid value (%d) of 'maxKeyCode' argument in script "
+                 "%s\nScript suspended.",
+                 keyMin, ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
+    }
+
+    for (auto key = keyMin; key <= keyMax; key++) {
+      bool isDown = g_instance.keyStatesCurr->at(key) & Key_Flag_Down;
+
+      if (isDown) {
+        OPCODE_WRITE_PARAM_INT(key);
+        OPCODE_CONDITION_RESULT(true);
+        return OR_CONTINUE;
+      }
+    }
+
+    OPCODE_SKIP_PARAMS(1); // no result
+    OPCODE_CONDITION_RESULT(false);
+    return OR_CONTINUE;
+  }
+
+  // get_key_just_pressed_in_range
+  // [var keyCode: KeyCode] = get_key_just_pressed_in_range {minKeyCode}
+  // [KeyCode] {maxKeyCode} [KeyCode] (logical)
+  static OpcodeResult __stdcall opcode_2082(CRunningScript *thread) {
+    auto keyMin = OPCODE_READ_PARAM_INT();
+    auto keyMax = OPCODE_READ_PARAM_INT();
+
+    if (keyMin < 0 || keyMin > Key_Code_Max) {
+      SHOW_ERROR("Invalid value (%d) of 'minKeyCode' argument in script "
+                 "%s\nScript suspended.",
+                 keyMin, ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
+    }
+    if (keyMax < 0 || keyMax > Key_Code_Max || keyMax < keyMin) {
+      SHOW_ERROR("Invalid value (%d) of 'maxKeyCode' argument in script "
+                 "%s\nScript suspended.",
+                 keyMin, ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
+    }
+
+    for (auto key = keyMin; key <= keyMax; key++) {
+      bool wasDown = g_instance.keyStatesPrev->at(key) & Key_Flag_Down;
+      bool isDown = g_instance.keyStatesCurr->at(key) & Key_Flag_Down;
+
+      if (!wasDown && isDown) {
+        OPCODE_WRITE_PARAM_INT(key);
+        OPCODE_CONDITION_RESULT(true);
+        return OR_CONTINUE;
+      }
+    }
+
+    OPCODE_SKIP_PARAMS(1); // no result
+    OPCODE_CONDITION_RESULT(false);
+    return OR_CONTINUE;
+  }
+
+  // emulate_key_press
+  // emulate_key_press {keyCode} [KeyCode]
+  static OpcodeResult __stdcall opcode_2083(CRunningScript *thread) {
+    auto key = OPCODE_READ_PARAM_INT();
+
+    if (key == Key_Code_None) {
+      return OR_CONTINUE;
+    }
+    if (key < 0 || key > Key_Code_Max) {
+      SHOW_ERROR("Invalid key code (%d) used in script %s\nScript suspended.",
+                 key, ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
+    }
+
+    SendKeyEvent(key, true);
+
+    return OR_CONTINUE;
+  }
+
+  // emulate_key_release
+  // emulate_key_release {keyCode} [KeyCode]
+  static OpcodeResult __stdcall opcode_2084(CRunningScript *thread) {
+    auto key = OPCODE_READ_PARAM_INT();
+
+    if (key == Key_Code_None) {
+      return OR_CONTINUE;
+    }
+    if (key < 0 || key > Key_Code_Max) {
+      SHOW_ERROR("Invalid key code (%d) used in script %s\nScript suspended.",
+                 key, ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
+    }
+
+    SendKeyEvent(key, false);
+
+    return OR_CONTINUE;
+  }
+
+  // get_controller_key
+  // [var keyCode: KeyCode] = get_controller_key {action} [ControllerAction]
+  // {altKeyIdx} [int] (logical)
+  static OpcodeResult __stdcall opcode_2085(CRunningScript *thread) {
+    auto actionId = OPCODE_READ_PARAM_INT();
+    auto altKeyIdx = OPCODE_READ_PARAM_INT();
+
+    if (actionId < 0 || actionId >= _countof(ControlsManager.m_actions)) {
+      SHOW_ERROR("Invalid value (%d) of 'action' argument in script %s\nScript "
+                 "suspended.",
+                 actionId, ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
+    }
+    if (altKeyIdx < 0 || altKeyIdx >= _countof(CControllerAction::keys)) {
+      SHOW_ERROR("Invalid value (%d) of 'altKeyIdx' argument in script "
+                 "%s\nScript suspended.",
+                 actionId, ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
+    }
+
+    auto &action = ControlsManager.m_actions[actionId];
+
+    // sort associated keys by priority
+    std::map<unsigned int, DWORD> mapping;
+    for (size_t i = 0; i < _countof(action.keys); i++) {
+      auto &k = action.keys[i];
+
+      if (k.keyCode == 0 || k.priority == 0) // key not assigned
+        continue;
+
+      if (k.keyCode == rsMOUSEWHEELUPBUTTON ||
+          k.keyCode == rsMOUSEWHEELDOWNBUTTON)
+        continue; // there is no VK codes for mouse wheel rolling
+
+      mapping[k.priority] = k.keyCode;
+    }
+
+    if (mapping.size() <= (size_t)altKeyIdx) {
+      OPCODE_SKIP_PARAMS(1); // no key assigned
+      OPCODE_CONDITION_RESULT(false);
+      return OR_CONTINUE;
+    }
+
+    // get the alt key code
+    auto it = std::next(mapping.begin(), altKeyIdx);
+    auto keyCode = it->second;
+
+    // translate RsKeyCode to VirtualKey
+    switch (keyCode) {
+    case rsMOUSELEFTBUTTON:
+      keyCode = VK_LBUTTON;
+      break;
+    case rsMOUSEMIDDLEBUTTON:
+      keyCode = VK_MBUTTON;
+      break;
+    case rsMOUSERIGHTBUTTON:
+      keyCode = VK_RBUTTON;
+      break;
+    // case rsMOUSEWHEELUPBUTTON:
+    // case rsMOUSEWHEELDOWNBUTTON:
+    case rsMOUSEX1BUTTON:
+      keyCode = VK_XBUTTON1;
+      break;
+    case rsMOUSEX2BUTTON:
+      keyCode = VK_XBUTTON2;
+      break;
+
+    case rsESC:
+      keyCode = VK_ESCAPE;
+      break;
+
+    case rsF1:
+      keyCode = VK_F1;
+      break;
+    case rsF2:
+      keyCode = VK_F2;
+      break;
+    case rsF3:
+      keyCode = VK_F3;
+      break;
+    case rsF4:
+      keyCode = VK_F4;
+      break;
+    case rsF5:
+      keyCode = VK_F5;
+      break;
+    case rsF6:
+      keyCode = VK_F6;
+      break;
+    case rsF7:
+      keyCode = VK_F7;
+      break;
+    case rsF8:
+      keyCode = VK_F8;
+      break;
+    case rsF9:
+      keyCode = VK_F9;
+      break;
+    case rsF10:
+      keyCode = VK_F10;
+      break;
+    case rsF11:
+      keyCode = VK_F11;
+      break;
+    case rsF12:
+      keyCode = VK_F12;
+      break;
+
+    case rsINS:
+      keyCode = VK_INSERT;
+      break;
+    case rsDEL:
+      keyCode = VK_DELETE;
+      break;
+    case rsHOME:
+      keyCode = VK_HOME;
+      break;
+    case rsEND:
+      keyCode = VK_END;
+      break;
+    case rsPGUP:
+      keyCode = VK_PRIOR;
+      break;
+    case rsPGDN:
+      keyCode = VK_NEXT;
+      break;
+
+    case rsUP:
+      keyCode = VK_UP;
+      break;
+    case rsDOWN:
+      keyCode = VK_DOWN;
+      break;
+    case rsLEFT:
+      keyCode = VK_LEFT;
+      break;
+    case rsRIGHT:
+      keyCode = VK_RIGHT;
+      break;
+
+    case rsDIVIDE:
+      keyCode = VK_DIVIDE;
+      break;
+    case rsTIMES:
+      keyCode = VK_MULTIPLY;
+      break;
+    case rsPLUS:
+      keyCode = VK_ADD;
+      break;
+    case rsMINUS:
+      keyCode = VK_SUBTRACT;
+      break;
+    case rsPADDEL:
+      keyCode = VK_DECIMAL;
+      break;
+    case rsPADEND:
+      keyCode = VK_NUMPAD1;
+      break;
+    case rsPADDOWN:
+      keyCode = VK_NUMPAD2;
+      break;
+    case rsPADPGDN:
+      keyCode = VK_NUMPAD3;
+      break;
+    case rsPADLEFT:
+      keyCode = VK_NUMPAD4;
+      break;
+    case rsPAD5:
+      keyCode = VK_NUMPAD5;
+      break;
+    case rsNUMLOCK:
+      keyCode = VK_NUMLOCK;
+      break;
+    case rsPADRIGHT:
+      keyCode = VK_NUMPAD6;
+      break;
+    case rsPADHOME:
+      keyCode = VK_NUMPAD7;
+      break;
+    case rsPADUP:
+      keyCode = VK_NUMPAD8;
+      break;
+    case rsPADPGUP:
+      keyCode = VK_NUMPAD9;
+      break;
+    case rsPADINS:
+      keyCode = VK_NUMPAD0;
+      break;
+    case rsPADENTER:
+      keyCode = VK_RETURN;
+      break; // not quite same
+
+    case rsSCROLL:
+      keyCode = VK_SCROLL;
+      break;
+    case rsPAUSE:
+      keyCode = VK_PAUSE;
+      break;
+
+    case rsBACKSP:
+      keyCode = VK_BACK;
+      break;
+    case rsTAB:
+      keyCode = VK_TAB;
+      break;
+    case rsCAPSLK:
+      keyCode = VK_CAPITAL;
+      break;
+    case rsENTER:
+      keyCode = VK_RETURN;
+      break;
+    case rsLSHIFT:
+      keyCode = VK_LSHIFT;
+      break;
+    case rsRSHIFT:
+      keyCode = VK_RSHIFT;
+      break;
+    case rsSHIFT:
+      keyCode = VK_SHIFT;
+      break;
+    case rsLCTRL:
+      keyCode = VK_LCONTROL;
+      break;
+    case rsRCTRL:
+      keyCode = VK_RCONTROL;
+      break;
+    case rsLALT:
+      keyCode = VK_LMENU;
+      break;
+    case rsRALT:
+      keyCode = VK_RMENU;
+      break;
+    case rsLWIN:
+      keyCode = VK_LWIN;
+      break;
+    case rsRWIN:
+      keyCode = VK_RWIN;
+      break;
+    case rsAPPS:
+      keyCode = VK_APPS;
+      break;
+    }
+
+    OPCODE_WRITE_PARAM_INT(keyCode);
+    OPCODE_CONDITION_RESULT(true);
+    return OR_CONTINUE;
+  }
+
+  // get_key_name
+  // [var name: string] = get_key_name {keyCode} [KeyCode] (logical)
+  static OpcodeResult __stdcall opcode_2086(CRunningScript *thread) {
+    auto key = OPCODE_READ_PARAM_INT();
+
+    static char buff[32];
+    const char *name = nullptr;
+
+    if ((key >= '0' && key <= '9') || (key >= 'A' && key <= 'Z')) {
+      // direct ASCII equivalent
+      buff[0] = (char)key;
+      buff[1] = '\0';
+      name = buff;
+    } else if (key >= VK_F1 && key <= VK_F24) {
+      CMessages::InsertNumberInString(TheText.Get("FEC_FNC"), key - VK_F1 + 1,
+                                      0, 0, 0, 0, 0, buff);
+      name = buff;
+    } else if (key >= VK_NUMPAD0 && key <= VK_NUMPAD9) {
+      CMessages::InsertNumberInString(TheText.Get("FEC_NMN"), key - VK_NUMPAD0,
+                                      0, 0, 0, 0, 0, buff);
+      name = buff;
+    } else {
+      // based on CInputEvents::getEventKeyName
+      switch (key) {
+      case Key_Code_None:
+        name = TheText.Get("FEC_UNB");
+        break;
+
+      case VK_LBUTTON:
+        name = TheText.Get("FEC_MSL");
+        break;
+      case VK_RBUTTON:
+        name = TheText.Get("FEC_MSR");
+        break;
+      // case VK_CANCEL
+      case VK_MBUTTON:
+        name = TheText.Get("FEC_MSM");
+        break;
+      case VK_XBUTTON1:
+        name = TheText.Get("FEC_MXO");
+        break;
+      case VK_XBUTTON2:
+        name = TheText.Get("FEC_MXT");
+        break;
+
+      case VK_BACK:
+        name = TheText.Get("FEC_BSP");
+        break;
+      case VK_TAB:
+        name = TheText.Get("FEC_TAB");
+        break;
+      case VK_CLEAR:
+        name = "CLEAR";
+        break;
+      case VK_RETURN:
+        name = TheText.Get("FEC_RTN");
+        break;
+      case VK_SHIFT:
+        name = TheText.Get("FEC_SFT");
+        break;
+      case VK_CONTROL:
+        name = "CTRL";
+        break;
+      case VK_MENU:
+        name = "ALT";
+        break;
+      case VK_PAUSE:
+        name = TheText.Get("FEC_PSB");
+        break; // FEC_PAS
+      case VK_CAPITAL:
+        name = TheText.Get("FEC_CLK");
+        break;
+      // case VK_KANA
+      // case VK_IME_ON
+      // case VK_JUNJA
+      // case VK_FINAL
+      // case VK_HANJA
+      // case VK_IME_OFF
+      case VK_ESCAPE:
+        name = "ESC";
+        break;
+      // case VK_CONVERT
+      // case VK_NONCONVERT
+      // case VK_ACCEPT
+      // case VK_MODECHANGE
+      case VK_SPACE:
+        name = TheText.Get("FEC_SPC");
+        break;
+      case VK_PRIOR:
+        name = TheText.Get("FEC_PGU");
+        break;
+      case VK_NEXT:
+        name = TheText.Get("FEC_PGD");
+        break;
+      case VK_END:
+        name = TheText.Get("FEC_END");
+        break;
+      case VK_HOME:
+        name = TheText.Get("FEC_HME");
+        break;
+      case VK_LEFT:
+        name = TheText.Get("FEC_LFA");
+        break;
+      case VK_UP:
+        name = TheText.Get("FEC_UPA");
+        break;
+      case VK_RIGHT:
+        name = TheText.Get("FEC_RFA");
+        break;
+      case VK_DOWN:
+        name = TheText.Get("FEC_DWA");
+        break;
+      case VK_SELECT:
+        name = "SELECT";
+        break;
+      case VK_PRINT:
+        name = "PRINT";
+        break;
+      case VK_EXECUTE:
+        name = "EXECUTE";
+        break;
+      case VK_SNAPSHOT:
+        name = "PRTSCR";
+        break;
+      case VK_INSERT:
+        name = TheText.Get("FEC_IRT");
+        break;
+      case VK_DELETE:
+        name = TheText.Get("FEC_DLL");
+        break;
+      case VK_HELP:
+        name = "HELP";
+        break;
+      case VK_LWIN:
+        name = TheText.Get("FEC_LWD");
+        break;
+      case VK_RWIN:
+        name = TheText.Get("FEC_RWD");
+        break;
+      case VK_APPS:
+        name = TheText.Get("FEC_WRC");
+        break;
+
+      case '^': // German "double s" letter
+        buff[0] = '|';
+        buff[1] = '\0';
+        name = buff;
+        break;
+
+      case VK_SLEEP:
+        name = "SLEEP";
+        break;
+      case VK_MULTIPLY:
+        name = TheText.Get("FECSTAR");
+        break;
+      case VK_ADD:
+        name = TheText.Get("FEC_PLS");
+        break;
+      // case VK_SEPARATOR ???
+      case VK_SUBTRACT:
+        name = TheText.Get("FEC_MIN");
+        break;
+      case VK_DECIMAL:
+        name = TheText.Get("FEC_DOT");
+        break;
+      case VK_DIVIDE:
+        name = TheText.Get("FEC_FWS");
+        break;
+      // case VK_NAVIGATION_VIEW
+      // case VK_NAVIGATION_MENU
+      // case VK_NAVIGATION_UP
+      // case VK_NAVIGATION_DOWN
+      // case VK_NAVIGATION_LEFT
+      // case VK_NAVIGATION_RIGHT
+      // case VK_NAVIGATION_ACCEPT
+      // case VK_NAVIGATION_CANCEL
+      case VK_NUMLOCK:
+        name = TheText.Get("FEC_NLK");
+        break;
+      case VK_SCROLL:
+        name = TheText.Get("FEC_SLK");
+        break;
+      case VK_OEM_NEC_EQUAL:
+        name = TheText.Get("FEC_ETR");
+        break;
+      // case VK_OEM_FJ_JISHO
+      // case VK_OEM_FJ_MASSHOU
+      // case VK_OEM_FJ_TOUROKU
+      // case VK_OEM_FJ_LOYA
+      // case VK_OEM_FJ_ROYA
+      case VK_LSHIFT:
+        name = TheText.Get("FEC_LSF");
+        break;
+      case VK_RSHIFT:
+        name = TheText.Get("FEC_RSF");
+        break;
+      case VK_LCONTROL:
+        name = TheText.Get("FEC_LCT");
+        break;
+      case VK_RCONTROL:
+        name = TheText.Get("FEC_RCT");
+        break;
+      case VK_LMENU:
+        name = TheText.Get("FEC_LAL");
+        break;
+      case VK_RMENU:
+        name = TheText.Get("FEC_RAL");
+        break;
+      // case VK_BROWSER_BACK
+      // case VK_BROWSER_FORWARD
+      // case VK_BROWSER_REFRESH
+      // case VK_BROWSER_STOP
+      // case VK_BROWSER_SEARCH
+      // case VK_BROWSER_FAVORITES
+      // case VK_BROWSER_HOME
+      // case VK_VOLUME_MUTE
+      // case VK_VOLUME_DOWN
+      // case VK_VOLUME_UP
+      // case VK_MEDIA_NEXT_TRACK
+      // case VK_MEDIA_PREV_TRACK
+      // case VK_MEDIA_STOP: in GTA some French letter?
+      // case VK_MEDIA_PLAY_PAUSE
+      // case VK_LAUNCH_MAIL
+      // case VK_LAUNCH_MEDIA_SELECT
+      // case VK_LAUNCH_APP1
+      // case VK_LAUNCH_APP2
+      case VK_OEM_1:
+        name = ",";
+        break;
+      case VK_OEM_PLUS:
+        name = "=";
+        break;
+      case VK_OEM_COMMA:
+        name = ",";
+        break;
+      case VK_OEM_MINUS:
+        name = "-";
+        break;
+      case VK_OEM_PERIOD:
+        name = ".";
+        break;
+      case VK_OEM_2:
+        name = "/";
+        break;
+      case VK_OEM_3:
+        name = "`";
+        break;
+      // case VK_GAMEPAD_A
+      // case VK_GAMEPAD_B
+      // case VK_GAMEPAD_X
+      // case VK_GAMEPAD_Y
+      // case VK_GAMEPAD_RIGHT_SHOULDER
+      // case VK_GAMEPAD_LEFT_SHOULDER
+      // case VK_GAMEPAD_LEFT_TRIGGER
+      // case VK_GAMEPAD_RIGHT_TRIGGER
+      // case VK_GAMEPAD_DPAD_UP
+      // case VK_GAMEPAD_DPAD_DOWN
+      // case VK_GAMEPAD_DPAD_LEFT
+      // case VK_GAMEPAD_DPAD_RIGHT
+      // case VK_GAMEPAD_MENU
+      // case VK_GAMEPAD_VIEW
+      // case VK_GAMEPAD_LEFT_THUMBSTICK_BUTTON
+      // case VK_GAMEPAD_RIGHT_THUMBSTICK_BUTTON
+      // case VK_GAMEPAD_LEFT_THUMBSTICK_UP
+      // case VK_GAMEPAD_LEFT_THUMBSTICK_DOWN
+      // case VK_GAMEPAD_LEFT_THUMBSTICK_RIGHT
+      // case VK_GAMEPAD_LEFT_THUMBSTICK_LEFT
+      // case VK_GAMEPAD_RIGHT_THUMBSTICK_UP
+      // case VK_GAMEPAD_RIGHT_THUMBSTICK_DOWN
+      // case VK_GAMEPAD_RIGHT_THUMBSTICK_RIGHT
+      // case VK_GAMEPAD_RIGHT_THUMBSTICK_LEFT
+      case VK_OEM_4:
+        name = "[";
+        break;
+      case VK_OEM_5:
+        name = "\\";
+        break;
+      case VK_OEM_6:
+        name = "]";
+        break;
+      case VK_OEM_7:
+        name = "'";
+        break;
+        // case VK_OEM_8
+        // case VK_OEM_AX
+        // case VK_OEM_102
+        // case VK_ICO_HELP
+        // case VK_ICO_00
+        // case VK_ICO_CLEAR
+        // case VK_PACKET
+        // case VK_OEM_RESET
+        // case VK_OEM_JUMP
+        // case VK_OEM_PA1
+        // case VK_OEM_PA2
+        // case VK_OEM_PA3
+        // case VK_OEM_WSCTRL
+        // case VK_OEM_CUSEL
+        // case VK_OEM_ATTN
+        // case VK_OEM_FINISH
+        // case VK_OEM_COPY
+        // case VK_OEM_AUTO
+        // case VK_OEM_ENLW
+        // case VK_OEM_BACKTAB
+        // case VK_OEM_BACKTAB
+        // case VK_ATTN
+        // case VK_CRSEL
+        // case VK_EXSEL
+        // case VK_EREOF
+        // case VK_PLAY
+        // case VK_ZOOM
+        // case VK_NONAME
+        // case VK_PA1
+        // case VK_OEM_CLEAR
+      }
+    }
+
+    if (name == nullptr) {
+      OPCODE_SKIP_PARAMS(1);
+      OPCODE_CONDITION_RESULT(false);
+      return OR_CONTINUE;
+    }
+
+    OPCODE_WRITE_PARAM_STRING(name);
+    OPCODE_CONDITION_RESULT(true);
+    return OR_CONTINUE;
+  }
 
 } g_instance;
-

--- a/cleo_plugins/Math/Math.cpp
+++ b/cleo_plugins/Math/Math.cpp
@@ -1,6 +1,6 @@
-#include "plugin.h"
 #include "CLEO.h"
 #include "CLEO_Utils.h"
+#include "plugin.h"
 
 #include <random>
 
@@ -8,528 +8,518 @@ using namespace CLEO;
 using namespace plugin;
 using namespace std;
 
-class Math
-{
+class Math {
 public:
-    random_device randomDevice;
-    mt19937 randomGenerator;
+  random_device randomDevice;
+  mt19937 randomGenerator;
 
-    Math() :
-        randomDevice(),
-        randomGenerator(randomDevice())
-    {
-        if (!PluginCheckCleoVersion()) return;
+  Math() : randomDevice(), randomGenerator(randomDevice()) {
+    if (!PluginCheckCleoVersion())
+      return;
 
-        // register opcodes
-        CLEO_RegisterOpcode(0x0A8E, opcode_0A8E); // x = a + b (int)
-        CLEO_RegisterOpcode(0x0A8F, opcode_0A8F); // x = a - b (int)
-        CLEO_RegisterOpcode(0x0A90, opcode_0A90); // x = a * b (int)
-        CLEO_RegisterOpcode(0x0A91, opcode_0A91); // x = a / b (int)
+    // register opcodes
+    CLEO_RegisterOpcode(0x0A8E, opcode_0A8E); // x = a + b (int)
+    CLEO_RegisterOpcode(0x0A8F, opcode_0A8F); // x = a - b (int)
+    CLEO_RegisterOpcode(0x0A90, opcode_0A90); // x = a * b (int)
+    CLEO_RegisterOpcode(0x0A91, opcode_0A91); // x = a / b (int)
 
-        CLEO_RegisterOpcode(0x0AEE, opcode_0AEE); // pow
-        CLEO_RegisterOpcode(0x0AEF, opcode_0AEF); // log
+    CLEO_RegisterOpcode(0x0AEE, opcode_0AEE); // pow
+    CLEO_RegisterOpcode(0x0AEF, opcode_0AEF); // log
 
-        CLEO_RegisterOpcode(0x0B10, Script_IntOp_AND);
-        CLEO_RegisterOpcode(0x0B11, Script_IntOp_OR);
-        CLEO_RegisterOpcode(0x0B12, Script_IntOp_XOR);
-        CLEO_RegisterOpcode(0x0B13, Script_IntOp_NOT);
-        CLEO_RegisterOpcode(0x0B14, Script_IntOp_MOD);
-        CLEO_RegisterOpcode(0x0B15, Script_IntOp_SHR);
-        CLEO_RegisterOpcode(0x0B16, Script_IntOp_SHL);
-        CLEO_RegisterOpcode(0x0B17, Scr_IntOp_AND);
-        CLEO_RegisterOpcode(0x0B18, Scr_IntOp_OR);
-        CLEO_RegisterOpcode(0x0B19, Scr_IntOp_XOR);
-        CLEO_RegisterOpcode(0x0B1A, Scr_IntOp_NOT);
-        CLEO_RegisterOpcode(0x0B1B, Scr_IntOp_MOD);
-        CLEO_RegisterOpcode(0x0B1C, Scr_IntOp_SHR);
-        CLEO_RegisterOpcode(0x0B1D, Scr_IntOp_SHL);
-        CLEO_RegisterOpcode(0x0B1E, Sign_Extend);
+    CLEO_RegisterOpcode(0x0B10, Script_IntOp_AND);
+    CLEO_RegisterOpcode(0x0B11, Script_IntOp_OR);
+    CLEO_RegisterOpcode(0x0B12, Script_IntOp_XOR);
+    CLEO_RegisterOpcode(0x0B13, Script_IntOp_NOT);
+    CLEO_RegisterOpcode(0x0B14, Script_IntOp_MOD);
+    CLEO_RegisterOpcode(0x0B15, Script_IntOp_SHR);
+    CLEO_RegisterOpcode(0x0B16, Script_IntOp_SHL);
+    CLEO_RegisterOpcode(0x0B17, Scr_IntOp_AND);
+    CLEO_RegisterOpcode(0x0B18, Scr_IntOp_OR);
+    CLEO_RegisterOpcode(0x0B19, Scr_IntOp_XOR);
+    CLEO_RegisterOpcode(0x0B1A, Scr_IntOp_NOT);
+    CLEO_RegisterOpcode(0x0B1B, Scr_IntOp_MOD);
+    CLEO_RegisterOpcode(0x0B1C, Scr_IntOp_SHR);
+    CLEO_RegisterOpcode(0x0B1D, Scr_IntOp_SHL);
+    CLEO_RegisterOpcode(0x0B1E, Sign_Extend);
 
-        CLEO_RegisterOpcode(0x2700, opcode_2700); // is_bit_set
-        CLEO_RegisterOpcode(0x2701, opcode_2701); // set_bit
-        CLEO_RegisterOpcode(0x2702, opcode_2702); // clear_bit
-        CLEO_RegisterOpcode(0x2703, opcode_2703); // toggle_bit
-        CLEO_RegisterOpcode(0x2704, opcode_2704); // is_truthy
-        CLEO_RegisterOpcode(0x2705, opcode_2705); // pick_random_int
-        CLEO_RegisterOpcode(0x2706, opcode_2706); // pick_random_float
-        CLEO_RegisterOpcode(0x2707, opcode_2707); // pick_random_text
-        CLEO_RegisterOpcode(0x2708, opcode_2708); // random_chance
+    CLEO_RegisterOpcode(0x2700, opcode_2700); // is_bit_set
+    CLEO_RegisterOpcode(0x2701, opcode_2701); // set_bit
+    CLEO_RegisterOpcode(0x2702, opcode_2702); // clear_bit
+    CLEO_RegisterOpcode(0x2703, opcode_2703); // toggle_bit
+    CLEO_RegisterOpcode(0x2704, opcode_2704); // is_truthy
+    CLEO_RegisterOpcode(0x2705, opcode_2705); // pick_random_int
+    CLEO_RegisterOpcode(0x2706, opcode_2706); // pick_random_float
+    CLEO_RegisterOpcode(0x2707, opcode_2707); // pick_random_text
+    CLEO_RegisterOpcode(0x2708, opcode_2708); // random_chance
+  }
+
+  // 0A8E=3,%3d% = %1d% + %2d% ; int
+  static OpcodeResult __stdcall opcode_0A8E(CRunningScript *thread) {
+    auto a = OPCODE_READ_PARAM_INT();
+    auto b = OPCODE_READ_PARAM_INT();
+
+    auto result = a + b;
+
+    OPCODE_WRITE_PARAM_INT(result);
+    return OR_CONTINUE;
+  }
+
+  // 0A8F=3,%3d% = %1d% - %2d% ; int
+  static OpcodeResult __stdcall opcode_0A8F(CRunningScript *thread) {
+    auto a = OPCODE_READ_PARAM_INT();
+    auto b = OPCODE_READ_PARAM_INT();
+
+    auto result = a - b;
+
+    OPCODE_WRITE_PARAM_INT(result);
+    return OR_CONTINUE;
+  }
+
+  // 0A90=3,%3d% = %1d% * %2d% ; int
+  static OpcodeResult __stdcall opcode_0A90(CRunningScript *thread) {
+    auto a = OPCODE_READ_PARAM_INT();
+    auto b = OPCODE_READ_PARAM_INT();
+
+    auto result = a * b;
+
+    OPCODE_WRITE_PARAM_INT(result);
+    return OR_CONTINUE;
+  }
+
+  // 0A91=3,%3d% = %1d% / %2d% ; int
+  static OpcodeResult __stdcall opcode_0A91(CRunningScript *thread) {
+    auto a = OPCODE_READ_PARAM_INT();
+    auto b = OPCODE_READ_PARAM_INT();
+
+    auto result = a / b;
+
+    OPCODE_WRITE_PARAM_INT(result);
+    return OR_CONTINUE;
+  }
+
+  // 0AEE=3,%3d% = %1d% exp %2d% // all floats
+  static OpcodeResult __stdcall opcode_0AEE(CRunningScript *thread) {
+    auto base = OPCODE_READ_PARAM_FLOAT();
+    auto exponent = OPCODE_READ_PARAM_FLOAT();
+
+    auto result = (float)pow(base, exponent);
+
+    OPCODE_WRITE_PARAM_FLOAT(result);
+    return OR_CONTINUE;
+  }
+
+  // 0AEF=3,%3d% = log %1d% base %2d% // all floats
+  static OpcodeResult __stdcall opcode_0AEF(CRunningScript *thread) {
+    auto argument = OPCODE_READ_PARAM_FLOAT();
+    auto base = OPCODE_READ_PARAM_FLOAT();
+
+    auto exponent = log(argument) / log(base);
+
+    OPCODE_WRITE_PARAM_FLOAT(exponent);
+    return OR_CONTINUE;
+  }
+
+  static OpcodeResult __stdcall Script_IntOp_AND(CRunningScript *thread)
+  /****************************************************************
+  Opcode Format
+  0B10=3,%3d% = %1d% AND %2d%
+  ****************************************************************/
+  {
+    auto a = OPCODE_READ_PARAM_INT();
+    auto b = OPCODE_READ_PARAM_INT();
+
+    auto result = a & b;
+
+    OPCODE_WRITE_PARAM_INT(result);
+    return OR_CONTINUE;
+  }
+
+  static OpcodeResult __stdcall Script_IntOp_OR(CRunningScript *thread)
+  /****************************************************************
+  Opcode Format
+  0B11=3,%3d% = %1d% OR %2d%
+  ****************************************************************/
+  {
+    auto a = OPCODE_READ_PARAM_INT();
+    auto b = OPCODE_READ_PARAM_INT();
+
+    auto result = a | b;
+
+    OPCODE_WRITE_PARAM_INT(result);
+    return OR_CONTINUE;
+  }
+
+  static OpcodeResult __stdcall Script_IntOp_XOR(CRunningScript *thread)
+  /****************************************************************
+  Opcode Format
+  0B12=3,%3d% = %1d% XOR %2d%
+  ****************************************************************/
+  {
+    auto a = OPCODE_READ_PARAM_INT();
+    auto b = OPCODE_READ_PARAM_INT();
+
+    auto result = a ^ b;
+
+    OPCODE_WRITE_PARAM_INT(result);
+    return OR_CONTINUE;
+  }
+
+  static OpcodeResult __stdcall Script_IntOp_NOT(CRunningScript *thread)
+  /****************************************************************
+  Opcode Format
+  0B13=2,%2d% = NOT %1d%
+  ****************************************************************/
+  {
+    auto a = OPCODE_READ_PARAM_INT();
+
+    OPCODE_WRITE_PARAM_INT(~a);
+    return OR_CONTINUE;
+  }
+
+  static OpcodeResult __stdcall Script_IntOp_MOD(CRunningScript *thread)
+  /****************************************************************
+  Opcode Format
+  0B14=3,%3d% = %1d% MOD %2d%
+  ****************************************************************/
+  {
+    auto a = OPCODE_READ_PARAM_INT();
+    auto b = OPCODE_READ_PARAM_INT();
+
+    auto result = a % b;
+
+    OPCODE_WRITE_PARAM_INT(result);
+    return OR_CONTINUE;
+  }
+
+  static OpcodeResult __stdcall Script_IntOp_SHR(CRunningScript *thread)
+  /****************************************************************
+  Opcode Format
+  0B15=3,%3d% = %1d% SHR %2d%
+  ****************************************************************/
+  {
+    auto a = OPCODE_READ_PARAM_INT();
+    auto b = OPCODE_READ_PARAM_INT();
+
+    auto result = a >> b;
+
+    OPCODE_WRITE_PARAM_INT(result);
+    return OR_CONTINUE;
+  }
+
+  static OpcodeResult __stdcall Script_IntOp_SHL(CRunningScript *thread)
+  /****************************************************************
+  Opcode Format
+  0B16=3,%3d% = %1d% SHL %2d%
+  ****************************************************************/
+  {
+    auto a = OPCODE_READ_PARAM_INT();
+    auto b = OPCODE_READ_PARAM_INT();
+
+    auto result = a << b;
+
+    OPCODE_WRITE_PARAM_INT(result);
+    return OR_CONTINUE;
+  }
+
+  /****************************************************************
+  Now do them as real operators...
+  *****************************************************************/
+
+  static OpcodeResult __stdcall Scr_IntOp_AND(CRunningScript *thread)
+  /****************************************************************
+  Opcode Format
+  0B17=2,%1d% &= %2d%
+  ****************************************************************/
+  {
+    auto operand = OPCODE_READ_PARAM_OUTPUT_VAR_INT();
+    auto value = OPCODE_READ_PARAM_INT();
+
+    *operand &= value;
+    return OR_CONTINUE;
+  }
+
+  static OpcodeResult __stdcall Scr_IntOp_OR(CRunningScript *thread)
+  /****************************************************************
+  Opcode Format
+  0B18=2,%1d% |= %2d%
+  ****************************************************************/
+  {
+    auto operand = OPCODE_READ_PARAM_OUTPUT_VAR_INT();
+    auto value = OPCODE_READ_PARAM_INT();
+
+    *operand |= value;
+    return OR_CONTINUE;
+  }
+
+  static OpcodeResult __stdcall Scr_IntOp_XOR(CRunningScript *thread)
+  /****************************************************************
+  Opcode Format
+  0B19=2,%1d% ^= %2d%
+  ****************************************************************/
+  {
+    auto operand = OPCODE_READ_PARAM_OUTPUT_VAR_INT();
+    auto value = OPCODE_READ_PARAM_INT();
+
+    *operand ^= value;
+    return OR_CONTINUE;
+  }
+
+  static OpcodeResult __stdcall Scr_IntOp_NOT(CRunningScript *thread)
+  /****************************************************************
+  Opcode Format
+  0B1A=1,~%1d%
+  ****************************************************************/
+  {
+    auto operand = OPCODE_READ_PARAM_OUTPUT_VAR_INT();
+
+    *operand = ~*operand;
+    return OR_CONTINUE;
+  }
+
+  static OpcodeResult __stdcall Scr_IntOp_MOD(CRunningScript *thread)
+  /****************************************************************
+  Opcode Format
+  0B1B=2,%1d% %= %2d%
+  ****************************************************************/
+  {
+    auto operand = OPCODE_READ_PARAM_OUTPUT_VAR_INT();
+    auto value = OPCODE_READ_PARAM_INT();
+
+    *operand %= value;
+    return OR_CONTINUE;
+  }
+
+  static OpcodeResult __stdcall Scr_IntOp_SHR(CRunningScript *thread)
+  /****************************************************************
+  Opcode Format
+  0B1C=2,%1d% >>= %2d%
+  ****************************************************************/
+  {
+    auto operand = OPCODE_READ_PARAM_OUTPUT_VAR_INT();
+    auto value = OPCODE_READ_PARAM_INT();
+
+    *operand >>= value;
+    return OR_CONTINUE;
+  }
+
+  static OpcodeResult __stdcall Scr_IntOp_SHL(CRunningScript *thread)
+  /****************************************************************
+  Opcode Format
+  0B1D=2,%1d% <<= %2d%
+  ****************************************************************/
+  {
+    auto operand = OPCODE_READ_PARAM_OUTPUT_VAR_INT();
+    auto value = OPCODE_READ_PARAM_INT();
+
+    *operand <<= value;
+    return OR_CONTINUE;
+  }
+
+  static OpcodeResult __stdcall Sign_Extend(CRunningScript *thread)
+  /****************************************************************
+  Opcode Format
+  0B1E=2,sign_extend %1d% size %2d%
+  ****************************************************************/
+  {
+    auto operand = OPCODE_READ_PARAM_OUTPUT_VAR_INT();
+    auto size = OPCODE_READ_PARAM_INT();
+
+    if (size <= 0 || size > 4) {
+      SHOW_ERROR("Invalid '%d' size argument in script %s\nScript suspended.",
+                 size, ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
     }
 
-    //0A8E=3,%3d% = %1d% + %2d% ; int
-    static OpcodeResult __stdcall opcode_0A8E(CRunningScript* thread)
-    {
-        auto a = OPCODE_READ_PARAM_INT();
-        auto b = OPCODE_READ_PARAM_INT();
+    size_t offset = size * 8 - 1; // bit offset of top most bit in source value
+    bool signBit = *operand & (1 << offset);
 
-        auto result = a + b;
-
-        OPCODE_WRITE_PARAM_INT(result);
-        return OR_CONTINUE;
+    if (signBit) {
+      *operand |= 0xFFFFFFFF << offset; // set all upper bits
     }
 
-    //0A8F=3,%3d% = %1d% - %2d% ; int
-    static OpcodeResult __stdcall opcode_0A8F(CRunningScript* thread)
-    {
-        auto a = OPCODE_READ_PARAM_INT();
-        auto b = OPCODE_READ_PARAM_INT();
+    return OR_CONTINUE;
+  }
 
-        auto result = a - b;
+  // 2700=2,  is_bit_set value %1d% bit_index %2d%
+  static OpcodeResult __stdcall opcode_2700(CRunningScript *thread) {
+    auto value = OPCODE_READ_PARAM_UINT();
+    auto bitIndex = OPCODE_READ_PARAM_INT();
 
-        OPCODE_WRITE_PARAM_INT(result);
-        return OR_CONTINUE;
+    if (bitIndex < 0 || bitIndex > 31) {
+      SHOW_ERROR(
+          "Invalid '%d' bit index argument in script %s\nScript suspended.",
+          bitIndex, ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
     }
 
-    //0A90=3,%3d% = %1d% * %2d% ; int
-    static OpcodeResult __stdcall opcode_0A90(CRunningScript* thread)
-    {
-        auto a = OPCODE_READ_PARAM_INT();
-        auto b = OPCODE_READ_PARAM_INT();
+    bool result = (value >> bitIndex) & 1;
 
-        auto result = a * b;
+    OPCODE_CONDITION_RESULT(result);
+    return OR_CONTINUE;
+  }
 
-        OPCODE_WRITE_PARAM_INT(result);
-        return OR_CONTINUE;
+  // 2701=2,set_bit value %1d% bit_index %2d%
+  static OpcodeResult __stdcall opcode_2701(CRunningScript *thread) {
+    auto value = OPCODE_READ_PARAM_OUTPUT_VAR_INT();
+    auto bitIndex = OPCODE_READ_PARAM_INT();
+
+    if (bitIndex < 0 || bitIndex > 31) {
+      SHOW_ERROR(
+          "Invalid '%d' bit index argument in script %s\nScript suspended.",
+          bitIndex, ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
     }
 
-    //0A91=3,%3d% = %1d% / %2d% ; int
-    static OpcodeResult __stdcall opcode_0A91(CRunningScript* thread)
-    {
-        auto a = OPCODE_READ_PARAM_INT();
-        auto b = OPCODE_READ_PARAM_INT();
+    *value |= 1 << bitIndex;
 
-        auto result = a / b;
+    return OR_CONTINUE;
+  }
 
-        OPCODE_WRITE_PARAM_INT(result);
-        return OR_CONTINUE;
+  // 2702=2,clear_bit value %1d% bit_index %2d%
+  static OpcodeResult __stdcall opcode_2702(CRunningScript *thread) {
+    auto value = OPCODE_READ_PARAM_OUTPUT_VAR_INT();
+    auto bitIndex = OPCODE_READ_PARAM_INT();
+
+    if (bitIndex < 0 || bitIndex > 31) {
+      SHOW_ERROR(
+          "Invalid '%d' bit index argument in script %s\nScript suspended.",
+          bitIndex, ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
     }
 
-    //0AEE=3,%3d% = %1d% exp %2d% // all floats
-    static OpcodeResult __stdcall opcode_0AEE(CRunningScript* thread)
-    {
-        auto base = OPCODE_READ_PARAM_FLOAT();
-        auto exponent = OPCODE_READ_PARAM_FLOAT();
+    *value &= ~(1 << bitIndex);
 
-        auto result = (float)pow(base, exponent);
+    return OR_CONTINUE;
+  }
 
-        OPCODE_WRITE_PARAM_FLOAT(result);
-        return OR_CONTINUE;
+  // 2703=3,toggle_bit value %1d% bit_index %2d% state %3d%
+  static OpcodeResult __stdcall opcode_2703(CRunningScript *thread) {
+    auto value = OPCODE_READ_PARAM_OUTPUT_VAR_INT();
+    auto bitIndex = OPCODE_READ_PARAM_INT();
+    auto state = OPCODE_READ_PARAM_BOOL();
+
+    if (bitIndex < 0 || bitIndex > 31) {
+      SHOW_ERROR(
+          "Invalid '%d' bit index argument in script %s\nScript suspended.",
+          bitIndex, ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
     }
 
-    //0AEF=3,%3d% = log %1d% base %2d% // all floats
-    static OpcodeResult __stdcall opcode_0AEF(CRunningScript* thread)
-    {
-        auto argument = OPCODE_READ_PARAM_FLOAT();
-        auto base = OPCODE_READ_PARAM_FLOAT();
+    DWORD flag = 1 << bitIndex;
+    if (state)
+      *value |= flag;
+    else
+      *value &= ~flag;
 
-        auto exponent = log(argument) / log(base);
+    return OR_CONTINUE;
+  }
 
-        OPCODE_WRITE_PARAM_FLOAT(exponent);
-        return OR_CONTINUE;
+  // 2704=1,  is_truthy value %1d%
+  static OpcodeResult __stdcall opcode_2704(CRunningScript *thread) {
+    auto paramType = OPCODE_PEEK_PARAM_TYPE();
+
+    if (IsImmString(paramType) || IsVarString(paramType)) {
+      OPCODE_READ_PARAM_STRING_LEN(text, 1); // one character is all we need
+      OPCODE_CONDITION_RESULT(text[0] != '\0');
+      return OR_CONTINUE;
     }
 
-    static OpcodeResult __stdcall Script_IntOp_AND(CRunningScript* thread)
-        /****************************************************************
-        Opcode Format
-        0B10=3,%3d% = %1d% AND %2d%
-        ****************************************************************/
+    auto value = OPCODE_READ_PARAM_ANY32();
+    OPCODE_CONDITION_RESULT(value.dwParam != 0);
+    return OR_CONTINUE;
+  }
+
+  // 2705=-1,pick_random_int values %d% store_to %d%
+  static OpcodeResult __stdcall opcode_2705(CRunningScript *thread) {
+    auto valueCount = CLEO_GetVarArgCount(thread);
+
+    if (valueCount < 2) // value + result
     {
-        auto a = OPCODE_READ_PARAM_INT();
-        auto b = OPCODE_READ_PARAM_INT();
-
-        auto result = a & b;
-
-        OPCODE_WRITE_PARAM_INT(result);
-        return OR_CONTINUE;
+      SHOW_ERROR(
+          "Insufficient number of arguments in script %s\nScript suspended.",
+          CLEO::ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
     }
+    valueCount -= 1; // output param
 
-    static OpcodeResult __stdcall Script_IntOp_OR(CRunningScript* thread)
-        /****************************************************************
-        Opcode Format
-        0B11=3,%3d% = %1d% OR %2d%
-        ****************************************************************/
+    uniform_int_distribution<size_t> dist(0, valueCount - 1); // 0 to last index
+    auto idx = dist(Instance.randomGenerator);
+
+    // read n-th param
+    OPCODE_SKIP_PARAMS(idx);
+    auto value = OPCODE_READ_PARAM_INT();
+
+    OPCODE_SKIP_PARAMS(valueCount - (idx + 1)); // seek to output param
+    OPCODE_WRITE_PARAM_INT(value);
+
+    CLEO_SkipUnusedVarArgs(thread);
+    return OR_CONTINUE;
+  }
+
+  // 2706=-1,pick_random_float values %d% store_to %d%
+  static OpcodeResult __stdcall opcode_2706(CRunningScript *thread) {
+    auto valueCount = CLEO_GetVarArgCount(thread);
+
+    if (valueCount < 2) // value + result
     {
-        auto a = OPCODE_READ_PARAM_INT();
-        auto b = OPCODE_READ_PARAM_INT();
-
-        auto result = a | b;
-
-        OPCODE_WRITE_PARAM_INT(result);
-        return OR_CONTINUE;
+      SHOW_ERROR(
+          "Insufficient number of arguments in script %s\nScript suspended.",
+          CLEO::ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
     }
+    valueCount -= 1; // output param
 
-    static OpcodeResult __stdcall Script_IntOp_XOR(CRunningScript* thread)
-        /****************************************************************
-        Opcode Format
-        0B12=3,%3d% = %1d% XOR %2d%
-        ****************************************************************/
+    uniform_int_distribution<size_t> dist(0, valueCount - 1); // 0 to last index
+    auto idx = dist(Instance.randomGenerator);
+
+    // read n-th param
+    OPCODE_SKIP_PARAMS(idx);
+    auto value = OPCODE_READ_PARAM_FLOAT();
+
+    OPCODE_SKIP_PARAMS(valueCount - (idx + 1)); // seek to output param
+    OPCODE_WRITE_PARAM_FLOAT(value);
+
+    CLEO_SkipUnusedVarArgs(thread);
+    return OR_CONTINUE;
+  }
+
+  // 2707=-1,pick_random_text values %d% store_to %d%
+  static OpcodeResult __stdcall opcode_2707(CRunningScript *thread) {
+    auto valueCount = CLEO_GetVarArgCount(thread);
+
+    if (valueCount < 2) // value + result
     {
-        auto a = OPCODE_READ_PARAM_INT();
-        auto b = OPCODE_READ_PARAM_INT();
-
-        auto result = a ^ b;
-
-        OPCODE_WRITE_PARAM_INT(result);
-        return OR_CONTINUE;
+      SHOW_ERROR(
+          "Insufficient number of arguments in script %s\nScript suspended.",
+          CLEO::ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
     }
+    valueCount -= 1; // output param
 
-    static OpcodeResult __stdcall Script_IntOp_NOT(CRunningScript* thread)
-        /****************************************************************
-        Opcode Format
-        0B13=2,%2d% = NOT %1d%
-        ****************************************************************/
-    {
-        auto a = OPCODE_READ_PARAM_INT();
+    uniform_int_distribution<size_t> dist(0, valueCount - 1); // 0 to last index
+    auto idx = dist(Instance.randomGenerator);
 
-        OPCODE_WRITE_PARAM_INT(~a);
-        return OR_CONTINUE;
-    }
+    // read n-th param
+    OPCODE_SKIP_PARAMS(idx);
+    OPCODE_READ_PARAM_STRING(value);
 
-    static OpcodeResult __stdcall Script_IntOp_MOD(CRunningScript* thread)
-        /****************************************************************
-        Opcode Format
-        0B14=3,%3d% = %1d% MOD %2d%
-        ****************************************************************/
-    {
-        auto a = OPCODE_READ_PARAM_INT();
-        auto b = OPCODE_READ_PARAM_INT();
+    OPCODE_SKIP_PARAMS(valueCount - (idx + 1)); // seek to output param
+    OPCODE_WRITE_PARAM_STRING(value);
 
-        auto result = a % b;
+    CLEO_SkipUnusedVarArgs(thread);
+    return OR_CONTINUE;
+  }
 
-        OPCODE_WRITE_PARAM_INT(result);
-        return OR_CONTINUE;
-    }
+  // 2708=1,random_chance %1d%
+  static OpcodeResult __stdcall opcode_2708(CRunningScript *thread) {
+    auto chance = OPCODE_READ_PARAM_FLOAT();
 
-    static  OpcodeResult __stdcall Script_IntOp_SHR(CRunningScript* thread)
-        /****************************************************************
-        Opcode Format
-        0B15=3,%3d% = %1d% SHR %2d%
-        ****************************************************************/
-    {
-        auto a = OPCODE_READ_PARAM_INT();
-        auto b = OPCODE_READ_PARAM_INT();
+    uniform_real_distribution<float> dist(0.0f, 100.0f); // 0.0 to 99.99(9)
+    auto random = dist(Instance.randomGenerator);
 
-        auto result = a >> b;
+    auto result = random < chance;
 
-        OPCODE_WRITE_PARAM_INT(result);
-        return OR_CONTINUE;
-    }
-
-    static OpcodeResult __stdcall Script_IntOp_SHL(CRunningScript* thread)
-        /****************************************************************
-        Opcode Format
-        0B16=3,%3d% = %1d% SHL %2d%
-        ****************************************************************/
-    {
-        auto a = OPCODE_READ_PARAM_INT();
-        auto b = OPCODE_READ_PARAM_INT();
-
-        auto result = a << b;
-
-        OPCODE_WRITE_PARAM_INT(result);
-        return OR_CONTINUE;
-    }
-
-    /****************************************************************
-    Now do them as real operators...
-    *****************************************************************/
-
-    static OpcodeResult __stdcall Scr_IntOp_AND(CRunningScript* thread)
-        /****************************************************************
-        Opcode Format
-        0B17=2,%1d% &= %2d%
-        ****************************************************************/
-    {
-        auto operand = OPCODE_READ_PARAM_OUTPUT_VAR_INT();
-        auto value = OPCODE_READ_PARAM_INT();
-
-        *operand &= value;
-        return OR_CONTINUE;
-    }
-
-    static OpcodeResult __stdcall Scr_IntOp_OR(CRunningScript* thread)
-        /****************************************************************
-        Opcode Format
-        0B18=2,%1d% |= %2d%
-        ****************************************************************/
-    {
-        auto operand = OPCODE_READ_PARAM_OUTPUT_VAR_INT();
-        auto value = OPCODE_READ_PARAM_INT();
-
-        *operand |= value;
-        return OR_CONTINUE;
-    }
-
-    static OpcodeResult __stdcall Scr_IntOp_XOR(CRunningScript* thread)
-        /****************************************************************
-        Opcode Format
-        0B19=2,%1d% ^= %2d%
-        ****************************************************************/
-    {
-        auto operand = OPCODE_READ_PARAM_OUTPUT_VAR_INT();
-        auto value = OPCODE_READ_PARAM_INT();
-
-        *operand ^= value;
-        return OR_CONTINUE;
-    }
-
-    static OpcodeResult __stdcall Scr_IntOp_NOT(CRunningScript* thread)
-        /****************************************************************
-        Opcode Format
-        0B1A=1,~%1d%
-        ****************************************************************/
-    {
-        auto operand = OPCODE_READ_PARAM_OUTPUT_VAR_INT();
-
-        *operand = ~*operand;
-        return OR_CONTINUE;
-    }
-
-    static OpcodeResult __stdcall Scr_IntOp_MOD(CRunningScript* thread)
-        /****************************************************************
-        Opcode Format
-        0B1B=2,%1d% %= %2d%
-        ****************************************************************/
-    {
-        auto operand = OPCODE_READ_PARAM_OUTPUT_VAR_INT();
-        auto value = OPCODE_READ_PARAM_INT();
-
-        *operand %= value;
-        return OR_CONTINUE;
-    }
-
-    static OpcodeResult __stdcall Scr_IntOp_SHR(CRunningScript* thread)
-        /****************************************************************
-        Opcode Format
-        0B1C=2,%1d% >>= %2d%
-        ****************************************************************/
-    {
-        auto operand = OPCODE_READ_PARAM_OUTPUT_VAR_INT();
-        auto value = OPCODE_READ_PARAM_INT();
-
-        *operand >>= value;
-        return OR_CONTINUE;
-    }
-
-    static OpcodeResult __stdcall Scr_IntOp_SHL(CRunningScript* thread)
-        /****************************************************************
-        Opcode Format
-        0B1D=2,%1d% <<= %2d%
-        ****************************************************************/
-    {
-        auto operand = OPCODE_READ_PARAM_OUTPUT_VAR_INT();
-        auto value = OPCODE_READ_PARAM_INT();
-
-        *operand <<= value;
-        return OR_CONTINUE;
-    }
-
-    static OpcodeResult __stdcall Sign_Extend(CRunningScript* thread)
-        /****************************************************************
-        Opcode Format
-        0B1E=2,sign_extend %1d% size %2d%
-        ****************************************************************/
-    {
-        auto operand = OPCODE_READ_PARAM_OUTPUT_VAR_INT();
-        auto size = OPCODE_READ_PARAM_INT();
-
-        if (size <= 0 || size > 4)
-        {
-            SHOW_ERROR("Invalid '%d' size argument in script %s\nScript suspended.", size, ScriptInfoStr(thread).c_str());
-            return thread->Suspend();
-        }
-
-        size_t offset = size * 8 - 1; // bit offset of top most bit in source value
-        bool signBit = *operand & (1 << offset);
-
-        if(signBit)
-        {
-            *operand |= 0xFFFFFFFF << offset; // set all upper bits
-        }
-        
-        return OR_CONTINUE;
-    }
-
-    //2700=2,  is_bit_set value %1d% bit_index %2d%
-    static OpcodeResult __stdcall opcode_2700(CRunningScript* thread)
-    {
-        auto value = OPCODE_READ_PARAM_UINT();
-        auto bitIndex = OPCODE_READ_PARAM_INT();
-
-        if (bitIndex < 0 || bitIndex > 31)
-        {
-            SHOW_ERROR("Invalid '%d' bit index argument in script %s\nScript suspended.", bitIndex, ScriptInfoStr(thread).c_str());
-            return thread->Suspend();
-        }
-
-        bool result = (value >> bitIndex) & 1;
-
-        OPCODE_CONDITION_RESULT(result);
-        return OR_CONTINUE;
-    }
-
-    //2701=2,set_bit value %1d% bit_index %2d%
-    static OpcodeResult __stdcall opcode_2701(CRunningScript* thread)
-    {
-        auto value = OPCODE_READ_PARAM_OUTPUT_VAR_INT();
-        auto bitIndex = OPCODE_READ_PARAM_INT();
-
-        if (bitIndex < 0 || bitIndex > 31)
-        {
-            SHOW_ERROR("Invalid '%d' bit index argument in script %s\nScript suspended.", bitIndex, ScriptInfoStr(thread).c_str());
-            return thread->Suspend();
-        }
-
-        *value |= 1 << bitIndex;
-
-        return OR_CONTINUE;
-    }
-
-    //2702=2,clear_bit value %1d% bit_index %2d%
-    static OpcodeResult __stdcall opcode_2702(CRunningScript* thread)
-    {
-        auto value = OPCODE_READ_PARAM_OUTPUT_VAR_INT();
-        auto bitIndex = OPCODE_READ_PARAM_INT();
-
-        if (bitIndex < 0 || bitIndex > 31)
-        {
-            SHOW_ERROR("Invalid '%d' bit index argument in script %s\nScript suspended.", bitIndex, ScriptInfoStr(thread).c_str());
-            return thread->Suspend();
-        }
-
-        *value &= ~(1 << bitIndex);
-
-        return OR_CONTINUE;
-    }
-
-    //2703=3,toggle_bit value %1d% bit_index %2d% state %3d%
-    static OpcodeResult __stdcall opcode_2703(CRunningScript* thread)
-    {
-        auto value = OPCODE_READ_PARAM_OUTPUT_VAR_INT();
-        auto bitIndex = OPCODE_READ_PARAM_INT();
-        auto state = OPCODE_READ_PARAM_BOOL();
-
-        if (bitIndex < 0 || bitIndex > 31)
-        {
-            SHOW_ERROR("Invalid '%d' bit index argument in script %s\nScript suspended.", bitIndex, ScriptInfoStr(thread).c_str());
-            return thread->Suspend();
-        }
-
-        DWORD flag = 1 << bitIndex;
-        if (state)
-            *value |= flag;
-        else
-            *value &= ~flag;
-
-        return OR_CONTINUE;
-    }
-
-    //2704=1,  is_truthy value %1d%
-    static OpcodeResult __stdcall opcode_2704(CRunningScript* thread)
-    {
-        auto paramType = OPCODE_PEEK_PARAM_TYPE();
-
-        if(IsImmString(paramType) || IsVarString(paramType))
-        {
-            OPCODE_READ_PARAM_STRING_LEN(text, 1); // one character is all we need
-            OPCODE_CONDITION_RESULT(text[0] != '\0');
-            return OR_CONTINUE;
-        }
-
-        auto value = OPCODE_READ_PARAM_ANY32();
-        OPCODE_CONDITION_RESULT(value.dwParam != 0);
-        return OR_CONTINUE;
-    }
-
-    //2705=-1,pick_random_int values %d% store_to %d%
-    static OpcodeResult __stdcall opcode_2705(CRunningScript* thread)
-    {
-        auto valueCount = CLEO_GetVarArgCount(thread);
-
-        if (valueCount < 2) // value + result
-        {
-            SHOW_ERROR("Insufficient number of arguments in script %s\nScript suspended.", CLEO::ScriptInfoStr(thread).c_str());
-            return thread->Suspend();
-        }
-        valueCount -= 1; // output param
-
-        uniform_int_distribution<size_t> dist(0, valueCount - 1); // 0 to last index
-        auto idx = dist(Instance.randomGenerator);
-
-        // read n-th param
-        OPCODE_SKIP_PARAMS(idx);
-        auto value = OPCODE_READ_PARAM_INT();
-
-        OPCODE_SKIP_PARAMS(valueCount - (idx + 1)); // seek to output param
-        OPCODE_WRITE_PARAM_INT(value);
-
-        CLEO_SkipUnusedVarArgs(thread);
-        return OR_CONTINUE;
-    }
-
-    //2706=-1,pick_random_float values %d% store_to %d%
-    static OpcodeResult __stdcall opcode_2706(CRunningScript* thread)
-    {
-        auto valueCount = CLEO_GetVarArgCount(thread);
-
-        if (valueCount < 2) // value + result
-        {
-            SHOW_ERROR("Insufficient number of arguments in script %s\nScript suspended.", CLEO::ScriptInfoStr(thread).c_str());
-            return thread->Suspend();
-        }
-        valueCount -= 1; // output param
-
-        uniform_int_distribution<size_t> dist(0, valueCount - 1); // 0 to last index
-        auto idx = dist(Instance.randomGenerator);
-
-        // read n-th param
-        OPCODE_SKIP_PARAMS(idx);
-        auto value = OPCODE_READ_PARAM_FLOAT();
-
-        OPCODE_SKIP_PARAMS(valueCount - (idx + 1)); // seek to output param
-        OPCODE_WRITE_PARAM_FLOAT(value);
-
-        CLEO_SkipUnusedVarArgs(thread);
-        return OR_CONTINUE;
-    }
-
-    //2707=-1,pick_random_text values %d% store_to %d%
-    static OpcodeResult __stdcall opcode_2707(CRunningScript* thread)
-    {
-        auto valueCount = CLEO_GetVarArgCount(thread);
-
-        if (valueCount < 2) // value + result
-        {
-            SHOW_ERROR("Insufficient number of arguments in script %s\nScript suspended.", CLEO::ScriptInfoStr(thread).c_str());
-            return thread->Suspend();
-        }
-        valueCount -= 1; // output param
-
-        uniform_int_distribution<size_t> dist(0, valueCount - 1); // 0 to last index
-        auto idx = dist(Instance.randomGenerator);
-
-        // read n-th param
-        OPCODE_SKIP_PARAMS(idx);
-        OPCODE_READ_PARAM_STRING(value);
-
-        OPCODE_SKIP_PARAMS(valueCount - (idx + 1)); // seek to output param
-        OPCODE_WRITE_PARAM_STRING(value);
-
-        CLEO_SkipUnusedVarArgs(thread);
-        return OR_CONTINUE;
-    }
-
-    //2708=1,random_chance %1d%
-    static OpcodeResult __stdcall opcode_2708(CRunningScript* thread)
-    {
-        auto chance = OPCODE_READ_PARAM_FLOAT();
-
-        uniform_real_distribution<float> dist(0.0f, 100.0f); // 0.0 to 99.99(9)
-        auto random = dist(Instance.randomGenerator);
-
-        auto result = random < chance;
-
-        OPCODE_CONDITION_RESULT(result);
-        return OR_CONTINUE;
-    }
+    OPCODE_CONDITION_RESULT(result);
+    return OR_CONTINUE;
+  }
 } Instance;

--- a/cleo_plugins/MemoryOperations/MemoryOperations.cpp
+++ b/cleo_plugins/MemoryOperations/MemoryOperations.cpp
@@ -1,226 +1,237 @@
 #include "CLEO.h"
 #include "CLEO_Utils.h"
-#include "plugin.h"
 #include "CTheScripts.h"
+#include "plugin.h"
 #include <filesystem>
 #include <unordered_map>
 
 using namespace CLEO;
 using namespace plugin;
 
-class MemoryOperations 
-{
+class MemoryOperations {
 public:
-    std::unordered_map<void*, size_t> m_allocations;
-    std::unordered_map<HMODULE, size_t> m_libraries;
+  std::unordered_map<void *, size_t> m_allocations;
+  std::unordered_map<HMODULE, size_t> m_libraries;
 
-    // keep track of per-script memory allocations
-    struct AllocationInfo { int count; int size; };
-    std::unordered_map<CLEO::CRunningScript*, AllocationInfo> m_scriptAllocationsInfo;
-    int m_configLimitAllocationCount;
-    int m_configLimitAllocationSize;
+  // keep track of per-script memory allocations
+  struct AllocationInfo {
+    int count;
+    int size;
+  };
+  std::unordered_map<CLEO::CRunningScript *, AllocationInfo>
+      m_scriptAllocationsInfo;
+  int m_configLimitAllocationCount;
+  int m_configLimitAllocationSize;
 
-    MemoryOperations()
+  MemoryOperations() {
+    if (!PluginCheckCleoVersion())
+      return;
+
+    auto config = GetConfigFilename();
+    m_configLimitAllocationCount = GetPrivateProfileInt(
+        "Limits", "MemoryAllocations", 2000, config.c_str());
+    m_configLimitAllocationSize =
+        GetPrivateProfileInt("Limits", "MemoryTotalSize", 16, config.c_str()) *
+        1024 * 1024; // megabytes
+
+    // register opcodes
+    CLEO_RegisterOpcode(0x0459,
+                        opcode_0459); // terminate_all_scripts_with_this_name
+
+    CLEO_RegisterOpcode(0x0A8C, opcode_0A8C); // write_memory
+    CLEO_RegisterOpcode(0x0A8D, opcode_0A8D); // read_memory
+
+    CLEO_RegisterOpcode(0x0A96, opcode_0A96); // get_ped_pointer
+    CLEO_RegisterOpcode(0x0A97, opcode_0A97); // get_vehicle_pointer
+    CLEO_RegisterOpcode(0x0A98, opcode_0A98); // get_object_pointer
+
+    CLEO_RegisterOpcode(0x0A9F, opcode_0A9F); // get_object_pointer
+
+    CLEO_RegisterOpcode(0x0AA2, opcode_0AA2); // load_dynamic_library
+    CLEO_RegisterOpcode(0x0AA3, opcode_0AA3); // free_library
+    CLEO_RegisterOpcode(0x0AA4, opcode_0AA4); // get_dynamic_library_procedure
+    CLEO_RegisterOpcode(0x0AA5, opcode_0AA5); // call_function
+    CLEO_RegisterOpcode(0x0AA6, opcode_0AA6); // call_method
+    CLEO_RegisterOpcode(0x0AA7, opcode_0AA7); // call_function_return
+    CLEO_RegisterOpcode(0x0AA8, opcode_0AA8); // call_method_return
+
+    CLEO_RegisterOpcode(0x0AAA, opcode_0AAA); // get_script_struct_named
+
+    CLEO_RegisterOpcode(
+        0x0ABA, opcode_0ABA); // terminate_all_custom_scripts_with_this_name
+
+    CLEO_RegisterOpcode(0x0AC6, opcode_0AC6); // get_label_pointer
+    CLEO_RegisterOpcode(0x0AC7, opcode_0AC7); // get_var_pointer
+    CLEO_RegisterOpcode(0x0AC8, opcode_0AC8); // allocate_memory
+    CLEO_RegisterOpcode(0x0AC9, opcode_0AC9); // free_memory
+
+    CLEO_RegisterOpcode(0x0AE9, opcode_0AE9); // pop_float
+    CLEO_RegisterOpcode(0x0AEA, opcode_0AEA); // get_ped_ref
+    CLEO_RegisterOpcode(0x0AEB, opcode_0AEB); // get_vehicle_ref
+    CLEO_RegisterOpcode(0x0AEC, opcode_0AEC); // get_object_ref
+
+    CLEO_RegisterOpcode(0x2400, opcode_2400); // copy_memory
+    CLEO_RegisterOpcode(0x2401, opcode_2401); // read_memory_with_offset
+    CLEO_RegisterOpcode(0x2402, opcode_2402); // write_memory_with_offset
+    CLEO_RegisterOpcode(0x2403, opcode_2403); // forget_memory
+    CLEO_RegisterOpcode(0x2404, opcode_2404); // get_script_struct_just_created
+    CLEO_RegisterOpcode(0x2405, opcode_2405); // is_script_running
+    CLEO_RegisterOpcode(0x2406, opcode_2406); // get_script_struct_from_filename
+    CLEO_RegisterOpcode(0x2407, opcode_2407); // is_memory_equal
+    CLEO_RegisterOpcode(0x2408, opcode_2408); // terminate_script
+
+    // register event callbacks
+    CLEO_RegisterCallback(eCallbackId::GameEnd, OnGameEnd);
+  }
+
+  ~MemoryOperations() {
+    CLEO_UnregisterCallback(eCallbackId::GameEnd, OnGameEnd);
+  }
+
+  static void __stdcall OnGameEnd() {
+    // release memory allocations
+    TRACE("");
+    TRACE("Cleaning up %d allocated memory block(s):",
+          Instance.m_allocations.size());
+    for (auto entry :
+         Instance
+             .m_scriptAllocationsInfo) // list remaining allocations per script
     {
-        if (!PluginCheckCleoVersion()) return;
+      if (entry.second.count == 0)
+        continue;
 
-        auto config = GetConfigFilename();
-        m_configLimitAllocationCount = GetPrivateProfileInt("Limits", "MemoryAllocations", 2000, config.c_str());
-        m_configLimitAllocationSize = GetPrivateProfileInt("Limits", "MemoryTotalSize", 16, config.c_str()) * 1024 * 1024; // megabytes
+      std::string str(128, '\0');
+      CLEO_GetScriptInfoStr(entry.first, false, str.data(), str.length());
+      TRACE(" %d block%s (%0.2f kB) in script %s", entry.second.count,
+            entry.second.count > 1 ? "s" : "", float(entry.second.size) / 1024,
+            str.c_str());
+    }
+    for (auto p : Instance.m_allocations)
+      free(p.first);
+    Instance.m_allocations.clear();
+    Instance.m_scriptAllocationsInfo.clear();
 
-        //register opcodes
-        CLEO_RegisterOpcode(0x0459, opcode_0459); // terminate_all_scripts_with_this_name
+    // release loaded dlls
+    size_t libCount =
+        std::count_if(Instance.m_libraries.begin(), Instance.m_libraries.end(),
+                      [](auto &entry) { return entry.second; });
+    TRACE("");
+    TRACE("Cleaning up %d loaded libraries:", libCount);
+    for (auto &entry : Instance.m_libraries) {
+      if (entry.second == 0)
+        continue;
 
-        CLEO_RegisterOpcode(0x0A8C, opcode_0A8C); // write_memory
-        CLEO_RegisterOpcode(0x0A8D, opcode_0A8D); // read_memory
+      std::string str(MAX_PATH, '\0');
+      GetModuleFileNameA(entry.first, str.data(), str.length());
+      FilepathRemoveParent(str, CLEO_GetGameDirectory());
+      TRACE(" %s", str.c_str());
 
-        CLEO_RegisterOpcode(0x0A96, opcode_0A96); // get_ped_pointer
-        CLEO_RegisterOpcode(0x0A97, opcode_0A97); // get_vehicle_pointer
-        CLEO_RegisterOpcode(0x0A98, opcode_0A98); // get_object_pointer
+      while (entry.second > 0) {
+        FreeLibrary(entry.first);
+        entry.second -= 1;
+      }
+    }
+    Instance.m_libraries.clear();
+  }
 
-        CLEO_RegisterOpcode(0x0A9F, opcode_0A9F); // get_object_pointer
+  void RegisterMemoryAllocation(CLEO::CRunningScript *thread, void *address,
+                                size_t size) {
+    m_allocations[address] = size;
+    auto &info = m_scriptAllocationsInfo[thread];
+    info.count++;
+    info.size += size;
+  }
 
-        CLEO_RegisterOpcode(0x0AA2, opcode_0AA2); // load_dynamic_library
-        CLEO_RegisterOpcode(0x0AA3, opcode_0AA3); // free_library
-        CLEO_RegisterOpcode(0x0AA4, opcode_0AA4); // get_dynamic_library_procedure
-        CLEO_RegisterOpcode(0x0AA5, opcode_0AA5); // call_function
-        CLEO_RegisterOpcode(0x0AA6, opcode_0AA6); // call_method
-        CLEO_RegisterOpcode(0x0AA7, opcode_0AA7); // call_function_return
-        CLEO_RegisterOpcode(0x0AA8, opcode_0AA8); // call_method_return
+  void UnregisterMemoryAllocation(CLEO::CRunningScript *thread, void *address) {
+    auto &info = m_scriptAllocationsInfo[thread];
+    info.count--;
+    info.size -= m_allocations[address];
+    m_allocations.erase(address);
+  }
 
-        CLEO_RegisterOpcode(0x0AAA, opcode_0AAA); // get_script_struct_named
+  // opcodes 0AA5 - 0AA8
+  static OpcodeResult CallFunctionGeneric(CLEO::CRunningScript *thread,
+                                          void *func, void *obj, int numArg,
+                                          int numPop, bool returnArg) {
+    auto inputArgCount = (int)CLEO_GetVarArgCount(thread) -
+                         returnArg; // return slot not counted as input argument
 
-        CLEO_RegisterOpcode(0x0ABA, opcode_0ABA); // terminate_all_custom_scripts_with_this_name
-
-        CLEO_RegisterOpcode(0x0AC6, opcode_0AC6); // get_label_pointer
-        CLEO_RegisterOpcode(0x0AC7, opcode_0AC7); // get_var_pointer
-        CLEO_RegisterOpcode(0x0AC8, opcode_0AC8); // allocate_memory
-        CLEO_RegisterOpcode(0x0AC9, opcode_0AC9); // free_memory
-
-        CLEO_RegisterOpcode(0x0AE9, opcode_0AE9); // pop_float
-        CLEO_RegisterOpcode(0x0AEA, opcode_0AEA); // get_ped_ref
-        CLEO_RegisterOpcode(0x0AEB, opcode_0AEB); // get_vehicle_ref
-        CLEO_RegisterOpcode(0x0AEC, opcode_0AEC); // get_object_ref
-
-        CLEO_RegisterOpcode(0x2400, opcode_2400); // copy_memory
-        CLEO_RegisterOpcode(0x2401, opcode_2401); // read_memory_with_offset
-        CLEO_RegisterOpcode(0x2402, opcode_2402); // write_memory_with_offset
-        CLEO_RegisterOpcode(0x2403, opcode_2403); // forget_memory
-        CLEO_RegisterOpcode(0x2404, opcode_2404); // get_script_struct_just_created
-        CLEO_RegisterOpcode(0x2405, opcode_2405); // is_script_running
-        CLEO_RegisterOpcode(0x2406, opcode_2406); // get_script_struct_from_filename
-        CLEO_RegisterOpcode(0x2407, opcode_2407); // is_memory_equal
-        CLEO_RegisterOpcode(0x2408, opcode_2408); // terminate_script
-        
-
-        // register event callbacks
-        CLEO_RegisterCallback(eCallbackId::GameEnd, OnGameEnd);
+    constexpr size_t Max_Args = 32;
+    if (inputArgCount > Max_Args) {
+      SHOW_ERROR("Provided more (%d) than supported (%d) arguments in script "
+                 "%s\nScript suspended.",
+                 inputArgCount, Max_Args, CLEO::ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
     }
 
-    ~MemoryOperations()
+    if (numArg != inputArgCount &&
+        !IsLegacyScript(thread)) // CLEO4 ignored param count missmatch (by
+                                 // providing zeros for missing)
     {
-        CLEO_UnregisterCallback(eCallbackId::GameEnd, OnGameEnd);
+      SHOW_ERROR_COMPAT("Declared %d input args, but provided %d in script "
+                        "%s\nScript suspended.",
+                        numArg, inputArgCount,
+                        CLEO::ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
     }
 
-    static void __stdcall OnGameEnd()
-    {
-        // release memory allocations
-        TRACE("");
-        TRACE("Cleaning up %d allocated memory block(s):", Instance.m_allocations.size());
-        for (auto entry : Instance.m_scriptAllocationsInfo) // list remaining allocations per script
-        {
-            if (entry.second.count == 0) continue;
+    static SCRIPT_VAR arguments[Max_Args] = {0};
 
-            std::string str(128, '\0');
-            CLEO_GetScriptInfoStr(entry.first, false, str.data(), str.length());
-            TRACE(" %d block%s (%0.2f kB) in script %s",
-                entry.second.count,
-                entry.second.count > 1 ? "s" : "",
-                float(entry.second.size) / 1024,
-                str.c_str());
-        }
-        for (auto p : Instance.m_allocations) free(p.first);
-        Instance.m_allocations.clear();
-        Instance.m_scriptAllocationsInfo.clear();
+    constexpr size_t Max_Text_Params = 5;
+    static char textParams[Max_Text_Params][MAX_STR_LEN];
+    size_t currTextParam = 0;
 
-        // release loaded dlls
-        size_t libCount = std::count_if(Instance.m_libraries.begin(), Instance.m_libraries.end(), [](auto& entry) { return entry.second; });
-        TRACE("");
-        TRACE("Cleaning up %d loaded libraries:", libCount);
-        for (auto& entry : Instance.m_libraries)
-        {
-            if (entry.second == 0) continue;
+    // retrieve parameters
+    auto scriptParams = CLEO_GetOpcodeParamsArray();
+    for (size_t i = 0; i < std::min<size_t>(numArg, inputArgCount); i++) {
+      auto &param = arguments[i];
 
-            std::string str(MAX_PATH, '\0');
-            GetModuleFileNameA(entry.first, str.data(), str.length());
-            FilepathRemoveParent(str, CLEO_GetGameDirectory());
-            TRACE(" %s", str.c_str());
+      auto paramType = thread->PeekDataType();
+      if (IsImmString(paramType) || IsVarString(paramType)) {
 
-            while (entry.second > 0)
-            {
-                FreeLibrary(entry.first);
-                entry.second -= 1;
-            }
-        }
-        Instance.m_libraries.clear();
-    }
-
-    void RegisterMemoryAllocation(CLEO::CRunningScript* thread, void* address, size_t size)
-    {
-        m_allocations[address] = size;
-        auto& info = m_scriptAllocationsInfo[thread];
-        info.count++;
-        info.size += size;
-    }
-
-    void UnregisterMemoryAllocation(CLEO::CRunningScript* thread, void* address)
-    {
-        auto& info = m_scriptAllocationsInfo[thread];
-        info.count--;
-        info.size -= m_allocations[address];
-        m_allocations.erase(address);
-    }
-
-    // opcodes 0AA5 - 0AA8
-    static OpcodeResult CallFunctionGeneric(CLEO::CRunningScript* thread, void* func, void* obj, int numArg, int numPop, bool returnArg)
-    {
-        auto inputArgCount = (int)CLEO_GetVarArgCount(thread) - returnArg; // return slot not counted as input argument
-
-        constexpr size_t Max_Args = 32;
-        if (inputArgCount > Max_Args)
-        {
-            SHOW_ERROR("Provided more (%d) than supported (%d) arguments in script %s\nScript suspended.", inputArgCount, Max_Args, CLEO::ScriptInfoStr(thread).c_str());
+        if (IsLegacyScript(thread) && IsVarString(paramType)) {
+          /*
+              Preserving behavior of CLEO 4 where string variables were always
+             passed as pointers. It allowed for neat tricks like: 0@ = 0
+              call_function 0x12345678 num_params 3 pop 0 0@v // pass pointer to
+             0@
+              // read result from 0@
+          */
+          param.pParam = CLEO_GetPointerToScriptVariable(thread);
+        } else {
+          if (currTextParam >= Max_Text_Params) {
+            SHOW_ERROR("Provided more (%d) than supported (%d) string "
+                       "arguments in script %s\nScript suspended.",
+                       currTextParam + 1, Max_Text_Params,
+                       CLEO::ScriptInfoStr(thread).c_str());
             return thread->Suspend();
+          }
+
+          OPCODE_READ_PARAM_STRING_LEN(str, MAX_STR_LEN);
+          strcpy_s(textParams[currTextParam], str);
+          param.pcParam = textParams[currTextParam];
+          currTextParam++;
         }
+      } else if (IsImmInteger(paramType) || IsImmFloat(paramType) ||
+                 IsVariable(paramType)) {
+        CLEO_RetrieveOpcodeParams(thread, 1);
+        param = scriptParams[0];
+      } else {
+        SHOW_ERROR("Invalid param type (%s) in script %s \nScript suspended.",
+                   ToKindStr(paramType), CLEO::ScriptInfoStr(thread).c_str());
+        return thread->Suspend();
+      }
+    }
 
-        if (numArg != inputArgCount && !IsLegacyScript(thread)) // CLEO4 ignored param count missmatch (by providing zeros for missing)
-        {
-            SHOW_ERROR_COMPAT("Declared %d input args, but provided %d in script %s\nScript suspended.", numArg, inputArgCount, CLEO::ScriptInfoStr(thread).c_str());
-            return thread->Suspend();
-        }
-
-        static SCRIPT_VAR arguments[Max_Args] = { 0 };
-
-        constexpr size_t Max_Text_Params = 5;
-        static char textParams[Max_Text_Params][MAX_STR_LEN];
-        size_t currTextParam = 0;
-
-        // retrieve parameters
-        auto scriptParams = CLEO_GetOpcodeParamsArray();
-        for (size_t i = 0; i < std::min<size_t>(numArg, inputArgCount); i++)
-        {
-            auto& param = arguments[i];
-
-            auto paramType = thread->PeekDataType();
-            if (IsImmString(paramType) || IsVarString(paramType))
-            {
-
-                if (IsLegacyScript(thread) && IsVarString(paramType))
-                {
-                    /*
-                        Preserving behavior of CLEO 4 where string variables were always passed as pointers.
-                        It allowed for neat tricks like: 
-                        0@ = 0
-                        call_function 0x12345678 num_params 3 pop 0 0@v // pass pointer to 0@
-                        // read result from 0@
-                    */
-                    param.pParam = CLEO_GetPointerToScriptVariable(thread);
-                }
-                else
-                {
-                    if (currTextParam >= Max_Text_Params)
-                    {
-                        SHOW_ERROR("Provided more (%d) than supported (%d) string arguments in script %s\nScript suspended.", currTextParam + 1, Max_Text_Params, CLEO::ScriptInfoStr(thread).c_str());
-                        return thread->Suspend();
-                    }
-
-                    OPCODE_READ_PARAM_STRING_LEN(str, MAX_STR_LEN);
-                    strcpy_s(textParams[currTextParam], str);
-                    param.pcParam = textParams[currTextParam];
-                    currTextParam++;
-                }
-            }
-            else if (IsImmInteger(paramType) || IsImmFloat(paramType) || IsVariable(paramType))
-            {
-                CLEO_RetrieveOpcodeParams(thread, 1);
-                param = scriptParams[0];
-            }
-            else
-            {
-                SHOW_ERROR("Invalid param type (%s) in script %s \nScript suspended.", ToKindStr(paramType), CLEO::ScriptInfoStr(thread).c_str());
-                return thread->Suspend();
-            }
-        }
-
-        SCRIPT_VAR* arguments_end = arguments + numArg;
-        numPop *= 4; // bytes peer argument
-        DWORD result;
-        int oriSp, postSp; // stack validation
-        _asm
-        {
+    SCRIPT_VAR *arguments_end = arguments + numArg;
+    numPop *= 4; // bytes peer argument
+    DWORD result;
+    int oriSp, postSp; // stack validation
+    _asm
+    {
             mov oriSp, esp
 
-            // transfer args to stack
+         // transfer args to stack
             lea ecx, arguments
             call_func_loop :
             cmp ecx, arguments_end
@@ -230,7 +241,7 @@ public:
                 jmp call_func_loop
                 call_func_loop_end :
 
-            // call function
+     // call function
             mov ecx, obj
                 xor eax, eax
                 call func
@@ -238,766 +249,721 @@ public:
                 add esp, numPop // cleanup stack
 
             mov postSp, esp
-        }
+    }
 
-        // validate stack pointer
-        if (postSp != oriSp)
-        {
-            _asm
-            {
+    // validate stack pointer
+    if (postSp != oriSp) {
+      _asm
+      {
                 mov esp, oriSp // fix stack pointer
-            }
+      }
 
-            int diff = oriSp - postSp;
-            int requiredPop = (numPop + diff) / 4;
-            SHOW_ERROR("Function call left stack position changed (%s%d). This usually happens when incorrect calling convention is used. \nArgument 'pop' value should have been %d in script %s \nScript suspended.", diff > 0 ? "+" : "", diff, requiredPop, CLEO::ScriptInfoStr(thread).c_str());
-            return thread->Suspend();
-        }
-
-        if (returnArg)
-        {
-            auto paramType = thread->PeekDataType();
-
-            if (IsVarString(paramType))
-            {
-                OPCODE_WRITE_PARAM_STRING((char*)result);
-            }
-            else
-            {
-                OPCODE_WRITE_PARAM_UINT(result);
-            }
-        }
-
-        CLEO_SkipUnusedVarArgs(thread);
-
-        // set condition result
-        if (!IsLegacyScript(thread))
-        {
-            if (!returnArg) result &= 0xFF; // clip to AL
-            OPCODE_CONDITION_RESULT(result != 0);
-        }
-
-        return OR_CONTINUE;
+      int diff = oriSp - postSp;
+      int requiredPop = (numPop + diff) / 4;
+      SHOW_ERROR(
+          "Function call left stack position changed (%s%d). This usually "
+          "happens when incorrect calling convention is used. \nArgument 'pop' "
+          "value should have been %d in script %s \nScript suspended.",
+          diff > 0 ? "+" : "", diff, requiredPop,
+          CLEO::ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
     }
 
-    //0459=1,terminate_all_scripts_with_this_name %1s%
-    static OpcodeResult __stdcall opcode_0459(CLEO::CRunningScript* thread)
-    {
-        OPCODE_READ_PARAM_STRING(threadName);
+    if (returnArg) {
+      auto paramType = thread->PeekDataType();
 
-        while (true)
-        {
-            // we only want to terminate game scripts, not custom ones
-            auto found = CLEO_GetScriptByName(threadName, true, false, 0);
-            if (found == nullptr)
-                break;
-
-            CLEO_TerminateScript(found);
-        }
-
-        return OR_CONTINUE;
+      if (IsVarString(paramType)) {
+        OPCODE_WRITE_PARAM_STRING((char *)result);
+      } else {
+        OPCODE_WRITE_PARAM_UINT(result);
+      }
     }
 
-    //0A8C=4,write_memory %1d% size %2d% value %3d% virtual_protect %4d%
-    static OpcodeResult __stdcall opcode_0A8C(CLEO::CRunningScript* thread)
-    {
-        // collect params
-        auto address = OPCODE_READ_PARAM_PTR();
-        auto size = OPCODE_READ_PARAM_INT();
+    CLEO_SkipUnusedVarArgs(thread);
 
-        // value param
-        const void* source;
-        auto paramType = thread->PeekDataType();
-        bool sourceText = false;
-        if (IsVariable(paramType) || IsVarString(paramType))
-        {
-            source = CLEO_GetPointerToScriptVariable(thread);
-        }
-        else if (IsImmString(paramType))
-        {
-            static char buffer[MAX_STR_LEN];
-
-            if (size > MAX_STR_LEN)
-            {
-                SHOW_ERROR("Size argument (%d) greater than supported (%d) in script %s\nScript suspended.", size, MAX_STR_LEN, ScriptInfoStr(thread).c_str());
-                return thread->Suspend();
-            }
-
-            ZeroMemory(buffer, size); // padd with zeros if size > length
-            source = CLEO_ReadStringOpcodeParam(thread, buffer, sizeof(buffer));
-            sourceText = true;
-        }
-        else
-        {
-            static SCRIPT_VAR value;
-
-            CLEO_RetrieveOpcodeParams(thread, 1);
-            value = CLEO_GetOpcodeParamsArray()[0];
-            source = &value;
-        }
-
-        auto virtualProtect = OPCODE_READ_PARAM_BOOL();
-
-        // validate params
-        if (size < 0)
-        {
-            SHOW_ERROR("Invalid '%d' size argument in script %s\nScript suspended.", size, ScriptInfoStr(thread).c_str());
-            return thread->Suspend();
-        }
-
-        // perform
-        if (size == 0) return OR_CONTINUE; // done
-
-        if (virtualProtect)
-        {
-            DWORD oldProtect;
-            VirtualProtect(address, size, PAGE_EXECUTE_READWRITE, &oldProtect);
-        }
-
-        if (!sourceText)
-        {
-            // that's how it worked since ever...
-            if (size == 2 || size == 4)
-                memcpy(address, source, size);
-            else
-                memset(address, *((int*)source), size);
-        }
-        else
-        {
-            memcpy(address, source, size);
-        }
-
-        return OR_CONTINUE;
+    // set condition result
+    if (!IsLegacyScript(thread)) {
+      if (!returnArg)
+        result &= 0xFF; // clip to AL
+      OPCODE_CONDITION_RESULT(result != 0);
     }
 
-    //0A8D=4,read_memory %1d% size %2d% virtual_protect %3d% store_to %4d%
-    static OpcodeResult __stdcall opcode_0A8D(CLEO::CRunningScript* thread)
-    {
-        // collect params
-        auto address = OPCODE_READ_PARAM_PTR();
-        auto size = OPCODE_READ_PARAM_INT();
-        auto virtualProtect = OPCODE_READ_PARAM_BOOL();
+    return OR_CONTINUE;
+  }
 
-        // validate params
-        if (size < 0 || size > sizeof(SCRIPT_VAR))
-        {
-            SHOW_ERROR("Invalid '%d' size argument in script %s\nScript suspended.", size, ScriptInfoStr(thread).c_str());
-            return thread->Suspend();
-        }
+  // 0459=1,terminate_all_scripts_with_this_name %1s%
+  static OpcodeResult __stdcall opcode_0459(CLEO::CRunningScript *thread) {
+    OPCODE_READ_PARAM_STRING(threadName);
 
-        // perform
-        DWORD value = 0;
-        if (size > 0)
-        {
-            if (virtualProtect)
-            {
-                DWORD oldProtect;
-                VirtualProtect(address, size, PAGE_EXECUTE_READWRITE, &oldProtect);
-            }
+    while (true) {
+      // we only want to terminate game scripts, not custom ones
+      auto found = CLEO_GetScriptByName(threadName, true, false, 0);
+      if (found == nullptr)
+        break;
 
-            memcpy(&value, address, size);
-        }
-
-        OPCODE_WRITE_PARAM_ANY32(value);
-        return OR_CONTINUE;
+      CLEO_TerminateScript(found);
     }
 
-    //0A96=2,get_ped_pointer %1d% store_to %2d%
-    static OpcodeResult __stdcall opcode_0A96(CLEO::CRunningScript* thread)
-    {
-        // collect params
-        auto handle = OPCODE_READ_PARAM_UINT();
+    return OR_CONTINUE;
+  }
 
-        // validate params
-        auto index = handle >> 8; // lowest byte holds flags
-        if (index >= (DWORD)CPools::ms_pPedPool->m_nSize)
-        {
-            OPCODE_WRITE_PARAM_PTR(nullptr);
-            return OR_CONTINUE;
-        }
+  // 0A8C=4,write_memory %1d% size %2d% value %3d% virtual_protect %4d%
+  static OpcodeResult __stdcall opcode_0A8C(CLEO::CRunningScript *thread) {
+    // collect params
+    auto address = OPCODE_READ_PARAM_PTR();
+    auto size = OPCODE_READ_PARAM_INT();
 
-        auto ptr = CPools::GetPed(handle);
+    // value param
+    const void *source;
+    auto paramType = thread->PeekDataType();
+    bool sourceText = false;
+    if (IsVariable(paramType) || IsVarString(paramType)) {
+      source = CLEO_GetPointerToScriptVariable(thread);
+    } else if (IsImmString(paramType)) {
+      static char buffer[MAX_STR_LEN];
 
-        OPCODE_WRITE_PARAM_PTR(ptr);
-        return OR_CONTINUE;
+      if (size > MAX_STR_LEN) {
+        SHOW_ERROR("Size argument (%d) greater than supported (%d) in script "
+                   "%s\nScript suspended.",
+                   size, MAX_STR_LEN, ScriptInfoStr(thread).c_str());
+        return thread->Suspend();
+      }
+
+      ZeroMemory(buffer, size); // padd with zeros if size > length
+      source = CLEO_ReadStringOpcodeParam(thread, buffer, sizeof(buffer));
+      sourceText = true;
+    } else {
+      static SCRIPT_VAR value;
+
+      CLEO_RetrieveOpcodeParams(thread, 1);
+      value = CLEO_GetOpcodeParamsArray()[0];
+      source = &value;
     }
 
-    //0A97=2,get_vehicle_pointer %1d% store_to %2d%
-    static OpcodeResult __stdcall opcode_0A97(CLEO::CRunningScript* thread)
-    {
-        // collect params
-        auto handle = OPCODE_READ_PARAM_UINT();
+    auto virtualProtect = OPCODE_READ_PARAM_BOOL();
 
-        // validate params
-        auto index = handle >> 8; // lowest byte holds flags
-        if (index >= (DWORD)CPools::ms_pVehiclePool->m_nSize)
-        {
-            OPCODE_WRITE_PARAM_PTR(nullptr);
-            return OR_CONTINUE;
-        }
-
-        auto ptr = CPools::GetVehicle(handle);
-
-        OPCODE_WRITE_PARAM_PTR(ptr);
-        return OR_CONTINUE;
+    // validate params
+    if (size < 0) {
+      SHOW_ERROR("Invalid '%d' size argument in script %s\nScript suspended.",
+                 size, ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
     }
 
-    //0A98=2,get_object_pointer %1d% store_to %2d%
-    static OpcodeResult __stdcall opcode_0A98(CLEO::CRunningScript* thread)
-    {
-        // collect params
-        auto handle = OPCODE_READ_PARAM_UINT();
+    // perform
+    if (size == 0)
+      return OR_CONTINUE; // done
 
-        // validate params
-        auto index = handle >> 8; // lowest byte holds flags
-        if (index >= (DWORD)CPools::ms_pObjectPool->m_nSize)
-        {
-            OPCODE_WRITE_PARAM_PTR(nullptr);
-            return OR_CONTINUE;
-        }
-
-        auto ptr = CPools::GetObject(handle);
-
-        OPCODE_WRITE_PARAM_PTR(ptr);
-        return OR_CONTINUE;
+    if (virtualProtect) {
+      DWORD oldProtect;
+      VirtualProtect(address, size, PAGE_EXECUTE_READWRITE, &oldProtect);
     }
 
-    //0A9F=1, get_this_script_struct store_to %1d%
-    static OpcodeResult __stdcall opcode_0A9F(CLEO::CRunningScript* thread)
-    {
-        OPCODE_WRITE_PARAM_PTR(thread);
-        return OR_CONTINUE;
+    if (!sourceText) {
+      // that's how it worked since ever...
+      if (size == 2 || size == 4)
+        memcpy(address, source, size);
+      else
+        memset(address, *((int *)source), size);
+    } else {
+      memcpy(address, source, size);
     }
 
-    //0AA2=2, load_dynamic_library %1s% store_to %2d% // IF and SET
-    static OpcodeResult __stdcall opcode_0AA2(CLEO::CRunningScript* thread)
-    {
-        OPCODE_READ_PARAM_STRING(path);
+    return OR_CONTINUE;
+  }
 
-        HMODULE ptr = nullptr;
-        
-        // resolve absolute path and try load
-        char buff[MAX_PATH];
-        strncpy_s(buff, path, sizeof(buff));
-        CLEO_ResolvePath(thread, buff, sizeof(buff));
-        ptr = LoadLibrary(buff);
+  // 0A8D=4,read_memory %1d% size %2d% virtual_protect %3d% store_to %4d%
+  static OpcodeResult __stdcall opcode_0A8D(CLEO::CRunningScript *thread) {
+    // collect params
+    auto address = OPCODE_READ_PARAM_PTR();
+    auto size = OPCODE_READ_PARAM_INT();
+    auto virtualProtect = OPCODE_READ_PARAM_BOOL();
 
-        // in case of just filename let LoadLibrary resolve it itself
-        if (ptr == nullptr && !std::filesystem::path(path).has_parent_path())
-        {
-            ptr = LoadLibrary(path);
-        }
-
-        if (ptr != nullptr)
-        {
-            Instance.m_libraries[ptr] += 1;
-        }
-
-        OPCODE_WRITE_PARAM_PTR(ptr);
-        OPCODE_CONDITION_RESULT(ptr != nullptr);
-        return OR_CONTINUE;
+    // validate params
+    if (size < 0 || size > sizeof(SCRIPT_VAR)) {
+      SHOW_ERROR("Invalid '%d' size argument in script %s\nScript suspended.",
+                 size, ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
     }
 
-    //0AA3=1,free_library %1h%
-    static OpcodeResult __stdcall opcode_0AA3(CLEO::CRunningScript* thread)
-    {
-        auto ptr = (HMODULE)OPCODE_READ_PARAM_PTR();
+    // perform
+    DWORD value = 0;
+    if (size > 0) {
+      if (virtualProtect) {
+        DWORD oldProtect;
+        VirtualProtect(address, size, PAGE_EXECUTE_READWRITE, &oldProtect);
+      }
 
-        // validate
-        if (Instance.m_libraries.find(ptr) == Instance.m_libraries.end())
-        {
-            LOG_WARNING(thread, "Invalid '0x%X' library pointer param in script %s", ptr, ScriptInfoStr(thread).c_str());
-            return OR_CONTINUE;
-        }
-
-        if (Instance.m_libraries[ptr] == 0)
-        {
-            LOG_WARNING(thread, "Trying to free already unloaded library in script %s", ScriptInfoStr(thread).c_str());
-            return OR_CONTINUE;
-        }
-
-        FreeLibrary(ptr);
-        Instance.m_libraries[ptr] -= 1;
-        return OR_CONTINUE;
+      memcpy(&value, address, size);
     }
 
-    //0AA4=3, get_proc_address %1d% library %2d% result %3d% // IF and SET
-    static OpcodeResult __stdcall opcode_0AA4(CLEO::CRunningScript* thread)
-    {
-        void* funcPtr = nullptr;
+    OPCODE_WRITE_PARAM_ANY32(value);
+    return OR_CONTINUE;
+  }
 
-        auto paramType = thread->PeekDataType();
-        if (IsImmInteger(paramType) || IsVariable(paramType))
-        {
-            auto procedure = OPCODE_READ_PARAM_UINT(); // text pointer or export index - see GetProcAddress docs
-            auto module = (HMODULE)OPCODE_READ_PARAM_PTR();
+  // 0A96=2,get_ped_pointer %1d% store_to %2d%
+  static OpcodeResult __stdcall opcode_0A96(CLEO::CRunningScript *thread) {
+    // collect params
+    auto handle = OPCODE_READ_PARAM_UINT();
 
-            funcPtr = (void*)GetProcAddress(module, (LPCSTR)procedure);
-        }
-        else
-        {
-            OPCODE_READ_PARAM_STRING(name);
-            auto module = (HMODULE)OPCODE_READ_PARAM_PTR();
-
-            funcPtr = (void*)GetProcAddress(module, name);
-        }
-
-        OPCODE_WRITE_PARAM_PTR(funcPtr);
-        OPCODE_CONDITION_RESULT(funcPtr != nullptr);
-        return OR_CONTINUE;
+    // validate params
+    auto index = handle >> 8; // lowest byte holds flags
+    if (index >= (DWORD)CPools::ms_pPedPool->m_nSize) {
+      OPCODE_WRITE_PARAM_PTR(nullptr);
+      return OR_CONTINUE;
     }
 
-    //0AA5=-1,call %1d% num_params %2h% pop %3h%
-    static OpcodeResult __stdcall opcode_0AA5(CLEO::CRunningScript* thread)
-    {
-        auto func = OPCODE_READ_PARAM_PTR();
-        auto numArgs = OPCODE_READ_PARAM_INT();
-        auto numPop = OPCODE_READ_PARAM_INT();
+    auto ptr = CPools::GetPed(handle);
 
-        return CallFunctionGeneric(thread, func, nullptr, numArgs, numPop, false);
+    OPCODE_WRITE_PARAM_PTR(ptr);
+    return OR_CONTINUE;
+  }
+
+  // 0A97=2,get_vehicle_pointer %1d% store_to %2d%
+  static OpcodeResult __stdcall opcode_0A97(CLEO::CRunningScript *thread) {
+    // collect params
+    auto handle = OPCODE_READ_PARAM_UINT();
+
+    // validate params
+    auto index = handle >> 8; // lowest byte holds flags
+    if (index >= (DWORD)CPools::ms_pVehiclePool->m_nSize) {
+      OPCODE_WRITE_PARAM_PTR(nullptr);
+      return OR_CONTINUE;
     }
 
-    //0AA6=-1,call_method %1d% struct %2d% num_params %3h% pop %4h%
-    static OpcodeResult __stdcall opcode_0AA6(CLEO::CRunningScript* thread)
-    {
-        auto func = OPCODE_READ_PARAM_PTR();
+    auto ptr = CPools::GetVehicle(handle);
 
-        void* obj = nullptr;
-        if (!IsLegacyScript(thread))
-        {
-            obj = OPCODE_READ_PARAM_PTR();
-        }
-        else
-        {
-            obj = (void*)OPCODE_READ_PARAM_INT(); // at least one mod used 0AA6 with 0 as struct argument (effectively turning it into 0AA5 opcode...)
-        }
+    OPCODE_WRITE_PARAM_PTR(ptr);
+    return OR_CONTINUE;
+  }
 
-        auto numArgs = OPCODE_READ_PARAM_INT();
-        auto numPop = OPCODE_READ_PARAM_INT();
+  // 0A98=2,get_object_pointer %1d% store_to %2d%
+  static OpcodeResult __stdcall opcode_0A98(CLEO::CRunningScript *thread) {
+    // collect params
+    auto handle = OPCODE_READ_PARAM_UINT();
 
-        return CallFunctionGeneric(thread, func, obj, numArgs, numPop, false);
+    // validate params
+    auto index = handle >> 8; // lowest byte holds flags
+    if (index >= (DWORD)CPools::ms_pObjectPool->m_nSize) {
+      OPCODE_WRITE_PARAM_PTR(nullptr);
+      return OR_CONTINUE;
     }
 
-    //0AA7=-1,call_function_return %1d% num_params %2h% pop %3h%
-    static OpcodeResult __stdcall opcode_0AA7(CLEO::CRunningScript* thread)
-    {
-        auto func = OPCODE_READ_PARAM_PTR();
-        auto numArgs = OPCODE_READ_PARAM_INT();
-        auto numPop = OPCODE_READ_PARAM_INT();
+    auto ptr = CPools::GetObject(handle);
 
-        return CallFunctionGeneric(thread, func, nullptr, numArgs, numPop, true);
+    OPCODE_WRITE_PARAM_PTR(ptr);
+    return OR_CONTINUE;
+  }
+
+  // 0A9F=1, get_this_script_struct store_to %1d%
+  static OpcodeResult __stdcall opcode_0A9F(CLEO::CRunningScript *thread) {
+    OPCODE_WRITE_PARAM_PTR(thread);
+    return OR_CONTINUE;
+  }
+
+  // 0AA2=2, load_dynamic_library %1s% store_to %2d% // IF and SET
+  static OpcodeResult __stdcall opcode_0AA2(CLEO::CRunningScript *thread) {
+    OPCODE_READ_PARAM_STRING(path);
+
+    HMODULE ptr = nullptr;
+
+    // resolve absolute path and try load
+    char buff[MAX_PATH];
+    strncpy_s(buff, path, sizeof(buff));
+    CLEO_ResolvePath(thread, buff, sizeof(buff));
+    ptr = LoadLibrary(buff);
+
+    // in case of just filename let LoadLibrary resolve it itself
+    if (ptr == nullptr && !std::filesystem::path(path).has_parent_path()) {
+      ptr = LoadLibrary(path);
     }
 
-    //0AA8=-1,call_method_return %1d% struct %2d% num_params %3h% pop %4h%
-    static OpcodeResult __stdcall opcode_0AA8(CLEO::CRunningScript* thread)
-    {
-        auto func = OPCODE_READ_PARAM_PTR();
-
-        void* obj = nullptr;
-        if (!IsLegacyScript(thread))
-        {
-            obj = OPCODE_READ_PARAM_PTR();
-        }
-        else
-        {
-            obj = (void*)OPCODE_READ_PARAM_INT(); // some mods got creative and used it as way to set ECX
-        }
-
-        auto numArgs = OPCODE_READ_PARAM_INT();
-        auto numPop = OPCODE_READ_PARAM_INT();
-
-        return CallFunctionGeneric(thread, func, obj, numArgs, numPop, true);
+    if (ptr != nullptr) {
+      Instance.m_libraries[ptr] += 1;
     }
 
-    //0AAA=2,  get_script_struct_named %1d% pointer %2d% // IF and SET
-    static OpcodeResult __stdcall opcode_0AAA(CLEO::CRunningScript *thread)
-    {
-        OPCODE_READ_PARAM_STRING(name);
+    OPCODE_WRITE_PARAM_PTR(ptr);
+    OPCODE_CONDITION_RESULT(ptr != nullptr);
+    return OR_CONTINUE;
+  }
 
-        auto ptr = CLEO_GetScriptByName(name, true, true, 0);
+  // 0AA3=1,free_library %1h%
+  static OpcodeResult __stdcall opcode_0AA3(CLEO::CRunningScript *thread) {
+    auto ptr = (HMODULE)OPCODE_READ_PARAM_PTR();
 
-        OPCODE_WRITE_PARAM_PTR(ptr);
-        OPCODE_CONDITION_RESULT(ptr != nullptr);
-        return OR_CONTINUE;
+    // validate
+    if (Instance.m_libraries.find(ptr) == Instance.m_libraries.end()) {
+      LOG_WARNING(thread, "Invalid '0x%X' library pointer param in script %s",
+                  ptr, ScriptInfoStr(thread).c_str());
+      return OR_CONTINUE;
     }
 
-    //0ABA=1,terminate_all_custom_scripts_with_this_name %1d%
-    static OpcodeResult __stdcall opcode_0ABA(CLEO::CRunningScript* thread)
-    {
-        OPCODE_READ_PARAM_STRING(threadName);
-
-        bool terminateCurrent = false;
-        while (true)
-        {
-            auto found = CLEO_GetScriptByName(threadName, false, true, 0);
-            if (found == nullptr)
-                break;
-
-            if (found == thread)
-                terminateCurrent = true;
-
-            CLEO_TerminateScript(found);
-        }
-
-        return terminateCurrent ? OR_INTERRUPT : OR_CONTINUE;
+    if (Instance.m_libraries[ptr] == 0) {
+      LOG_WARNING(thread,
+                  "Trying to free already unloaded library in script %s",
+                  ScriptInfoStr(thread).c_str());
+      return OR_CONTINUE;
     }
 
-    //0AC6=2,get_label_pointer %1d% store_to %2d%
-    static OpcodeResult __stdcall opcode_0AC6(CLEO::CRunningScript* thread)
-    {
-        auto label = OPCODE_READ_PARAM_INT();
+    FreeLibrary(ptr);
+    Instance.m_libraries[ptr] -= 1;
+    return OR_CONTINUE;
+  }
 
-        // perform
-        void* ptr = nullptr;
-        if (label < 0)
-            ptr = thread->GetBasePointer() - label;
-        else
-            ptr = CTheScripts::ScriptSpace + label;
+  // 0AA4=3, get_proc_address %1d% library %2d% result %3d% // IF and SET
+  static OpcodeResult __stdcall opcode_0AA4(CLEO::CRunningScript *thread) {
+    void *funcPtr = nullptr;
 
-        OPCODE_WRITE_PARAM_PTR(ptr);
-        return OR_CONTINUE;
+    auto paramType = thread->PeekDataType();
+    if (IsImmInteger(paramType) || IsVariable(paramType)) {
+      auto procedure = OPCODE_READ_PARAM_UINT(); // text pointer or export index
+                                                 // - see GetProcAddress docs
+      auto module = (HMODULE)OPCODE_READ_PARAM_PTR();
+
+      funcPtr = (void *)GetProcAddress(module, (LPCSTR)procedure);
+    } else {
+      OPCODE_READ_PARAM_STRING(name);
+      auto module = (HMODULE)OPCODE_READ_PARAM_PTR();
+
+      funcPtr = (void *)GetProcAddress(module, name);
     }
 
-    //0AC7=2,get_var_pointer %1d% store_to %2d%
-    static OpcodeResult __stdcall opcode_0AC7(CLEO::CRunningScript* thread)
-    {
-        auto resultType = thread->PeekDataType();
-        if (!IsVariable(resultType) && !IsVarString(resultType))
-        {
-            SHOW_ERROR("Input argument #%d expected to be variable, got constant in script %s\nScript suspended.", CLEO_GetParamsHandledCount(), ScriptInfoStr(thread).c_str());
-            return thread->Suspend();
-        }
+    OPCODE_WRITE_PARAM_PTR(funcPtr);
+    OPCODE_CONDITION_RESULT(funcPtr != nullptr);
+    return OR_CONTINUE;
+  }
 
-        auto ptr = CLEO_GetPointerToScriptVariable(thread);
+  // 0AA5=-1,call %1d% num_params %2h% pop %3h%
+  static OpcodeResult __stdcall opcode_0AA5(CLEO::CRunningScript *thread) {
+    auto func = OPCODE_READ_PARAM_PTR();
+    auto numArgs = OPCODE_READ_PARAM_INT();
+    auto numPop = OPCODE_READ_PARAM_INT();
 
-        OPCODE_WRITE_PARAM_PTR(ptr);
-        return OR_CONTINUE;
+    return CallFunctionGeneric(thread, func, nullptr, numArgs, numPop, false);
+  }
+
+  // 0AA6=-1,call_method %1d% struct %2d% num_params %3h% pop %4h%
+  static OpcodeResult __stdcall opcode_0AA6(CLEO::CRunningScript *thread) {
+    auto func = OPCODE_READ_PARAM_PTR();
+
+    void *obj = nullptr;
+    if (!IsLegacyScript(thread)) {
+      obj = OPCODE_READ_PARAM_PTR();
+    } else {
+      obj =
+          (void *)OPCODE_READ_PARAM_INT(); // at least one mod used 0AA6 with 0
+                                           // as struct argument (effectively
+                                           // turning it into 0AA5 opcode...)
     }
 
-    //0AC8=2,  allocate_memory size %1d% store_to %2d%
-    static OpcodeResult __stdcall opcode_0AC8(CLEO::CRunningScript* thread)
-    {
-        // collect params
-        int size = OPCODE_READ_PARAM_INT();
+    auto numArgs = OPCODE_READ_PARAM_INT();
+    auto numPop = OPCODE_READ_PARAM_INT();
 
-        // validate params
-        if (size <= 0)
-        {
-            SHOW_ERROR("Invalid '%d' size argument in script %s\nScript suspended.", size, ScriptInfoStr(thread).c_str());
-            return thread->Suspend();
-        }
+    return CallFunctionGeneric(thread, func, obj, numArgs, numPop, false);
+  }
 
-        // perform
-        void* mem = calloc(size, 1);
-        if (mem)
-        {
-            DWORD oldProtect;
-            VirtualProtect(mem, size, PAGE_EXECUTE_READWRITE, &oldProtect);
+  // 0AA7=-1,call_function_return %1d% num_params %2h% pop %3h%
+  static OpcodeResult __stdcall opcode_0AA7(CLEO::CRunningScript *thread) {
+    auto func = OPCODE_READ_PARAM_PTR();
+    auto numArgs = OPCODE_READ_PARAM_INT();
+    auto numPop = OPCODE_READ_PARAM_INT();
 
-            Instance.RegisterMemoryAllocation(thread, mem, size);
+    return CallFunctionGeneric(thread, func, nullptr, numArgs, numPop, true);
+  }
 
-            const auto& info = Instance.m_scriptAllocationsInfo[thread];
-            if (Instance.m_configLimitAllocationSize > 0 && info.size > Instance.m_configLimitAllocationSize)
-            {
-                LOG_WARNING(thread, "%d MB of memory currently allocated by script %s", info.size / (1024 * 1024), ScriptInfoStr(thread).c_str());
-            }
-            else if (Instance.m_configLimitAllocationCount > 0 && info.count > Instance.m_configLimitAllocationCount)
-            {
-                LOG_WARNING(thread, "More than %d memory blocks currently allocated by script %s", Instance.m_configLimitAllocationCount, ScriptInfoStr(thread).c_str());
-            }
-        }
-        else
-            LOG_WARNING(thread, "Failed to allocate %d bytes of memory in script %s", size, ScriptInfoStr(thread).c_str());
+  // 0AA8=-1,call_method_return %1d% struct %2d% num_params %3h% pop %4h%
+  static OpcodeResult __stdcall opcode_0AA8(CLEO::CRunningScript *thread) {
+    auto func = OPCODE_READ_PARAM_PTR();
 
-        OPCODE_WRITE_PARAM_PTR(mem);
-        OPCODE_CONDITION_RESULT(mem != nullptr);
-        return OR_CONTINUE;
+    void *obj = nullptr;
+    if (!IsLegacyScript(thread)) {
+      obj = OPCODE_READ_PARAM_PTR();
+    } else {
+      obj = (void *)OPCODE_READ_PARAM_INT(); // some mods got creative and used
+                                             // it as way to set ECX
     }
 
-    //0AC9=1,free_memory %1d%
-    static OpcodeResult __stdcall opcode_0AC9(CLEO::CRunningScript* thread)
-    {
-        // collect params
-        auto address = OPCODE_READ_PARAM_PTR();
+    auto numArgs = OPCODE_READ_PARAM_INT();
+    auto numPop = OPCODE_READ_PARAM_INT();
 
-        // validate params
-        if (Instance.m_allocations.find(address) == Instance.m_allocations.end())
-        {
-            LOG_WARNING(thread, "Invalid '0x%X' pointer param to unknown or already freed memory in script %s", address, ScriptInfoStr(thread).c_str());
-            return OR_CONTINUE;
-        }
+    return CallFunctionGeneric(thread, func, obj, numArgs, numPop, true);
+  }
 
-        free(address);
-        
-        Instance.UnregisterMemoryAllocation(thread, address);
+  // 0AAA=2,  get_script_struct_named %1d% pointer %2d% // IF and SET
+  static OpcodeResult __stdcall opcode_0AAA(CLEO::CRunningScript *thread) {
+    OPCODE_READ_PARAM_STRING(name);
 
-        return OR_CONTINUE; // done
+    auto ptr = CLEO_GetScriptByName(name, true, true, 0);
+
+    OPCODE_WRITE_PARAM_PTR(ptr);
+    OPCODE_CONDITION_RESULT(ptr != nullptr);
+    return OR_CONTINUE;
+  }
+
+  // 0ABA=1,terminate_all_custom_scripts_with_this_name %1d%
+  static OpcodeResult __stdcall opcode_0ABA(CLEO::CRunningScript *thread) {
+    OPCODE_READ_PARAM_STRING(threadName);
+
+    bool terminateCurrent = false;
+    while (true) {
+      auto found = CLEO_GetScriptByName(threadName, false, true, 0);
+      if (found == nullptr)
+        break;
+
+      if (found == thread)
+        terminateCurrent = true;
+
+      CLEO_TerminateScript(found);
     }
 
-    //0AE9=1,pop_float store_to %1d%
-    static OpcodeResult __stdcall opcode_0AE9(CLEO::CRunningScript* thread)
-    {
-        float result;
-        _asm fstp result
+    return terminateCurrent ? OR_INTERRUPT : OR_CONTINUE;
+  }
+
+  // 0AC6=2,get_label_pointer %1d% store_to %2d%
+  static OpcodeResult __stdcall opcode_0AC6(CLEO::CRunningScript *thread) {
+    auto label = OPCODE_READ_PARAM_INT();
+
+    // perform
+    void *ptr = nullptr;
+    if (label < 0)
+      ptr = thread->GetBasePointer() - label;
+    else
+      ptr = CTheScripts::ScriptSpace + label;
+
+    OPCODE_WRITE_PARAM_PTR(ptr);
+    return OR_CONTINUE;
+  }
+
+  // 0AC7=2,get_var_pointer %1d% store_to %2d%
+  static OpcodeResult __stdcall opcode_0AC7(CLEO::CRunningScript *thread) {
+    auto resultType = thread->PeekDataType();
+    if (!IsVariable(resultType) && !IsVarString(resultType)) {
+      SHOW_ERROR("Input argument #%d expected to be variable, got constant in "
+                 "script %s\nScript suspended.",
+                 CLEO_GetParamsHandledCount(), ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
+    }
+
+    auto ptr = CLEO_GetPointerToScriptVariable(thread);
+
+    OPCODE_WRITE_PARAM_PTR(ptr);
+    return OR_CONTINUE;
+  }
+
+  // 0AC8=2,  allocate_memory size %1d% store_to %2d%
+  static OpcodeResult __stdcall opcode_0AC8(CLEO::CRunningScript *thread) {
+    // collect params
+    int size = OPCODE_READ_PARAM_INT();
+
+    // validate params
+    if (size <= 0) {
+      SHOW_ERROR("Invalid '%d' size argument in script %s\nScript suspended.",
+                 size, ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
+    }
+
+    // perform
+    void *mem = calloc(size, 1);
+    if (mem) {
+      DWORD oldProtect;
+      VirtualProtect(mem, size, PAGE_EXECUTE_READWRITE, &oldProtect);
+
+      Instance.RegisterMemoryAllocation(thread, mem, size);
+
+      const auto &info = Instance.m_scriptAllocationsInfo[thread];
+      if (Instance.m_configLimitAllocationSize > 0 &&
+          info.size > Instance.m_configLimitAllocationSize) {
+        LOG_WARNING(thread, "%d MB of memory currently allocated by script %s",
+                    info.size / (1024 * 1024), ScriptInfoStr(thread).c_str());
+      } else if (Instance.m_configLimitAllocationCount > 0 &&
+                 info.count > Instance.m_configLimitAllocationCount) {
+        LOG_WARNING(
+            thread,
+            "More than %d memory blocks currently allocated by script %s",
+            Instance.m_configLimitAllocationCount,
+            ScriptInfoStr(thread).c_str());
+      }
+    } else
+      LOG_WARNING(thread, "Failed to allocate %d bytes of memory in script %s",
+                  size, ScriptInfoStr(thread).c_str());
+
+    OPCODE_WRITE_PARAM_PTR(mem);
+    OPCODE_CONDITION_RESULT(mem != nullptr);
+    return OR_CONTINUE;
+  }
+
+  // 0AC9=1,free_memory %1d%
+  static OpcodeResult __stdcall opcode_0AC9(CLEO::CRunningScript *thread) {
+    // collect params
+    auto address = OPCODE_READ_PARAM_PTR();
+
+    // validate params
+    if (Instance.m_allocations.find(address) == Instance.m_allocations.end()) {
+      LOG_WARNING(thread,
+                  "Invalid '0x%X' pointer param to unknown or already freed "
+                  "memory in script %s",
+                  address, ScriptInfoStr(thread).c_str());
+      return OR_CONTINUE;
+    }
+
+    free(address);
+
+    Instance.UnregisterMemoryAllocation(thread, address);
+
+    return OR_CONTINUE; // done
+  }
+
+  // 0AE9=1,pop_float store_to %1d%
+  static OpcodeResult __stdcall opcode_0AE9(CLEO::CRunningScript *thread) {
+    float result;
+    _asm fstp result
 
         OPCODE_WRITE_PARAM_FLOAT(result);
-        return OR_CONTINUE;
+    return OR_CONTINUE;
+  }
+
+  // 0AEA=2,get_ped_ref %1d% store_to %2d%
+  static OpcodeResult __stdcall opcode_0AEA(CLEO::CRunningScript *thread) {
+    // collect params
+    auto ptr = (CPed *)OPCODE_READ_PARAM_PTR();
+
+    int handle = -1;
+    if (!CPools::ms_pPedPool->IsObjectValid(ptr)) {
+      OPCODE_WRITE_PARAM_INT(-1); // invalid handle
+      return OR_CONTINUE;
     }
 
-    //0AEA=2,get_ped_ref %1d% store_to %2d%
-    static OpcodeResult __stdcall opcode_0AEA(CLEO::CRunningScript* thread)
-    {
-        // collect params
-        auto ptr = (CPed*)OPCODE_READ_PARAM_PTR();
+    handle = CPools::GetPedRef(ptr);
 
-        int handle = -1;
-        if (!CPools::ms_pPedPool->IsObjectValid(ptr))
-        {
-            OPCODE_WRITE_PARAM_INT(-1); // invalid handle
-            return OR_CONTINUE;
-        }
+    OPCODE_WRITE_PARAM_INT(handle);
+    return OR_CONTINUE;
+  }
 
-        handle = CPools::GetPedRef(ptr);
+  // 0AEB=2,get_vehicle_ref %1d% store_to %2d%
+  static OpcodeResult __stdcall opcode_0AEB(CLEO::CRunningScript *thread) {
+    auto ptr = (CVehicle *)OPCODE_READ_PARAM_PTR();
 
-        OPCODE_WRITE_PARAM_INT(handle);
-        return OR_CONTINUE;
+    int handle = -1;
+    if (!CPools::ms_pVehiclePool->IsObjectValid(ptr)) {
+      OPCODE_WRITE_PARAM_INT(-1); // invalid handle
+      return OR_CONTINUE;
     }
 
-    //0AEB=2,get_vehicle_ref %1d% store_to %2d%
-    static OpcodeResult __stdcall opcode_0AEB(CLEO::CRunningScript* thread)
-    {
-        auto ptr = (CVehicle*)OPCODE_READ_PARAM_PTR();
+    handle = CPools::GetVehicleRef(ptr);
 
-        int handle = -1;
-        if (!CPools::ms_pVehiclePool->IsObjectValid(ptr))
-        {
-            OPCODE_WRITE_PARAM_INT(-1); // invalid handle
-            return OR_CONTINUE;
-        }
+    OPCODE_WRITE_PARAM_INT(handle);
+    return OR_CONTINUE;
+  }
 
-        handle = CPools::GetVehicleRef(ptr);
+  // 0AEC=2,get_object_ref %1d% store_to %2d%
+  static OpcodeResult __stdcall opcode_0AEC(CLEO::CRunningScript *thread) {
+    auto ptr = (CObject *)OPCODE_READ_PARAM_PTR();
 
-        OPCODE_WRITE_PARAM_INT(handle);
-        return OR_CONTINUE;
+    int handle = -1;
+    if (!CPools::ms_pObjectPool->IsObjectValid(ptr)) {
+      OPCODE_WRITE_PARAM_INT(-1); // invalid handle
+      return OR_CONTINUE;
     }
 
-    //0AEC=2,get_object_ref %1d% store_to %2d%
-    static OpcodeResult __stdcall opcode_0AEC(CLEO::CRunningScript* thread)
-    {
-        auto ptr = (CObject*)OPCODE_READ_PARAM_PTR();
+    handle = CPools::GetObjectRef(ptr);
 
-        int handle = -1;
-        if (!CPools::ms_pObjectPool->IsObjectValid(ptr))
-        {
-            OPCODE_WRITE_PARAM_INT(-1); // invalid handle
-            return OR_CONTINUE;
-        }
+    OPCODE_WRITE_PARAM_INT(handle);
+    return OR_CONTINUE;
+  }
 
-        handle = CPools::GetObjectRef(ptr);
+  // 2400=3,copy_memory %1d% to %2d% size %3d%
+  static OpcodeResult __stdcall opcode_2400(CLEO::CRunningScript *thread) {
+    auto src = (BYTE *)OPCODE_READ_PARAM_PTR();
+    auto trg = (BYTE *)OPCODE_READ_PARAM_PTR();
+    auto size = OPCODE_READ_PARAM_INT();
 
-        OPCODE_WRITE_PARAM_INT(handle);
-        return OR_CONTINUE;
+    if (size == 0) {
+      return OR_CONTINUE; // done
+    }
+    if (size < 0) {
+      SHOW_ERROR("Invalid '%d' size argument in script %s\nScript suspended.",
+                 size, ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
     }
 
-    //2400=3,copy_memory %1d% to %2d% size %3d%
-    static OpcodeResult __stdcall opcode_2400(CLEO::CRunningScript* thread)
-    {
-        auto src = (BYTE*)OPCODE_READ_PARAM_PTR();
-        auto trg = (BYTE*)OPCODE_READ_PARAM_PTR();
-        auto size = OPCODE_READ_PARAM_INT();
+    memmove((void *)trg, (void *)src, size);
+    return OR_CONTINUE;
+  }
 
-        if (size == 0)
-        {
-            return OR_CONTINUE; // done
-        }
-        if (size < 0)
-        {
-            SHOW_ERROR("Invalid '%d' size argument in script %s\nScript suspended.", size, ScriptInfoStr(thread).c_str());
-            return thread->Suspend();
-        }
+  // 2401=4,read_memory_with_offset %1d% offset %2d% size %3d% store_to %4d%
+  static OpcodeResult __stdcall opcode_2401(CLEO::CRunningScript *thread) {
+    auto ptr = (BYTE *)OPCODE_READ_PARAM_PTR();
+    auto offset = OPCODE_READ_PARAM_INT();
+    auto size = OPCODE_READ_PARAM_INT();
 
-        memmove((void*)trg, (void*)src, size);
-        return OR_CONTINUE;
+    if (size < 0) {
+      SHOW_ERROR("Invalid '%d' size argument in script %s\nScript suspended.",
+                 size, ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
     }
 
-    //2401=4,read_memory_with_offset %1d% offset %2d% size %3d% store_to %4d%
-    static OpcodeResult __stdcall opcode_2401(CLEO::CRunningScript* thread)
-    {
-        auto ptr = (BYTE*)OPCODE_READ_PARAM_PTR();
-        auto offset = OPCODE_READ_PARAM_INT();
-        auto size = OPCODE_READ_PARAM_INT();
-
-        if (size < 0)
-        {
-            SHOW_ERROR("Invalid '%d' size argument in script %s\nScript suspended.", size, ScriptInfoStr(thread).c_str());
-            return thread->Suspend();
-        }
-
-        auto resultType = thread->PeekDataType();
-        if (IsVariable(resultType))
-        {
-            if (size == 0)
-            {
-                OPCODE_WRITE_PARAM_ANY32(0);
-                return OR_CONTINUE; // done
-            }
-
-            DWORD result = 0;
-            if (size > sizeof(result))
-            {
-                LOG_WARNING(thread, "Size '%d' argument out of supported range (%d) in script %s", size, sizeof(result), ScriptInfoStr(thread).c_str());
-                size = sizeof(result);
-            }
-            if (size > 0) memcpy(&result, (void*)(ptr + offset), size);
-
-            OPCODE_WRITE_PARAM_ANY32(result);
-            return OR_CONTINUE;
-        }
-        else if (IsVarString(resultType))
-        {
-            std::string str(std::string_view((char*)ptr + offset, size)); // null terminated
-            OPCODE_WRITE_PARAM_STRING(str.c_str());
-            return OR_CONTINUE;
-        }
-
-        SHOW_ERROR("Invalid type (%s) of the result argument in script %s \nScript suspended.", ToKindStr(resultType), ScriptInfoStr(thread).c_str());
-        return thread->Suspend();
-    }
-
-    //2402=4,write_memory_with_offset %1d% offset %2d% size %3d% value %4d%
-    static OpcodeResult __stdcall opcode_2402(CLEO::CRunningScript* thread)
-    {
-        auto ptr = (BYTE*)OPCODE_READ_PARAM_PTR();
-        auto offset = OPCODE_READ_PARAM_INT();
-        auto size = OPCODE_READ_PARAM_INT();
-
-        if (size < 0)
-        {
-            SHOW_ERROR("Invalid '%d' size argument in script %s\nScript suspended.", size, ScriptInfoStr(thread).c_str());
-            return thread->Suspend();
-        }
-
-        if (size == 0)
-        {
-            CLEO_SkipOpcodeParams(thread, 1); // value not used
-            return OR_CONTINUE; // done
-        }
-
-        auto valueType = thread->PeekDataType();
-        if (IsImmInteger(valueType) || IsImmFloat(valueType) || IsVariable(valueType))
-        {
-            if (size > sizeof(DWORD))
-            {
-                LOG_WARNING(thread, "Size '%d' argument out of supported range (%d) in script %s", size, sizeof(DWORD), ScriptInfoStr(thread).c_str());
-                size = sizeof(DWORD);
-            }
-
-            auto value = OPCODE_READ_PARAM_ANY32();
-            memcpy(ptr + offset, &value, size);
-
-            return OR_CONTINUE;
-        }
-        else if (IsImmString(valueType) || IsVarString(valueType))
-        {
-            OPCODE_READ_PARAM_STRING(str);
-            auto len = (int)strlen(str);
-
-            memcpy(ptr + offset, str, std::min(size, len));
-            if (size > len) ZeroMemory(ptr + offset + len, size - len); // fill rest with zeros
-
-            return OR_CONTINUE;
-        }
-
-        SHOW_ERROR("Invalid type (%s) of the input argument #%d in script %s \nScript suspended.", CLEO_GetParamsHandledCount(), ToKindStr(valueType), ScriptInfoStr(thread).c_str());
-        return thread->Suspend();
-    }
-
-    //2403=1,forget_memory %1d%
-    static OpcodeResult __stdcall opcode_2403(CLEO::CRunningScript* thread)
-    {
-        // collect params
-        auto address = OPCODE_READ_PARAM_PTR();
-
-        // validate params
-        if (Instance.m_allocations.find(address) == Instance.m_allocations.end())
-        {
-            LOG_WARNING(thread, "Invalid '0x%X' pointer param to unknown or already freed memory in script %s", address, ScriptInfoStr(thread).c_str());
-            return OR_CONTINUE;
-        }
-
-        Instance.UnregisterMemoryAllocation(thread, address);
-
+    auto resultType = thread->PeekDataType();
+    if (IsVariable(resultType)) {
+      if (size == 0) {
+        OPCODE_WRITE_PARAM_ANY32(0);
         return OR_CONTINUE; // done
+      }
+
+      DWORD result = 0;
+      if (size > sizeof(result)) {
+        LOG_WARNING(
+            thread,
+            "Size '%d' argument out of supported range (%d) in script %s", size,
+            sizeof(result), ScriptInfoStr(thread).c_str());
+        size = sizeof(result);
+      }
+      if (size > 0)
+        memcpy(&result, (void *)(ptr + offset), size);
+
+      OPCODE_WRITE_PARAM_ANY32(result);
+      return OR_CONTINUE;
+    } else if (IsVarString(resultType)) {
+      std::string str(
+          std::string_view((char *)ptr + offset, size)); // null terminated
+      OPCODE_WRITE_PARAM_STRING(str.c_str());
+      return OR_CONTINUE;
     }
 
-    //2404=1,get_script_struct_just_created %1d%
-    static OpcodeResult __stdcall opcode_2404(CLEO::CRunningScript* thread)
-    {
-        auto head = thread;
-        while(head->Previous)
-        {
-            head = head->Previous;
-        }
+    SHOW_ERROR("Invalid type (%s) of the result argument in script %s \nScript "
+               "suspended.",
+               ToKindStr(resultType), ScriptInfoStr(thread).c_str());
+    return thread->Suspend();
+  }
 
-        OPCODE_WRITE_PARAM_PTR(head);
-        return OR_CONTINUE;
+  // 2402=4,write_memory_with_offset %1d% offset %2d% size %3d% value %4d%
+  static OpcodeResult __stdcall opcode_2402(CLEO::CRunningScript *thread) {
+    auto ptr = (BYTE *)OPCODE_READ_PARAM_PTR();
+    auto offset = OPCODE_READ_PARAM_INT();
+    auto size = OPCODE_READ_PARAM_INT();
+
+    if (size < 0) {
+      SHOW_ERROR("Invalid '%d' size argument in script %s\nScript suspended.",
+                 size, ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
     }
 
-    //2405=1,  is_script_running %1d%
-    static OpcodeResult __stdcall opcode_2405(CLEO::CRunningScript* thread)
-    {
-        auto address = (CLEO::CRunningScript*)OPCODE_READ_PARAM_INT(); // allow invalid pointers too
-
-        auto running = CLEO_IsScriptRunning(address);
-
-        OPCODE_CONDITION_RESULT(running);
-        return OR_CONTINUE;
+    if (size == 0) {
+      CLEO_SkipOpcodeParams(thread, 1); // value not used
+      return OR_CONTINUE;               // done
     }
 
-    //2406=1,  get_script_struct_from_filename %1s%
-    static OpcodeResult __stdcall opcode_2406(CLEO::CRunningScript* thread)
-    {
-        OPCODE_READ_PARAM_STRING(filename);
+    auto valueType = thread->PeekDataType();
+    if (IsImmInteger(valueType) || IsImmFloat(valueType) ||
+        IsVariable(valueType)) {
+      if (size > sizeof(DWORD)) {
+        LOG_WARNING(
+            thread,
+            "Size '%d' argument out of supported range (%d) in script %s", size,
+            sizeof(DWORD), ScriptInfoStr(thread).c_str());
+        size = sizeof(DWORD);
+      }
 
-        auto address = CLEO_GetScriptByFilename(filename);
+      auto value = OPCODE_READ_PARAM_ANY32();
+      memcpy(ptr + offset, &value, size);
 
-        OPCODE_WRITE_PARAM_PTR(address);
-        OPCODE_CONDITION_RESULT(address != nullptr);
-        return OR_CONTINUE;
+      return OR_CONTINUE;
+    } else if (IsImmString(valueType) || IsVarString(valueType)) {
+      OPCODE_READ_PARAM_STRING(str);
+      auto len = (int)strlen(str);
+
+      memcpy(ptr + offset, str, std::min(size, len));
+      if (size > len)
+        ZeroMemory(ptr + offset + len, size - len); // fill rest with zeros
+
+      return OR_CONTINUE;
     }
 
-    //2407=3,  is_memory_equal address_a %1d% address_b %2d% size %d3%
-    static OpcodeResult __stdcall opcode_2407(CLEO::CRunningScript* thread)
-    {
-        auto addressA = OPCODE_READ_PARAM_PTR();
-        auto addressB = OPCODE_READ_PARAM_PTR();
-        auto size = OPCODE_READ_PARAM_INT();
+    SHOW_ERROR("Invalid type (%s) of the input argument #%d in script %s "
+               "\nScript suspended.",
+               CLEO_GetParamsHandledCount(), ToKindStr(valueType),
+               ScriptInfoStr(thread).c_str());
+    return thread->Suspend();
+  }
 
-        if (size == 0)
-        {
-            OPCODE_CONDITION_RESULT(true);
-            return OR_CONTINUE;
-        }
-        if (size < 0)
-        {
-            SHOW_ERROR("Invalid '%d' size argument in script %s\nScript suspended.", size, ScriptInfoStr(thread).c_str());
-            return thread->Suspend();
-        }
+  // 2403=1,forget_memory %1d%
+  static OpcodeResult __stdcall opcode_2403(CLEO::CRunningScript *thread) {
+    // collect params
+    auto address = OPCODE_READ_PARAM_PTR();
 
-        auto result = memcmp(addressA, addressB, size);
-
-        OPCODE_CONDITION_RESULT(result == 0);
-        return OR_CONTINUE;
+    // validate params
+    if (Instance.m_allocations.find(address) == Instance.m_allocations.end()) {
+      LOG_WARNING(thread,
+                  "Invalid '0x%X' pointer param to unknown or already freed "
+                  "memory in script %s",
+                  address, ScriptInfoStr(thread).c_str());
+      return OR_CONTINUE;
     }
 
-    //2408=1,terminate_script %1d%
-    static OpcodeResult __stdcall opcode_2408(CLEO::CRunningScript* thread)
-    {
-        auto address = (CLEO::CRunningScript*)OPCODE_READ_PARAM_PTR();
+    Instance.UnregisterMemoryAllocation(thread, address);
 
-        CLEO_TerminateScript(address);
+    return OR_CONTINUE; // done
+  }
 
-        return (address == thread) ? OR_INTERRUPT : OR_CONTINUE;
+  // 2404=1,get_script_struct_just_created %1d%
+  static OpcodeResult __stdcall opcode_2404(CLEO::CRunningScript *thread) {
+    auto head = thread;
+    while (head->Previous) {
+      head = head->Previous;
     }
+
+    OPCODE_WRITE_PARAM_PTR(head);
+    return OR_CONTINUE;
+  }
+
+  // 2405=1,  is_script_running %1d%
+  static OpcodeResult __stdcall opcode_2405(CLEO::CRunningScript *thread) {
+    auto address = (CLEO::CRunningScript *)
+        OPCODE_READ_PARAM_INT(); // allow invalid pointers too
+
+    auto running = CLEO_IsScriptRunning(address);
+
+    OPCODE_CONDITION_RESULT(running);
+    return OR_CONTINUE;
+  }
+
+  // 2406=1,  get_script_struct_from_filename %1s%
+  static OpcodeResult __stdcall opcode_2406(CLEO::CRunningScript *thread) {
+    OPCODE_READ_PARAM_STRING(filename);
+
+    auto address = CLEO_GetScriptByFilename(filename);
+
+    OPCODE_WRITE_PARAM_PTR(address);
+    OPCODE_CONDITION_RESULT(address != nullptr);
+    return OR_CONTINUE;
+  }
+
+  // 2407=3,  is_memory_equal address_a %1d% address_b %2d% size %d3%
+  static OpcodeResult __stdcall opcode_2407(CLEO::CRunningScript *thread) {
+    auto addressA = OPCODE_READ_PARAM_PTR();
+    auto addressB = OPCODE_READ_PARAM_PTR();
+    auto size = OPCODE_READ_PARAM_INT();
+
+    if (size == 0) {
+      OPCODE_CONDITION_RESULT(true);
+      return OR_CONTINUE;
+    }
+    if (size < 0) {
+      SHOW_ERROR("Invalid '%d' size argument in script %s\nScript suspended.",
+                 size, ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
+    }
+
+    auto result = memcmp(addressA, addressB, size);
+
+    OPCODE_CONDITION_RESULT(result == 0);
+    return OR_CONTINUE;
+  }
+
+  // 2408=1,terminate_script %1d%
+  static OpcodeResult __stdcall opcode_2408(CLEO::CRunningScript *thread) {
+    auto address = (CLEO::CRunningScript *)OPCODE_READ_PARAM_PTR();
+
+    CLEO_TerminateScript(address);
+
+    return (address == thread) ? OR_INTERRUPT : OR_CONTINUE;
+  }
 } Instance;
-

--- a/cleo_plugins/Text/CTextManager.cpp
+++ b/cleo_plugins/Text/CTextManager.cpp
@@ -2,194 +2,166 @@
 #include "..\cleo_sdk\CLEO_Utils.h"
 #include "CFileMgr.h"
 #include "CText.h"
-#include <wtypes.h>
 #include <direct.h>
 #include <filesystem>
 #include <fstream>
 #include <set>
 #include <sstream>
 #include <string>
+#include <wtypes.h>
 
 namespace FS = std::filesystem;
 
-namespace CLEO
-{
-    CTextManager::CTextManager() : fxts(1, crc32FromUpcaseStdString)
-    {
+namespace CLEO {
+CTextManager::CTextManager() : fxts(1, crc32FromUpcaseStdString) {}
+
+const char *CTextManager::Get(const char *key) { return TheText.Get(key); }
+
+bool CTextManager::AddFxt(const char *key, const char *value, bool dynamic) {
+  auto fxt = fxts.find(key);
+
+  if (fxt != fxts.end()) {
+    if (fxt->second->text.compare(value) == 0)
+      return true; // already present
+
+    if (!dynamic || fxt->second->is_static) {
+      LOG_WARNING(0, "Attempting to add FXT \'%s\' - FAILED (GXT conflict)",
+                  key, value);
+      return false;
     }
 
-    const char* CTextManager::Get(const char* key)
-    {
-        return TheText.Get(key);
-    }
+    fxt->second->text = value;
+  } else {
+    std::string str = key;
+    std::transform(str.begin(), str.end(), str.begin(), ::toupper);
+    fxts[str.c_str()] = new FxtEntry(value, !dynamic);
+  }
 
-    bool CTextManager::AddFxt(const char *key, const char *value, bool dynamic)
-    {
-        auto fxt = fxts.find(key);
-
-        if (fxt != fxts.end())
-        {
-            if (fxt->second->text.compare(value) == 0)
-                return true; // already present
-
-            if (!dynamic || fxt->second->is_static)
-            {
-                LOG_WARNING(0, "Attempting to add FXT \'%s\' - FAILED (GXT conflict)", key, value);
-                return false;
-            }
-
-            fxt->second->text = value;
-        }
-        else
-        {
-            std::string str = key;
-            std::transform(str.begin(), str.end(), str.begin(), ::toupper);
-            fxts[str.c_str()] = new FxtEntry(value, !dynamic);
-        }
-
-        return true;
-    }
-
-    bool CTextManager::RemoveFxt(const char *key)
-    {
-        return fxts.erase(key) != 0;
-    }
-
-    const char *CTextManager::LocateFxt(const char *key)
-    {
-        std::string str = key;
-        std::transform(str.begin(), str.end(), str.begin(), ::toupper);
-        const_fxt_iterator found = fxts.find(str);
-        if (found == fxts.end()) return nullptr;
-        return found->second->text.c_str();
-    }
-
-    void CTextManager::ClearDynamicFxts()
-    {
-        TRACE("Deleting dynamic fxts...");
-        for (auto it = fxts.begin(); it != fxts.end();)
-        {
-            if (!it->second->is_static)
-            {
-                delete it->second;
-                fxts.erase(it++);
-            }
-            else ++it;
-        }
-    }
-
-    CTextManager::~CTextManager()
-    {
-        TRACE(""); // separator
-        TRACE("Deleting FXTs...");
-        size_t count = 0;
-        for (auto it = fxts.begin(); it != fxts.end();)
-        {
-            delete it->second;
-            fxts.erase(it++);
-            ++count;
-        }
-    }
-
-    void CTextManager::LoadFxts()
-    {
-        TRACE(""); // separator
-        TRACE("Loading CLEO text files...");
-
-        // create FXT directory if not present yet
-        FS::create_directory(std::string(CLEO_GetGameDirectory()) + "\\cleo\\cleo_text");
-
-        // load whole FXT files directory
-        auto list = CLEO::CLEO_ListDirectory(nullptr, "cleo\\cleo_text\\*.fxt", false, true);
-        for (DWORD i = 0; i < list.count; i++)
-        {
-            try
-            {
-                std::ifstream stream(list.strings[i]);
-                auto result = ParseFxtFile(stream);
-                TRACE(" Added %d new FXT entries from file '%s'", result, list.strings[i]);
-            }
-            catch (std::exception& ex)
-            {
-                LOG_WARNING(0, " Loading of FXT file '%s' failed: \n%s", list.strings[i], ex.what());
-            }
-        }
-        CLEO::CLEO_StringListFree(list);
-
-        TRACE(""); // separator
-    }
-
-    void CTextManager::Clear()
-    {
-        fxts.clear();
-    }
-
-    CTextManager::FxtEntry::FxtEntry(const char *_text, bool _static) : text(_text), is_static(_static)
-    {
-    }
-
-    size_t CTextManager::ParseFxtFile(std::istream& stream, bool dynamic, bool remove)
-    {
-        static char buf[0x100];
-        char *key_iterator, *value_iterator, *value_start, *key_start;
-        stream.exceptions(std::ios::badbit);
-
-        size_t keyCount = 0;
-        while (true)
-        {
-            if (stream.eof()) break;
-
-            stream.getline(buf, sizeof(buf));
-            if (stream.fail()) break;
-
-            // parse extracted line	
-            key_start = key_iterator = buf;
-            while (*key_iterator)
-            {
-                if (*key_iterator == '#')	// start of comment
-                    break;
-                if (*key_iterator == '/' && key_iterator[1] == '/') // comment
-                    break;
-
-                if (isspace(*key_iterator))
-                {
-                    *key_iterator = '\0'; // terminate key string
-
-                    if (remove)
-                    {
-                        if (RemoveFxt(key_start))
-                        {
-                            keyCount++;
-                        }
-                        break;
-                    }
-
-                    // while (isspace(*++key_iterator)) ; // skip leading spaces
-                    value_start = value_iterator = key_iterator + 1;
-                    while (*value_iterator)
-                    {
-                        // start of comment
-                        if (*value_iterator == '#' || (*key_iterator == '/' && key_iterator[1] == '/'))
-                        {
-                            *value_iterator = '\0';
-                            break;
-                        }
-                        break;
-                        value_iterator++;
-                    }
-
-                    // register found fxt entry
-                    if (AddFxt(key_start, value_start, dynamic))
-                    {
-                        keyCount++;
-                    }
-
-                    break;
-                }
-                key_iterator++;
-            }
-        }
-
-        return keyCount;
-    }
+  return true;
 }
+
+bool CTextManager::RemoveFxt(const char *key) { return fxts.erase(key) != 0; }
+
+const char *CTextManager::LocateFxt(const char *key) {
+  std::string str = key;
+  std::transform(str.begin(), str.end(), str.begin(), ::toupper);
+  const_fxt_iterator found = fxts.find(str);
+  if (found == fxts.end())
+    return nullptr;
+  return found->second->text.c_str();
+}
+
+void CTextManager::ClearDynamicFxts() {
+  TRACE("Deleting dynamic fxts...");
+  for (auto it = fxts.begin(); it != fxts.end();) {
+    if (!it->second->is_static) {
+      delete it->second;
+      fxts.erase(it++);
+    } else
+      ++it;
+  }
+}
+
+CTextManager::~CTextManager() {
+  TRACE(""); // separator
+  TRACE("Deleting FXTs...");
+  size_t count = 0;
+  for (auto it = fxts.begin(); it != fxts.end();) {
+    delete it->second;
+    fxts.erase(it++);
+    ++count;
+  }
+}
+
+void CTextManager::LoadFxts() {
+  TRACE(""); // separator
+  TRACE("Loading CLEO text files...");
+
+  // create FXT directory if not present yet
+  FS::create_directory(std::string(CLEO_GetGameDirectory()) +
+                       "\\cleo\\cleo_text");
+
+  // load whole FXT files directory
+  auto list =
+      CLEO::CLEO_ListDirectory(nullptr, "cleo\\cleo_text\\*.fxt", false, true);
+  for (DWORD i = 0; i < list.count; i++) {
+    try {
+      std::ifstream stream(list.strings[i]);
+      auto result = ParseFxtFile(stream);
+      TRACE(" Added %d new FXT entries from file '%s'", result,
+            list.strings[i]);
+    } catch (std::exception &ex) {
+      LOG_WARNING(0, " Loading of FXT file '%s' failed: \n%s", list.strings[i],
+                  ex.what());
+    }
+  }
+  CLEO::CLEO_StringListFree(list);
+
+  TRACE(""); // separator
+}
+
+void CTextManager::Clear() { fxts.clear(); }
+
+CTextManager::FxtEntry::FxtEntry(const char *_text, bool _static)
+    : text(_text), is_static(_static) {}
+
+size_t CTextManager::ParseFxtFile(std::istream &stream, bool dynamic,
+                                  bool remove) {
+  static char buf[0x100];
+  char *key_iterator, *value_iterator, *value_start, *key_start;
+  stream.exceptions(std::ios::badbit);
+
+  size_t keyCount = 0;
+  while (true) {
+    if (stream.eof())
+      break;
+
+    stream.getline(buf, sizeof(buf));
+    if (stream.fail())
+      break;
+
+    // parse extracted line
+    key_start = key_iterator = buf;
+    while (*key_iterator) {
+      if (*key_iterator == '#') // start of comment
+        break;
+      if (*key_iterator == '/' && key_iterator[1] == '/') // comment
+        break;
+
+      if (isspace(*key_iterator)) {
+        *key_iterator = '\0'; // terminate key string
+
+        if (remove) {
+          if (RemoveFxt(key_start)) {
+            keyCount++;
+          }
+          break;
+        }
+
+        // while (isspace(*++key_iterator)) ; // skip leading spaces
+        value_start = value_iterator = key_iterator + 1;
+        while (*value_iterator) {
+          // start of comment
+          if (*value_iterator == '#' ||
+              (*key_iterator == '/' && key_iterator[1] == '/')) {
+            *value_iterator = '\0';
+            break;
+          }
+          break;
+          value_iterator++;
+        }
+
+        // register found fxt entry
+        if (AddFxt(key_start, value_start, dynamic)) {
+          keyCount++;
+        }
+
+        break;
+      }
+      key_iterator++;
+    }
+  }
+
+  return keyCount;
+}
+} // namespace CLEO

--- a/cleo_plugins/Text/CTextManager.h
+++ b/cleo_plugins/Text/CTextManager.h
@@ -4,37 +4,37 @@
 #include <string>
 #include <unordered_map>
 
-namespace CLEO
-{
-    class CTextManager
-    {
-        class FxtEntry
-        {
-            friend class CTextManager;
-            std::string text;
-            bool is_static;
-            FxtEntry(const char *_text, bool _static = false);
-        };
+namespace CLEO {
+class CTextManager {
+  class FxtEntry {
+    friend class CTextManager;
+    std::string text;
+    bool is_static;
+    FxtEntry(const char *_text, bool _static = false);
+  };
 
-        typedef std::unordered_map<std::string, FxtEntry *, decltype(&crc32FromUpcaseStdString)> fxt_map_type;
-        typedef fxt_map_type::iterator fxt_iterator;
-        typedef fxt_map_type::const_iterator const_fxt_iterator;
-        fxt_map_type fxts;
+  typedef std::unordered_map<std::string, FxtEntry *,
+                             decltype(&crc32FromUpcaseStdString)>
+      fxt_map_type;
+  typedef fxt_map_type::iterator fxt_iterator;
+  typedef fxt_map_type::const_iterator const_fxt_iterator;
+  fxt_map_type fxts;
 
-    public:
-        CTextManager();
-        ~CTextManager();
+public:
+  CTextManager();
+  ~CTextManager();
 
-        void LoadFxts();
-        void Clear();
+  void LoadFxts();
+  void Clear();
 
-        const char* Get(const char* key);
-        bool AddFxt(const char *key, const char *value, bool dynamic = true);
-        bool RemoveFxt(const char *key);
-        // find fxt text by its key
-        const char *LocateFxt(const char *key);
-        // erase all fxts, added by scripts
-        void ClearDynamicFxts();
-        size_t ParseFxtFile(std::istream& stream, bool dynamic = false, bool remove = false);
-    };
-}
+  const char *Get(const char *key);
+  bool AddFxt(const char *key, const char *value, bool dynamic = true);
+  bool RemoveFxt(const char *key);
+  // find fxt text by its key
+  const char *LocateFxt(const char *key);
+  // erase all fxts, added by scripts
+  void ClearDynamicFxts();
+  size_t ParseFxtFile(std::istream &stream, bool dynamic = false,
+                      bool remove = false);
+};
+} // namespace CLEO

--- a/cleo_plugins/Text/ScriptDrawing.cpp
+++ b/cleo_plugins/Text/ScriptDrawing.cpp
@@ -6,75 +6,72 @@
 
 using namespace CLEO;
 
+void ScriptDrawing::ScriptProcessingBegin(CLEO::CRunningScript *script) {
+  if (!script->IsCustom())
+    return;
 
-void ScriptDrawing::ScriptProcessingBegin(CLEO::CRunningScript* script)
-{
-    if (!script->IsCustom()) return;
+  m_globalDrawingState.Store();
+  m_scriptDrawingStates[script].Apply(true); // initialize for new frame
 
-    m_globalDrawingState.Store();
-    m_scriptDrawingStates[script].Apply(true); // initialize for new frame
-
-    m_currCustomScript = script;
+  m_currCustomScript = script;
 }
 
-void ScriptDrawing::ScriptProcessingEnd(CLEO::CRunningScript* script)
-{
-    if (!script->IsCustom()) return;
+void ScriptDrawing::ScriptProcessingEnd(CLEO::CRunningScript *script) {
+  if (!script->IsCustom())
+    return;
 
-    if (script->IsActive()) m_scriptDrawingStates[script].Store();
-    m_globalDrawingState.Apply();
+  if (script->IsActive())
+    m_scriptDrawingStates[script].Store();
+  m_globalDrawingState.Apply();
 
-    m_currCustomScript = nullptr;
+  m_currCustomScript = nullptr;
 }
 
-void ScriptDrawing::ScriptUnregister(CLEO::CRunningScript* script)
-{
-    if (!script->IsCustom()) return;
+void ScriptDrawing::ScriptUnregister(CLEO::CRunningScript *script) {
+  if (!script->IsCustom())
+    return;
 
-    m_scriptDrawingStates.erase(script);
+  m_scriptDrawingStates.erase(script);
 }
 
-void ScriptDrawing::Draw(bool beforeFade)
-{
-    if (std::all_of(m_scriptDrawingStates.cbegin(), m_scriptDrawingStates.cend(), [](auto& p) { return p.second.IsEmpty(); }))
-    {
-        return; // no custom scripts with draws
-    }
+void ScriptDrawing::Draw(bool beforeFade) {
+  if (std::all_of(m_scriptDrawingStates.cbegin(), m_scriptDrawingStates.cend(),
+                  [](auto &p) { return p.second.IsEmpty(); })) {
+    return; // no custom scripts with draws
+  }
 
-    m_globalDrawingState.Store();
+  m_globalDrawingState.Store();
 
-    for(auto& [script, state] : m_scriptDrawingStates)
-    {
-        if (state.IsEmpty()) continue;
+  for (auto &[script, state] : m_scriptDrawingStates) {
+    if (state.IsEmpty())
+      continue;
 
-        state.Apply();
-        CHud::DrawScriptText(beforeFade);
-    }
+    state.Apply();
+    CHud::DrawScriptText(beforeFade);
+  }
 
-    m_globalDrawingState.Apply();
+  m_globalDrawingState.Apply();
 }
 
-RwTexture* ScriptDrawing::GetScriptTexture(CLEO::CRunningScript* script, DWORD slot)
-{
-    if (script == nullptr || slot == 0 || slot > _countof(CTheScripts::ScriptSprites))
-    {
-        return nullptr; // invalid param
-    }
-    slot -= 1; // to 0-based index
+RwTexture *ScriptDrawing::GetScriptTexture(CLEO::CRunningScript *script,
+                                           DWORD slot) {
+  if (script == nullptr || slot == 0 ||
+      slot > _countof(CTheScripts::ScriptSprites)) {
+    return nullptr; // invalid param
+  }
+  slot -= 1; // to 0-based index
 
-    if (script->IsCustom())
-    {
-        if (script == m_currCustomScript)
-        {
-            return CTheScripts::ScriptSprites[slot].m_pTexture;
-        }
-        else
-        {
-            return (m_scriptDrawingStates.find(script) != m_scriptDrawingStates.end()) ? CTheScripts::ScriptSprites[slot].m_pTexture : nullptr;
-        }
+  if (script->IsCustom()) {
+    if (script == m_currCustomScript) {
+      return CTheScripts::ScriptSprites[slot].m_pTexture;
+    } else {
+      return (m_scriptDrawingStates.find(script) != m_scriptDrawingStates.end())
+                 ? CTheScripts::ScriptSprites[slot].m_pTexture
+                 : nullptr;
     }
-    else
-    {
-        return (m_currCustomScript == nullptr) ? CTheScripts::ScriptSprites[slot].m_pTexture : m_globalDrawingState.sprites[slot].m_pTexture;
-    }
+  } else {
+    return (m_currCustomScript == nullptr)
+               ? CTheScripts::ScriptSprites[slot].m_pTexture
+               : m_globalDrawingState.sprites[slot].m_pTexture;
+  }
 }

--- a/cleo_plugins/Text/ScriptDrawing.h
+++ b/cleo_plugins/Text/ScriptDrawing.h
@@ -3,21 +3,20 @@
 #include "ScriptDrawsState.h"
 #include <map>
 
-
-class ScriptDrawing
-{
+class ScriptDrawing {
 public:
-    void ScriptProcessingBegin(CLEO::CRunningScript* script);
-    void ScriptProcessingEnd(CLEO::CRunningScript* script);
-    void ScriptUnregister(CLEO::CRunningScript* script);
+  void ScriptProcessingBegin(CLEO::CRunningScript *script);
+  void ScriptProcessingEnd(CLEO::CRunningScript *script);
+  void ScriptUnregister(CLEO::CRunningScript *script);
 
-    void Draw(bool beforeFade); // draw buffered script draws to screen
+  void Draw(bool beforeFade); // draw buffered script draws to screen
 
-    RwTexture* GetScriptTexture(CLEO::CRunningScript* script, DWORD slot);
+  RwTexture *GetScriptTexture(CLEO::CRunningScript *script, DWORD slot);
 
 private:
-    ScriptDrawsState m_globalDrawingState;
-    CLEO::CRunningScript* m_currCustomScript = nullptr; // currently processed script
-    std::map<CLEO::CRunningScript*, ScriptDrawsState> m_scriptDrawingStates; // buffered script draws
+  ScriptDrawsState m_globalDrawingState;
+  CLEO::CRunningScript *m_currCustomScript =
+      nullptr; // currently processed script
+  std::map<CLEO::CRunningScript *, ScriptDrawsState>
+      m_scriptDrawingStates; // buffered script draws
 };
-

--- a/cleo_plugins/Text/ScriptDrawsState.h
+++ b/cleo_plugins/Text/ScriptDrawsState.h
@@ -2,75 +2,75 @@
 #include <CTheScripts.h>
 #include <array>
 
+struct ScriptDrawsState {
+  eUseTextCommandState useTextCommands = eUseTextCommandState::DISABLED;
 
-struct ScriptDrawsState
-{
-    eUseTextCommandState useTextCommands = eUseTextCommandState::DISABLED;
+  WORD textsCount = 0;
+  std::array<tScriptText, _countof(CTheScripts::IntroTextLines)> texts;
 
-    WORD textsCount = 0;
-    std::array<tScriptText, _countof(CTheScripts::IntroTextLines)> texts;
-    
-    WORD rectanglesCount = 0;
-    std::array<tScriptRectangle, _countof(CTheScripts::IntroRectangles)> rectangles;
+  WORD rectanglesCount = 0;
+  std::array<tScriptRectangle, _countof(CTheScripts::IntroRectangles)>
+      rectangles;
 
-    std::array<CSprite2d, _countof(CTheScripts::ScriptSprites)> sprites;
+  std::array<CSprite2d, _countof(CTheScripts::ScriptSprites)> sprites;
 
-    ScriptDrawsState() = default;
-    ScriptDrawsState(const ScriptDrawsState&) = delete; // no copying!
-    ~ScriptDrawsState() = default;
+  ScriptDrawsState() = default;
+  ScriptDrawsState(const ScriptDrawsState &) = delete; // no copying!
+  ~ScriptDrawsState() = default;
 
-    void Store()
-    {
-        useTextCommands = CTheScripts::UseTextCommands;
+  void Store() {
+    useTextCommands = CTheScripts::UseTextCommands;
 
-        textsCount = CTheScripts::NumberOfIntroTextLinesThisFrame;
-        std::memcpy(texts.data(), CTheScripts::IntroTextLines, texts.size() * sizeof(tScriptText));
+    textsCount = CTheScripts::NumberOfIntroTextLinesThisFrame;
+    std::memcpy(texts.data(), CTheScripts::IntroTextLines,
+                texts.size() * sizeof(tScriptText));
 
-        rectanglesCount = CTheScripts::NumberOfIntroRectanglesThisFrame;
-        std::memcpy(rectangles.data(), CTheScripts::IntroRectangles, rectangles.size() * sizeof(tScriptRectangle));
+    rectanglesCount = CTheScripts::NumberOfIntroRectanglesThisFrame;
+    std::memcpy(rectangles.data(), CTheScripts::IntroRectangles,
+                rectangles.size() * sizeof(tScriptRectangle));
 
-        std::memcpy(sprites.data(), CTheScripts::ScriptSprites, sprites.size() * sizeof(CSprite2d));
-    }
+    std::memcpy(sprites.data(), CTheScripts::ScriptSprites,
+                sprites.size() * sizeof(CSprite2d));
+  }
 
-    void Apply(bool newFrame = false)
-    {
-        if (!newFrame)
-        {
-            CTheScripts::UseTextCommands = useTextCommands;
+  void Apply(bool newFrame = false) {
+    if (!newFrame) {
+      CTheScripts::UseTextCommands = useTextCommands;
 
-            // texts
-            CTheScripts::NumberOfIntroTextLinesThisFrame = textsCount;
-            std::memcpy(CTheScripts::IntroTextLines, texts.data(), texts.size() * sizeof(tScriptText));
+      // texts
+      CTheScripts::NumberOfIntroTextLinesThisFrame = textsCount;
+      std::memcpy(CTheScripts::IntroTextLines, texts.data(),
+                  texts.size() * sizeof(tScriptText));
 
-            // rectangles
-            CTheScripts::NumberOfIntroRectanglesThisFrame = rectanglesCount;
-            std::memcpy(CTheScripts::IntroRectangles, rectangles.data(), rectangles.size() * sizeof(tScriptRectangle));
-        }
-        else
-        {
-            CTheScripts::UseTextCommands = (useTextCommands == eUseTextCommandState::DISABLE_NEXT_FRAME) ? eUseTextCommandState::DISABLED : useTextCommands;
+      // rectangles
+      CTheScripts::NumberOfIntroRectanglesThisFrame = rectanglesCount;
+      std::memcpy(CTheScripts::IntroRectangles, rectangles.data(),
+                  rectangles.size() * sizeof(tScriptRectangle));
+    } else {
+      CTheScripts::UseTextCommands =
+          (useTextCommands == eUseTextCommandState::DISABLE_NEXT_FRAME)
+              ? eUseTextCommandState::DISABLED
+              : useTextCommands;
 
-            // texts
-            CTheScripts::NumberOfIntroTextLinesThisFrame = 0;
-            std::fill(
-                CTheScripts::IntroTextLines,
-                CTheScripts::IntroTextLines + _countof(CTheScripts::IntroTextLines),
+      // texts
+      CTheScripts::NumberOfIntroTextLinesThisFrame = 0;
+      std::fill(CTheScripts::IntroTextLines,
+                CTheScripts::IntroTextLines +
+                    _countof(CTheScripts::IntroTextLines),
                 tScriptText());
 
-            // rectangles
-            CTheScripts::NumberOfIntroRectanglesThisFrame = 0;
-            std::fill(
-                CTheScripts::IntroRectangles,
-                CTheScripts::IntroRectangles + _countof(CTheScripts::IntroRectangles),
+      // rectangles
+      CTheScripts::NumberOfIntroRectanglesThisFrame = 0;
+      std::fill(CTheScripts::IntroRectangles,
+                CTheScripts::IntroRectangles +
+                    _countof(CTheScripts::IntroRectangles),
                 tScriptRectangle());
-        }
-
-        // loaded textures
-        std::memcpy(CTheScripts::ScriptSprites, sprites.data(), sprites.size() * sizeof(CSprite2d));
     }
 
-    bool IsEmpty() const
-    {
-        return !rectanglesCount && !textsCount;
-    }
+    // loaded textures
+    std::memcpy(CTheScripts::ScriptSprites, sprites.data(),
+                sprites.size() * sizeof(CSprite2d));
+  }
+
+  bool IsEmpty() const { return !rectanglesCount && !textsCount; }
 };

--- a/cleo_plugins/Text/Text.cpp
+++ b/cleo_plugins/Text/Text.cpp
@@ -1,638 +1,612 @@
-﻿#include "plugin.h"
-#include "CLEO.h"
+﻿#include "CLEO.h"
 #include "CLEO_Utils.h"
-#include "ScriptDrawing.h"
 #include "CTextManager.h"
+#include "ScriptDrawing.h"
+#include "plugin.h"
 #include <CGame.h>
 #include <CHud.h>
 #include <CMessages.h>
 #include <CModelInfo.h>
-#include <CTheScripts.h>
 #include <CText.h>
+#include <CTheScripts.h>
 #include <shlwapi.h>
 
 using namespace CLEO;
 using namespace plugin;
 
-
-class Text
-{
+class Text {
 public:
-	static ScriptDrawing scriptDrawing;
-	static CTextManager textManager;
-	
-	static char msgBuffLow[MAX_STR_LEN + 1];
-	static char msgBuffHigh[MAX_STR_LEN + 1];
-	static const size_t MsgBigStyleCount = 7;
-	static char msgBuffBig[MsgBigStyleCount][MAX_STR_LEN + 1];
-
-	static WORD genericLabelCounter;
-
-	bool m_initialized = false;
-	MemPatch m_patchCTextGet;
-
-	Text()
-	{
-		if (!PluginCheckCleoVersion()) return;
-
-		//register opcodes
-		CLEO_RegisterOpcode(0x0ACA, opcode_0ACA); // print_help_string
-		CLEO_RegisterOpcode(0x0ACB, opcode_0ACB); // print_big_string
-		CLEO_RegisterOpcode(0x0ACC, opcode_0ACC); // print_string
-		CLEO_RegisterOpcode(0x0ACD, opcode_0ACD); // print_string_now
-		CLEO_RegisterOpcode(0x0ACE, opcode_0ACE); // print_help_formatted
-		CLEO_RegisterOpcode(0x0ACF, opcode_0ACF); // print_big_formatted
-		CLEO_RegisterOpcode(0x0AD0, opcode_0AD0); // print_formatted
-		CLEO_RegisterOpcode(0x0AD1, opcode_0AD1); // print_formatted_now
-
-		CLEO_RegisterOpcode(0x0AD3, opcode_0AD3); // string_format
-		CLEO_RegisterOpcode(0x0AD4, opcode_0AD4); // scan_string
-		CLEO_RegisterOpcode(0x0ADB, opcode_0ADB); // get_name_of_vehicle_model
-							    
-		CLEO_RegisterOpcode(0x0ADE, opcode_0ADE); // get_text_label_string
-		CLEO_RegisterOpcode(0x0ADF, opcode_0ADF); // add_text_label
-		CLEO_RegisterOpcode(0x0AE0, opcode_0AE0); // remove_text_label
-							    
-		CLEO_RegisterOpcode(0x0AED, opcode_0AED); // string_float_format
-
-		CLEO_RegisterOpcode(0x2600, opcode_2600); // is_text_empty
-		CLEO_RegisterOpcode(0x2601, opcode_2601); // is_text_equal
-		CLEO_RegisterOpcode(0x2602, opcode_2602); // is_text_in_text
-		CLEO_RegisterOpcode(0x2603, opcode_2603); // is_text_prefix
-		CLEO_RegisterOpcode(0x2604, opcode_2604); // is_text_sufix
-		CLEO_RegisterOpcode(0x2605, opcode_2605); // display_text_formatted
-		CLEO_RegisterOpcode(0x2606, opcode_2606); // load_fxt
-		CLEO_RegisterOpcode(0x2607, opcode_2607); // unload_fxt
-		CLEO_RegisterOpcode(0x2608, opcode_2608); // get_text_length
-		CLEO_RegisterOpcode(0x2609, opcode_2609); // add_text_label_formatted
-
-		// register event callbacks
-		CLEO_RegisterCallback(eCallbackId::GameBegin, OnGameBegin);
-		CLEO_RegisterCallback(eCallbackId::GameProcessBefore, OnGameProcessBefore);
-		CLEO_RegisterCallback(eCallbackId::GameEnd, OnGameEnd);
-
-		CLEO_RegisterCallback(eCallbackId::ScriptProcessBefore, OnScriptBeforeProcess);
-		CLEO_RegisterCallback(eCallbackId::ScriptProcessAfter, OnScriptAfterProcess);
-		CLEO_RegisterCallback(eCallbackId::ScriptUnregister, OnScriptUnregister);
-		CLEO_RegisterCallback(eCallbackId::ScriptDraw, OnScriptDraw);
-		CLEO_RegisterCallback(eCallbackId::DrawingFinished, OnDrawingFinished);
-	}
-
-	~Text()
-	{
-		CLEO_UnregisterCallback(eCallbackId::GameBegin, OnGameBegin);
-		CLEO_UnregisterCallback(eCallbackId::GameProcessBefore, OnGameProcessBefore);
-		CLEO_UnregisterCallback(eCallbackId::GameEnd, OnGameEnd);
-
-		CLEO_UnregisterCallback(eCallbackId::ScriptProcessBefore, OnScriptBeforeProcess);
-		CLEO_UnregisterCallback(eCallbackId::ScriptProcessAfter, OnScriptAfterProcess);
-		CLEO_UnregisterCallback(eCallbackId::ScriptUnregister, OnScriptUnregister);
-		CLEO_UnregisterCallback(eCallbackId::ScriptDraw, OnScriptDraw);
-		CLEO_UnregisterCallback(eCallbackId::DrawingFinished, OnDrawingFinished);
-		
-		m_patchCTextGet.Apply(); // undo hook
-	}
-
-	static void __stdcall OnGameBegin(DWORD saveSlot)
-	{
-		textManager.LoadFxts();
-	}
-
-	static void __stdcall OnGameProcessBefore()
-	{
-		genericLabelCounter = 0;
-	}
-
-	static void __stdcall OnGameEnd()
-	{
-		textManager.Clear();
-	}
-
-	static bool __stdcall OnScriptBeforeProcess(CLEO::CRunningScript* pScript)
-	{
-		scriptDrawing.ScriptProcessingBegin(pScript);
-		return true;
-	}
-
-	static void __stdcall OnScriptAfterProcess(CLEO::CRunningScript* pScript)
-	{
-		scriptDrawing.ScriptProcessingEnd(pScript);
-	}
-
-	static void __stdcall OnScriptUnregister(CLEO::CRunningScript* pScript)
-	{
-		scriptDrawing.ScriptUnregister(pScript);
-	}
-
-	static void __stdcall OnScriptDraw(bool beforeFade)
-	{
-		scriptDrawing.Draw(beforeFade);
-	}
-
-	static void WINAPI OnDrawingFinished()
-	{
-		// late initialization
-		if (!instance.m_initialized)
-		{
-			instance.m_patchCTextGet = MemPatchJump(gaddrof(CText::Get), &HOOK_CTextGet);
-
-			instance.m_initialized = true;
-		}
-	}
-
-	// hook of game's CText::Get
-	static const char* __fastcall HOOK_CTextGet(CText* text, int dummy, const char* gxt)
-	{
-		if ((gxt[0] == '\0') || (gxt[0] == ' ')) return "";
-
-		// check CLEO's texts
-		auto result = Text::textManager.LocateFxt(gxt);
-		if (result != nullptr) return result;
-
-		// call original function
-		instance.m_patchCTextGet.Apply(); // restore original function code
-		result = text->Get(gxt);
-		MemPatchJump(gaddrof(CText::Get), &HOOK_CTextGet); // reinstall our hook
-
-		return result;
-	}
-
-	//0ACA=1,show_text_box %1d%
-	static OpcodeResult __stdcall opcode_0ACA(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING(text);
-
-		CHud::SetHelpMessage(text, true, false, false);
-		return OR_CONTINUE;
-	}
-
-	//0ACB=3,show_styled_text %1d% time %2d% style %3d%
-	static OpcodeResult __stdcall opcode_0ACB(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING(text);
-		auto time = OPCODE_READ_PARAM_INT();
-		auto style = OPCODE_READ_PARAM_INT();
-
-		auto styleIdx = std::clamp(style, 0, (int)MsgBigStyleCount - 1);
-		strncpy_s(msgBuffBig[styleIdx], text, sizeof(msgBuffBig[styleIdx]));
-		CMessages::AddBigMessage(msgBuffBig[styleIdx], time, style - 1);
-		return OR_CONTINUE;
-	}
-
-	//0ACC=2,show_text_lowpriority %1d% time %2d%
-	static OpcodeResult __stdcall opcode_0ACC(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING(text);
-		auto time = OPCODE_READ_PARAM_INT();
-
-		strncpy_s(msgBuffLow, text, sizeof(msgBuffLow));
-		CMessages::AddMessage(msgBuffLow, time, false, false);
-		return OR_CONTINUE;
-	}
-
-	//0ACD=2,show_text_highpriority %1d% time %2d%
-	static OpcodeResult __stdcall opcode_0ACD(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING(text);
-		auto time = OPCODE_READ_PARAM_INT();
-
-		strncpy_s(msgBuffHigh, text, sizeof(msgBuffHigh));
-		CMessages::AddMessageJumpQ(msgBuffHigh, time, false, false);
-		return OR_CONTINUE;
-	}
-
-	//0ACE=-1,show_formatted_text_box %1d%
-	static OpcodeResult __stdcall opcode_0ACE(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING_FORMATTED(text);
-
-		CHud::SetHelpMessage(text, true, false, false);
-		return OR_CONTINUE;
-	}
-
-	//0ACF=-1,show_formatted_styled_text %1d% time %2d% style %3d%
-	static OpcodeResult __stdcall opcode_0ACF(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING(format);
-		auto time = OPCODE_READ_PARAM_INT();
-		auto style = OPCODE_READ_PARAM_INT();
-		OPCODE_READ_PARAMS_FORMATTED(format, text);
-
-		auto styleIdx = std::clamp(style, 0, (int)MsgBigStyleCount - 1);
-		strncpy_s(msgBuffBig[styleIdx], text, sizeof(msgBuffBig[styleIdx]));
-		CMessages::AddBigMessage(msgBuffBig[styleIdx], time, style - 1);
-		return OR_CONTINUE;
-	}
-
-	//0AD0=-1,show_formatted_text_lowpriority %1d% time %2d%
-	static OpcodeResult __stdcall opcode_0AD0(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING(format);
-		auto time = OPCODE_READ_PARAM_INT();
-		OPCODE_READ_PARAMS_FORMATTED(format, text);
-
-		strncpy_s(msgBuffLow, text, sizeof(msgBuffLow));
-		CMessages::AddMessage(msgBuffLow, time, false, false);
-		return OR_CONTINUE;
-	}
-
-	//0AD1=-1,show_formatted_text_highpriority %1d% time %2d%
-	static OpcodeResult __stdcall opcode_0AD1(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING(format);
-		auto time = OPCODE_READ_PARAM_INT();
-		OPCODE_READ_PARAMS_FORMATTED(format, text);
-
-		strncpy_s(msgBuffHigh, text, sizeof(msgBuffHigh));
-		CMessages::AddMessageJumpQ(msgBuffHigh, time, false, false);
-		return OR_CONTINUE;
-	}
-
-	//0AD3=-1,string %1d% format %2d% ...
-	static OpcodeResult __stdcall opcode_0AD3(CLEO::CRunningScript* thread)
-	{
-		auto result = OPCODE_READ_PARAM_OUTPUT_VAR_STRING();
-		OPCODE_READ_PARAM_STRING_FORMATTED(text);
-
-		OPCODE_WRITE_PARAM_VAR_STRING(result, text);
-		return OR_CONTINUE;
-	}
-
-	//0AD4=-1,%3d% = scan_string %1d% format %2d%  //IF and SET
-	static OpcodeResult __stdcall opcode_0AD4(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING(src);
-		OPCODE_READ_PARAM_STRING(format);
-
-		auto readCount = OPCODE_READ_PARAM_OUTPUT_VAR_INT(); // store_to
-
-		// format string tokens processing helper
-		const char* formatPos = format;
-		auto GetNextTokenType = [&]()
-		{
-			while (true)
-			{
-				if (*formatPos == '\0') return DT_END;
-
-				if (*formatPos == '%') // formatting sequence start
-				{
-					if (formatPos[1] == '%' || // escaped % character
-						formatPos[1] == '*') // sscanf non-capturing token
-					{
-						formatPos += 2;
-						continue;
-					}
-
-					while (true)
-					{
-						formatPos++; // next char
-						if (*formatPos == '\0')
-						{
-							SHOW_ERROR("Invalid string format sequence ('%s') in script %s\nScript suspended.", format, ScriptInfoStr(thread).c_str());
-							return DT_INVALID;
-						}
-
-						// width specification
-						if (*formatPos >= '0' && *formatPos <= '9')
-						{
-							formatPos++;
-							continue;
-						}
-
-						switch(*formatPos)
-						{
-							case 's': return DT_STRING;
-							default: return DT_VAR; // any32. TODO: actually parse and verify other types?
-						}
-					}
-				}
-
-				formatPos++;
-			}
-		};
-
-		// collect provided by caller store_to variables
-		size_t outputParamCount = 0;
-		SCRIPT_VAR* outputParams[35];
-		struct StringParamDesc
-		{
-			bool used = false;
-			StringParamBufferInfo target;
-			std::string str;
-		} stringParams[35];
-
-		for (int i = 0; i < 35; i++)
-		{
-			auto paramType = thread->PeekDataType();
-
-			auto formatTokenType = GetNextTokenType();
-			if (formatTokenType == DT_INVALID) return thread->Suspend(); // error message already displayed
-
-			if (paramType == DT_END)
-			{
-				if (formatTokenType != DT_END && !IsLegacyScript(thread))
-				{
-					SHOW_ERROR("More tokens in format string than return variables in script %s\nScript suspended.", format, ScriptInfoStr(thread).c_str());
-					return thread->Suspend();
-				}
-				break;
-			}
-
-			if (formatTokenType == DT_END && !IsLegacyScript(thread))
-			{
-				SHOW_ERROR("More return variables than tokens in format string in script %s\nScript suspended.", format, ScriptInfoStr(thread).c_str());
-				return thread->Suspend();
-			}
-
-			if (IsVarString(paramType))
-			{
-				if (IsLegacyScript(thread))
-				{
-					// older CLEOs did not carred about string variable size limitations
-					// just give pointer to the variable's data and allow overflow depending on input data
-					outputParams[i] = CLEO_GetPointerToScriptVariable(thread);
-				}
-				else
-				{
-					stringParams[i].used = true;
-					stringParams[i].target = OPCODE_READ_PARAM_OUTPUT_VAR_STRING();
-
-					stringParams[i].str.resize(MAX_STR_LEN); // temp storage
-					outputParams[i] = (SCRIPT_VAR*)stringParams[i].str.data();
-				}
-			}
-			else if (formatTokenType == DT_STRING) // `%s`
-			{
-				auto ptr = OPCODE_READ_PARAM_PTR();
-				outputParams[i] = (SCRIPT_VAR*)ptr;
-			}
-			else
-			{
-				outputParams[i] = OPCODE_READ_PARAM_OUTPUT_VAR_ANY32();
-			}
-
-			outputParamCount++;
-		}
-		CLEO_SkipUnusedVarArgs(thread); // and var args terminator
-
-		#pragma warning(suppress: 4996) // sscanf_s would expect additional arg after each %s arg
-		*readCount = sscanf(src, format,
-			outputParams[0], outputParams[1], outputParams[2], outputParams[3], outputParams[4], outputParams[5],
-			outputParams[6], outputParams[7], outputParams[8], outputParams[9], outputParams[10], outputParams[11],
-			outputParams[12], outputParams[13], outputParams[14], outputParams[15], outputParams[16], outputParams[17],
-			outputParams[18], outputParams[19], outputParams[20], outputParams[21], outputParams[22], outputParams[23],
-			outputParams[24], outputParams[25], outputParams[26], outputParams[27], outputParams[28], outputParams[29],
-			outputParams[30], outputParams[31], outputParams[32], outputParams[33], outputParams[34]);
-
-		// transfer string params to target variables
-		for (auto& p : stringParams)
-		{
-			if (p.used) OPCODE_WRITE_PARAM_VAR_STRING(p.target, p.str.c_str());
-		}
-
-		OPCODE_CONDITION_RESULT(outputParamCount == *readCount);
-		return OR_CONTINUE;
-	}
-
-	//0ADB=2,%2d% = car_model %1d% name
-	static OpcodeResult __stdcall opcode_0ADB(CLEO::CRunningScript* thread)
-	{
-		auto modelIndex = OPCODE_READ_PARAM_UINT();
-
-		CVehicleModelInfo* model;
-		// if 1.0 US, prefer GetModelInfo function  makes it compatible with fastman92's limit adjuster
-		if (CLEO_GetGameVersion() == CLEO::GV_US10)
-			model = plugin::CallAndReturn<CVehicleModelInfo*, 0x403DA0, int>(modelIndex);
-		else
-			model = reinterpret_cast<CVehicleModelInfo*>(CModelInfo::ms_modelInfoPtrs[modelIndex]);
-
-		auto str = std::string(std::string_view(model->m_szGameName, sizeof(model->m_szGameName))); // to proper cstr
-
-		OPCODE_WRITE_PARAM_STRING(str.c_str());
-		return OR_CONTINUE;
-	}
-
-	//0ADE=2,%2d% = text_by_GXT_entry %1d%
-	static OpcodeResult __stdcall opcode_0ADE(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING_LEN(gxt, 7); // GXT labels can be max 7 character long
-
-		auto txt = textManager.Get(gxt);
-
-		if (IsVarString(thread->PeekDataType()))
-		{
-			OPCODE_WRITE_PARAM_STRING(txt);
-		}
-		else
-		{
-			OPCODE_WRITE_PARAM_PTR(txt); // address of the text
-		}
-		return OR_CONTINUE;
-	}
-
-	//0ADF=2,add_dynamic_GXT_entry %1d% text %2d%
-	static OpcodeResult __stdcall opcode_0ADF(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING_LEN(gxt, 7); // GXT labels can be max 7 character long
-		OPCODE_READ_PARAM_STRING(txt);
-
-		textManager.AddFxt(gxt, txt);
-		return OR_CONTINUE;
-	}
-
-	//0AE0=1,remove_dynamic_GXT_entry %1d%
-	static OpcodeResult __stdcall opcode_0AE0(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING_LEN(gxt, 7); // GXT labels can be max 7 character long
-
-		textManager.RemoveFxt(gxt);
-		return OR_CONTINUE;
-	}
-
-	//0AED=3,%3d% = float %1d% to_string_format %2d%
-	static OpcodeResult __stdcall opcode_0AED(CLEO::CRunningScript* thread)
-	{
-		// this opcode is useless now
-		auto val = OPCODE_READ_PARAM_FLOAT();
-		OPCODE_READ_PARAM_STRING(format);
-
-		char result[32];
-		sprintf_s(result, sizeof(result), format, val);
-
-		OPCODE_WRITE_PARAM_STRING(result);
-		return OR_CONTINUE;
-	}
-
-	//2600=1,  is_text_empty %1s%
-	static OpcodeResult __stdcall opcode_2600(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING(str);
-
-		OPCODE_CONDITION_RESULT(str[0] == '\0');
-		return OR_CONTINUE;
-	}
-
-	//2601=3,  is_text_equal %1s% another %2s% ignore_case %3d%
-	static OpcodeResult __stdcall opcode_2601(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING(a);
-		OPCODE_READ_PARAM_STRING(b);
-		auto ignoreCase = OPCODE_READ_PARAM_BOOL();
-
-		auto result = ignoreCase ? _stricmp(a, b) : strcmp(a, b);
-
-		OPCODE_CONDITION_RESULT(result == 0);
-		return OR_CONTINUE;
-	}
-
-	//2602=3,  is_text_in_text %1s% sub_text %2s% ignore_case %3d%
-	static OpcodeResult __stdcall opcode_2602(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING(str);
-		OPCODE_READ_PARAM_STRING(substr);
-		auto ignoreCase = OPCODE_READ_PARAM_BOOL();
-
-		if (substr[0] == '\0')
-		{
-			OPCODE_CONDITION_RESULT(true);
-			return OR_CONTINUE;
-		}
-
-		auto result = ignoreCase ? StrStrIA(str, substr) : strstr(str, substr);
-
-		OPCODE_CONDITION_RESULT(result != nullptr);
-		return OR_CONTINUE;
-	}
-
-	//2603=3,  is_text_prefix %1s% prefix %2s% ignore_case %3d%
-	static OpcodeResult __stdcall opcode_2603(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING(str);
-		OPCODE_READ_PARAM_STRING(prefix);
-		auto ignoreCase = OPCODE_READ_PARAM_BOOL();
-
-		auto prefixLen = strlen(prefix);
-		auto result = ignoreCase ? _strnicmp(str, prefix, prefixLen) : strncmp(str, prefix, prefixLen);
-
-		OPCODE_CONDITION_RESULT(result == 0);
-		return OR_CONTINUE;
-	}
-
-	//2604=3,  is_text_sufix %1s% sufix %2s% ignore_case %3d%
-	static OpcodeResult __stdcall opcode_2604(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING(str);
-		OPCODE_READ_PARAM_STRING(sufix);
-		auto ignoreCase = OPCODE_READ_PARAM_BOOL();
-
-		auto strLen = strlen(str);
-		auto sufixLen = strlen(sufix);
-
-		if (sufixLen > strLen)
-		{
-			OPCODE_CONDITION_RESULT(false);
-			return OR_CONTINUE;
-		}
-
-		auto offset = strLen - sufixLen;
-		auto result = ignoreCase ? _stricmp(str + offset, sufix) : strcmp(str + offset, sufix);
-
-		OPCODE_CONDITION_RESULT(result == 0);
-		return OR_CONTINUE;
-	}
-
-	//2605=-1,display_text_formatted offset_left %1d% offset_top %2d% format %3d% args
-	static OpcodeResult __stdcall opcode_2605(CLEO::CRunningScript* thread)
-	{
-		auto posX = OPCODE_READ_PARAM_FLOAT();
-		auto posY = OPCODE_READ_PARAM_FLOAT();
-		OPCODE_READ_PARAM_STRING_FORMATTED(text);
-
-		if (CTheScripts::NumberOfIntroTextLinesThisFrame >= 0x60) // GTA SA CTheScripts::IntroTextLines capacity
-		{
-			LOG_WARNING(thread, "Display text limit (%d) exceeded in script %s", 0x60, ScriptInfoStr(thread).c_str());
-			return OR_CONTINUE;
-		}
-
-		// new generic GXT label
-		// includes unprintable character, to ensure there will be no collision with user GXT labels
-		char gxt[9] = { 0x01, 'C', 'L', 'E', 0x00, 0x00, 0x00, 0x00, 0x00 }; // enough space for even worst case scenario
-		_itoa_s(genericLabelCounter, gxt + 4, sizeof(gxt) - 4, 36); // 0xFFFF -> "1ekf"
-		genericLabelCounter++;
-
-		textManager.AddFxt(gxt, text);
-
-		auto& draw = CTheScripts::IntroTextLines[CTheScripts::NumberOfIntroTextLinesThisFrame];
-		memcpy(&draw.xPosition, &posX, sizeof(draw.xPosition)); // invalid type in Plugin SDK. Just copy memory
-		memcpy(&draw.yPosition, &posY, sizeof(draw.yPosition));
-		strcpy_s(draw.text, gxt);
-
-		CTheScripts::NumberOfIntroTextLinesThisFrame++;
-
-		return OR_CONTINUE;
-	}
-
-	//2606=1,  load_fxt %1d%
-	static OpcodeResult __stdcall opcode_2606(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_FILEPATH(filename);
-
-		size_t added = 0;
-		try
-		{
-			std::ifstream stream(filename);
-			added = textManager.ParseFxtFile(stream, true, false);
-		}
-		catch (std::exception& ex)
-		{
-			LOG_WARNING(0, "Loading of FXT file '%s' failed: \n%s", filename, ex.what());
-		}
-
-		OPCODE_CONDITION_RESULT(added != 0);
-		return OR_CONTINUE;
-	}
-
-	//2607=1,  unload_fxt %1d%
-	static OpcodeResult __stdcall opcode_2607(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_FILEPATH(filename);
-
-		size_t removed = 0;
-		try
-		{
-			std::ifstream stream(filename);
-			removed = textManager.ParseFxtFile(stream, true, true);
-		}
-		catch (std::exception& ex)
-		{
-			LOG_WARNING(0, "Unloading of FXT file '%s' failed: \n%s", filename, ex.what());
-		}
-
-		OPCODE_CONDITION_RESULT(removed != 0);
-		return OR_CONTINUE;
-	}
-
-	//2608=3,get_text_length %1d% store_to %2d%
-	static OpcodeResult __stdcall opcode_2608(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING(str);
-
-		auto result = strlen(str);
-
-		OPCODE_WRITE_PARAM_INT(result);
-		return OR_CONTINUE;
-	}
-
-	//2609=-1,add_text_label_formatted %1d% args %2d% 
-	static OpcodeResult __stdcall opcode_2609(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING_LEN(gxt, 7); // GXT labels can be max 7 character long
-		OPCODE_READ_PARAM_STRING_FORMATTED(str);
-
-		textManager.AddFxt(gxt, str);
-
-		return OR_CONTINUE;
-	}
+  static ScriptDrawing scriptDrawing;
+  static CTextManager textManager;
+
+  static char msgBuffLow[MAX_STR_LEN + 1];
+  static char msgBuffHigh[MAX_STR_LEN + 1];
+  static const size_t MsgBigStyleCount = 7;
+  static char msgBuffBig[MsgBigStyleCount][MAX_STR_LEN + 1];
+
+  static WORD genericLabelCounter;
+
+  bool m_initialized = false;
+  MemPatch m_patchCTextGet;
+
+  Text() {
+    if (!PluginCheckCleoVersion())
+      return;
+
+    // register opcodes
+    CLEO_RegisterOpcode(0x0ACA, opcode_0ACA); // print_help_string
+    CLEO_RegisterOpcode(0x0ACB, opcode_0ACB); // print_big_string
+    CLEO_RegisterOpcode(0x0ACC, opcode_0ACC); // print_string
+    CLEO_RegisterOpcode(0x0ACD, opcode_0ACD); // print_string_now
+    CLEO_RegisterOpcode(0x0ACE, opcode_0ACE); // print_help_formatted
+    CLEO_RegisterOpcode(0x0ACF, opcode_0ACF); // print_big_formatted
+    CLEO_RegisterOpcode(0x0AD0, opcode_0AD0); // print_formatted
+    CLEO_RegisterOpcode(0x0AD1, opcode_0AD1); // print_formatted_now
+
+    CLEO_RegisterOpcode(0x0AD3, opcode_0AD3); // string_format
+    CLEO_RegisterOpcode(0x0AD4, opcode_0AD4); // scan_string
+    CLEO_RegisterOpcode(0x0ADB, opcode_0ADB); // get_name_of_vehicle_model
+
+    CLEO_RegisterOpcode(0x0ADE, opcode_0ADE); // get_text_label_string
+    CLEO_RegisterOpcode(0x0ADF, opcode_0ADF); // add_text_label
+    CLEO_RegisterOpcode(0x0AE0, opcode_0AE0); // remove_text_label
+
+    CLEO_RegisterOpcode(0x0AED, opcode_0AED); // string_float_format
+
+    CLEO_RegisterOpcode(0x2600, opcode_2600); // is_text_empty
+    CLEO_RegisterOpcode(0x2601, opcode_2601); // is_text_equal
+    CLEO_RegisterOpcode(0x2602, opcode_2602); // is_text_in_text
+    CLEO_RegisterOpcode(0x2603, opcode_2603); // is_text_prefix
+    CLEO_RegisterOpcode(0x2604, opcode_2604); // is_text_sufix
+    CLEO_RegisterOpcode(0x2605, opcode_2605); // display_text_formatted
+    CLEO_RegisterOpcode(0x2606, opcode_2606); // load_fxt
+    CLEO_RegisterOpcode(0x2607, opcode_2607); // unload_fxt
+    CLEO_RegisterOpcode(0x2608, opcode_2608); // get_text_length
+    CLEO_RegisterOpcode(0x2609, opcode_2609); // add_text_label_formatted
+
+    // register event callbacks
+    CLEO_RegisterCallback(eCallbackId::GameBegin, OnGameBegin);
+    CLEO_RegisterCallback(eCallbackId::GameProcessBefore, OnGameProcessBefore);
+    CLEO_RegisterCallback(eCallbackId::GameEnd, OnGameEnd);
+
+    CLEO_RegisterCallback(eCallbackId::ScriptProcessBefore,
+                          OnScriptBeforeProcess);
+    CLEO_RegisterCallback(eCallbackId::ScriptProcessAfter,
+                          OnScriptAfterProcess);
+    CLEO_RegisterCallback(eCallbackId::ScriptUnregister, OnScriptUnregister);
+    CLEO_RegisterCallback(eCallbackId::ScriptDraw, OnScriptDraw);
+    CLEO_RegisterCallback(eCallbackId::DrawingFinished, OnDrawingFinished);
+  }
+
+  ~Text() {
+    CLEO_UnregisterCallback(eCallbackId::GameBegin, OnGameBegin);
+    CLEO_UnregisterCallback(eCallbackId::GameProcessBefore,
+                            OnGameProcessBefore);
+    CLEO_UnregisterCallback(eCallbackId::GameEnd, OnGameEnd);
+
+    CLEO_UnregisterCallback(eCallbackId::ScriptProcessBefore,
+                            OnScriptBeforeProcess);
+    CLEO_UnregisterCallback(eCallbackId::ScriptProcessAfter,
+                            OnScriptAfterProcess);
+    CLEO_UnregisterCallback(eCallbackId::ScriptUnregister, OnScriptUnregister);
+    CLEO_UnregisterCallback(eCallbackId::ScriptDraw, OnScriptDraw);
+    CLEO_UnregisterCallback(eCallbackId::DrawingFinished, OnDrawingFinished);
+
+    m_patchCTextGet.Apply(); // undo hook
+  }
+
+  static void __stdcall OnGameBegin(DWORD saveSlot) { textManager.LoadFxts(); }
+
+  static void __stdcall OnGameProcessBefore() { genericLabelCounter = 0; }
+
+  static void __stdcall OnGameEnd() { textManager.Clear(); }
+
+  static bool __stdcall OnScriptBeforeProcess(CLEO::CRunningScript *pScript) {
+    scriptDrawing.ScriptProcessingBegin(pScript);
+    return true;
+  }
+
+  static void __stdcall OnScriptAfterProcess(CLEO::CRunningScript *pScript) {
+    scriptDrawing.ScriptProcessingEnd(pScript);
+  }
+
+  static void __stdcall OnScriptUnregister(CLEO::CRunningScript *pScript) {
+    scriptDrawing.ScriptUnregister(pScript);
+  }
+
+  static void __stdcall OnScriptDraw(bool beforeFade) {
+    scriptDrawing.Draw(beforeFade);
+  }
+
+  static void WINAPI OnDrawingFinished() {
+    // late initialization
+    if (!instance.m_initialized) {
+      instance.m_patchCTextGet =
+          MemPatchJump(gaddrof(CText::Get), &HOOK_CTextGet);
+
+      instance.m_initialized = true;
+    }
+  }
+
+  // hook of game's CText::Get
+  static const char *__fastcall HOOK_CTextGet(CText *text, int dummy,
+                                              const char *gxt) {
+    if ((gxt[0] == '\0') || (gxt[0] == ' '))
+      return "";
+
+    // check CLEO's texts
+    auto result = Text::textManager.LocateFxt(gxt);
+    if (result != nullptr)
+      return result;
+
+    // call original function
+    instance.m_patchCTextGet.Apply(); // restore original function code
+    result = text->Get(gxt);
+    MemPatchJump(gaddrof(CText::Get), &HOOK_CTextGet); // reinstall our hook
+
+    return result;
+  }
+
+  // 0ACA=1,show_text_box %1d%
+  static OpcodeResult __stdcall opcode_0ACA(CLEO::CRunningScript *thread) {
+    OPCODE_READ_PARAM_STRING(text);
+
+    CHud::SetHelpMessage(text, true, false, false);
+    return OR_CONTINUE;
+  }
+
+  // 0ACB=3,show_styled_text %1d% time %2d% style %3d%
+  static OpcodeResult __stdcall opcode_0ACB(CLEO::CRunningScript *thread) {
+    OPCODE_READ_PARAM_STRING(text);
+    auto time = OPCODE_READ_PARAM_INT();
+    auto style = OPCODE_READ_PARAM_INT();
+
+    auto styleIdx = std::clamp(style, 0, (int)MsgBigStyleCount - 1);
+    strncpy_s(msgBuffBig[styleIdx], text, sizeof(msgBuffBig[styleIdx]));
+    CMessages::AddBigMessage(msgBuffBig[styleIdx], time, style - 1);
+    return OR_CONTINUE;
+  }
+
+  // 0ACC=2,show_text_lowpriority %1d% time %2d%
+  static OpcodeResult __stdcall opcode_0ACC(CLEO::CRunningScript *thread) {
+    OPCODE_READ_PARAM_STRING(text);
+    auto time = OPCODE_READ_PARAM_INT();
+
+    strncpy_s(msgBuffLow, text, sizeof(msgBuffLow));
+    CMessages::AddMessage(msgBuffLow, time, false, false);
+    return OR_CONTINUE;
+  }
+
+  // 0ACD=2,show_text_highpriority %1d% time %2d%
+  static OpcodeResult __stdcall opcode_0ACD(CLEO::CRunningScript *thread) {
+    OPCODE_READ_PARAM_STRING(text);
+    auto time = OPCODE_READ_PARAM_INT();
+
+    strncpy_s(msgBuffHigh, text, sizeof(msgBuffHigh));
+    CMessages::AddMessageJumpQ(msgBuffHigh, time, false, false);
+    return OR_CONTINUE;
+  }
+
+  // 0ACE=-1,show_formatted_text_box %1d%
+  static OpcodeResult __stdcall opcode_0ACE(CLEO::CRunningScript *thread) {
+    OPCODE_READ_PARAM_STRING_FORMATTED(text);
+
+    CHud::SetHelpMessage(text, true, false, false);
+    return OR_CONTINUE;
+  }
+
+  // 0ACF=-1,show_formatted_styled_text %1d% time %2d% style %3d%
+  static OpcodeResult __stdcall opcode_0ACF(CLEO::CRunningScript *thread) {
+    OPCODE_READ_PARAM_STRING(format);
+    auto time = OPCODE_READ_PARAM_INT();
+    auto style = OPCODE_READ_PARAM_INT();
+    OPCODE_READ_PARAMS_FORMATTED(format, text);
+
+    auto styleIdx = std::clamp(style, 0, (int)MsgBigStyleCount - 1);
+    strncpy_s(msgBuffBig[styleIdx], text, sizeof(msgBuffBig[styleIdx]));
+    CMessages::AddBigMessage(msgBuffBig[styleIdx], time, style - 1);
+    return OR_CONTINUE;
+  }
+
+  // 0AD0=-1,show_formatted_text_lowpriority %1d% time %2d%
+  static OpcodeResult __stdcall opcode_0AD0(CLEO::CRunningScript *thread) {
+    OPCODE_READ_PARAM_STRING(format);
+    auto time = OPCODE_READ_PARAM_INT();
+    OPCODE_READ_PARAMS_FORMATTED(format, text);
+
+    strncpy_s(msgBuffLow, text, sizeof(msgBuffLow));
+    CMessages::AddMessage(msgBuffLow, time, false, false);
+    return OR_CONTINUE;
+  }
+
+  // 0AD1=-1,show_formatted_text_highpriority %1d% time %2d%
+  static OpcodeResult __stdcall opcode_0AD1(CLEO::CRunningScript *thread) {
+    OPCODE_READ_PARAM_STRING(format);
+    auto time = OPCODE_READ_PARAM_INT();
+    OPCODE_READ_PARAMS_FORMATTED(format, text);
+
+    strncpy_s(msgBuffHigh, text, sizeof(msgBuffHigh));
+    CMessages::AddMessageJumpQ(msgBuffHigh, time, false, false);
+    return OR_CONTINUE;
+  }
+
+  // 0AD3=-1,string %1d% format %2d% ...
+  static OpcodeResult __stdcall opcode_0AD3(CLEO::CRunningScript *thread) {
+    auto result = OPCODE_READ_PARAM_OUTPUT_VAR_STRING();
+    OPCODE_READ_PARAM_STRING_FORMATTED(text);
+
+    OPCODE_WRITE_PARAM_VAR_STRING(result, text);
+    return OR_CONTINUE;
+  }
+
+  // 0AD4=-1,%3d% = scan_string %1d% format %2d%  //IF and SET
+  static OpcodeResult __stdcall opcode_0AD4(CLEO::CRunningScript *thread) {
+    OPCODE_READ_PARAM_STRING(src);
+    OPCODE_READ_PARAM_STRING(format);
+
+    auto readCount = OPCODE_READ_PARAM_OUTPUT_VAR_INT(); // store_to
+
+    // format string tokens processing helper
+    const char *formatPos = format;
+    auto GetNextTokenType = [&]() {
+      while (true) {
+        if (*formatPos == '\0')
+          return DT_END;
+
+        if (*formatPos == '%') // formatting sequence start
+        {
+          if (formatPos[1] == '%' || // escaped % character
+              formatPos[1] == '*')   // sscanf non-capturing token
+          {
+            formatPos += 2;
+            continue;
+          }
+
+          while (true) {
+            formatPos++; // next char
+            if (*formatPos == '\0') {
+              SHOW_ERROR("Invalid string format sequence ('%s') in script "
+                         "%s\nScript suspended.",
+                         format, ScriptInfoStr(thread).c_str());
+              return DT_INVALID;
+            }
+
+            // width specification
+            if (*formatPos >= '0' && *formatPos <= '9') {
+              formatPos++;
+              continue;
+            }
+
+            switch (*formatPos) {
+            case 's':
+              return DT_STRING;
+            default:
+              return DT_VAR; // any32. TODO: actually parse and verify other
+                             // types?
+            }
+          }
+        }
+
+        formatPos++;
+      }
+    };
+
+    // collect provided by caller store_to variables
+    size_t outputParamCount = 0;
+    SCRIPT_VAR *outputParams[35];
+    struct StringParamDesc {
+      bool used = false;
+      StringParamBufferInfo target;
+      std::string str;
+    } stringParams[35];
+
+    for (int i = 0; i < 35; i++) {
+      auto paramType = thread->PeekDataType();
+
+      auto formatTokenType = GetNextTokenType();
+      if (formatTokenType == DT_INVALID)
+        return thread->Suspend(); // error message already displayed
+
+      if (paramType == DT_END) {
+        if (formatTokenType != DT_END && !IsLegacyScript(thread)) {
+          SHOW_ERROR("More tokens in format string than return variables in "
+                     "script %s\nScript suspended.",
+                     format, ScriptInfoStr(thread).c_str());
+          return thread->Suspend();
+        }
+        break;
+      }
+
+      if (formatTokenType == DT_END && !IsLegacyScript(thread)) {
+        SHOW_ERROR("More return variables than tokens in format string in "
+                   "script %s\nScript suspended.",
+                   format, ScriptInfoStr(thread).c_str());
+        return thread->Suspend();
+      }
+
+      if (IsVarString(paramType)) {
+        if (IsLegacyScript(thread)) {
+          // older CLEOs did not carred about string variable size limitations
+          // just give pointer to the variable's data and allow overflow
+          // depending on input data
+          outputParams[i] = CLEO_GetPointerToScriptVariable(thread);
+        } else {
+          stringParams[i].used = true;
+          stringParams[i].target = OPCODE_READ_PARAM_OUTPUT_VAR_STRING();
+
+          stringParams[i].str.resize(MAX_STR_LEN); // temp storage
+          outputParams[i] = (SCRIPT_VAR *)stringParams[i].str.data();
+        }
+      } else if (formatTokenType == DT_STRING) // `%s`
+      {
+        auto ptr = OPCODE_READ_PARAM_PTR();
+        outputParams[i] = (SCRIPT_VAR *)ptr;
+      } else {
+        outputParams[i] = OPCODE_READ_PARAM_OUTPUT_VAR_ANY32();
+      }
+
+      outputParamCount++;
+    }
+    CLEO_SkipUnusedVarArgs(thread); // and var args terminator
+
+#pragma warning(                                                               \
+    suppress : 4996) // sscanf_s would expect additional arg after each %s arg
+    *readCount = sscanf(
+        src, format, outputParams[0], outputParams[1], outputParams[2],
+        outputParams[3], outputParams[4], outputParams[5], outputParams[6],
+        outputParams[7], outputParams[8], outputParams[9], outputParams[10],
+        outputParams[11], outputParams[12], outputParams[13], outputParams[14],
+        outputParams[15], outputParams[16], outputParams[17], outputParams[18],
+        outputParams[19], outputParams[20], outputParams[21], outputParams[22],
+        outputParams[23], outputParams[24], outputParams[25], outputParams[26],
+        outputParams[27], outputParams[28], outputParams[29], outputParams[30],
+        outputParams[31], outputParams[32], outputParams[33], outputParams[34]);
+
+    // transfer string params to target variables
+    for (auto &p : stringParams) {
+      if (p.used)
+        OPCODE_WRITE_PARAM_VAR_STRING(p.target, p.str.c_str());
+    }
+
+    OPCODE_CONDITION_RESULT(outputParamCount == *readCount);
+    return OR_CONTINUE;
+  }
+
+  // 0ADB=2,%2d% = car_model %1d% name
+  static OpcodeResult __stdcall opcode_0ADB(CLEO::CRunningScript *thread) {
+    auto modelIndex = OPCODE_READ_PARAM_UINT();
+
+    CVehicleModelInfo *model;
+    // if 1.0 US, prefer GetModelInfo function  makes it compatible with
+    // fastman92's limit adjuster
+    if (CLEO_GetGameVersion() == CLEO::GV_US10)
+      model =
+          plugin::CallAndReturn<CVehicleModelInfo *, 0x403DA0, int>(modelIndex);
+    else
+      model = reinterpret_cast<CVehicleModelInfo *>(
+          CModelInfo::ms_modelInfoPtrs[modelIndex]);
+
+    auto str = std::string(std::string_view(
+        model->m_szGameName, sizeof(model->m_szGameName))); // to proper cstr
+
+    OPCODE_WRITE_PARAM_STRING(str.c_str());
+    return OR_CONTINUE;
+  }
+
+  // 0ADE=2,%2d% = text_by_GXT_entry %1d%
+  static OpcodeResult __stdcall opcode_0ADE(CLEO::CRunningScript *thread) {
+    OPCODE_READ_PARAM_STRING_LEN(gxt,
+                                 7); // GXT labels can be max 7 character long
+
+    auto txt = textManager.Get(gxt);
+
+    if (IsVarString(thread->PeekDataType())) {
+      OPCODE_WRITE_PARAM_STRING(txt);
+    } else {
+      OPCODE_WRITE_PARAM_PTR(txt); // address of the text
+    }
+    return OR_CONTINUE;
+  }
+
+  // 0ADF=2,add_dynamic_GXT_entry %1d% text %2d%
+  static OpcodeResult __stdcall opcode_0ADF(CLEO::CRunningScript *thread) {
+    OPCODE_READ_PARAM_STRING_LEN(gxt,
+                                 7); // GXT labels can be max 7 character long
+    OPCODE_READ_PARAM_STRING(txt);
+
+    textManager.AddFxt(gxt, txt);
+    return OR_CONTINUE;
+  }
+
+  // 0AE0=1,remove_dynamic_GXT_entry %1d%
+  static OpcodeResult __stdcall opcode_0AE0(CLEO::CRunningScript *thread) {
+    OPCODE_READ_PARAM_STRING_LEN(gxt,
+                                 7); // GXT labels can be max 7 character long
+
+    textManager.RemoveFxt(gxt);
+    return OR_CONTINUE;
+  }
+
+  // 0AED=3,%3d% = float %1d% to_string_format %2d%
+  static OpcodeResult __stdcall opcode_0AED(CLEO::CRunningScript *thread) {
+    // this opcode is useless now
+    auto val = OPCODE_READ_PARAM_FLOAT();
+    OPCODE_READ_PARAM_STRING(format);
+
+    char result[32];
+    sprintf_s(result, sizeof(result), format, val);
+
+    OPCODE_WRITE_PARAM_STRING(result);
+    return OR_CONTINUE;
+  }
+
+  // 2600=1,  is_text_empty %1s%
+  static OpcodeResult __stdcall opcode_2600(CLEO::CRunningScript *thread) {
+    OPCODE_READ_PARAM_STRING(str);
+
+    OPCODE_CONDITION_RESULT(str[0] == '\0');
+    return OR_CONTINUE;
+  }
+
+  // 2601=3,  is_text_equal %1s% another %2s% ignore_case %3d%
+  static OpcodeResult __stdcall opcode_2601(CLEO::CRunningScript *thread) {
+    OPCODE_READ_PARAM_STRING(a);
+    OPCODE_READ_PARAM_STRING(b);
+    auto ignoreCase = OPCODE_READ_PARAM_BOOL();
+
+    auto result = ignoreCase ? _stricmp(a, b) : strcmp(a, b);
+
+    OPCODE_CONDITION_RESULT(result == 0);
+    return OR_CONTINUE;
+  }
+
+  // 2602=3,  is_text_in_text %1s% sub_text %2s% ignore_case %3d%
+  static OpcodeResult __stdcall opcode_2602(CLEO::CRunningScript *thread) {
+    OPCODE_READ_PARAM_STRING(str);
+    OPCODE_READ_PARAM_STRING(substr);
+    auto ignoreCase = OPCODE_READ_PARAM_BOOL();
+
+    if (substr[0] == '\0') {
+      OPCODE_CONDITION_RESULT(true);
+      return OR_CONTINUE;
+    }
+
+    auto result = ignoreCase ? StrStrIA(str, substr) : strstr(str, substr);
+
+    OPCODE_CONDITION_RESULT(result != nullptr);
+    return OR_CONTINUE;
+  }
+
+  // 2603=3,  is_text_prefix %1s% prefix %2s% ignore_case %3d%
+  static OpcodeResult __stdcall opcode_2603(CLEO::CRunningScript *thread) {
+    OPCODE_READ_PARAM_STRING(str);
+    OPCODE_READ_PARAM_STRING(prefix);
+    auto ignoreCase = OPCODE_READ_PARAM_BOOL();
+
+    auto prefixLen = strlen(prefix);
+    auto result = ignoreCase ? _strnicmp(str, prefix, prefixLen)
+                             : strncmp(str, prefix, prefixLen);
+
+    OPCODE_CONDITION_RESULT(result == 0);
+    return OR_CONTINUE;
+  }
+
+  // 2604=3,  is_text_sufix %1s% sufix %2s% ignore_case %3d%
+  static OpcodeResult __stdcall opcode_2604(CLEO::CRunningScript *thread) {
+    OPCODE_READ_PARAM_STRING(str);
+    OPCODE_READ_PARAM_STRING(sufix);
+    auto ignoreCase = OPCODE_READ_PARAM_BOOL();
+
+    auto strLen = strlen(str);
+    auto sufixLen = strlen(sufix);
+
+    if (sufixLen > strLen) {
+      OPCODE_CONDITION_RESULT(false);
+      return OR_CONTINUE;
+    }
+
+    auto offset = strLen - sufixLen;
+    auto result = ignoreCase ? _stricmp(str + offset, sufix)
+                             : strcmp(str + offset, sufix);
+
+    OPCODE_CONDITION_RESULT(result == 0);
+    return OR_CONTINUE;
+  }
+
+  // 2605=-1,display_text_formatted offset_left %1d% offset_top %2d% format %3d%
+  // args
+  static OpcodeResult __stdcall opcode_2605(CLEO::CRunningScript *thread) {
+    auto posX = OPCODE_READ_PARAM_FLOAT();
+    auto posY = OPCODE_READ_PARAM_FLOAT();
+    OPCODE_READ_PARAM_STRING_FORMATTED(text);
+
+    if (CTheScripts::NumberOfIntroTextLinesThisFrame >=
+        0x60) // GTA SA CTheScripts::IntroTextLines capacity
+    {
+      LOG_WARNING(thread, "Display text limit (%d) exceeded in script %s", 0x60,
+                  ScriptInfoStr(thread).c_str());
+      return OR_CONTINUE;
+    }
+
+    // new generic GXT label
+    // includes unprintable character, to ensure there will be no collision with
+    // user GXT labels
+    char gxt[9] = {
+        0x01, 'C',  'L',  'E', 0x00,
+        0x00, 0x00, 0x00, 0x00}; // enough space for even worst case scenario
+    _itoa_s(genericLabelCounter, gxt + 4, sizeof(gxt) - 4,
+            36); // 0xFFFF -> "1ekf"
+    genericLabelCounter++;
+
+    textManager.AddFxt(gxt, text);
+
+    auto &draw = CTheScripts::IntroTextLines
+        [CTheScripts::NumberOfIntroTextLinesThisFrame];
+    memcpy(
+        &draw.xPosition, &posX,
+        sizeof(draw.xPosition)); // invalid type in Plugin SDK. Just copy memory
+    memcpy(&draw.yPosition, &posY, sizeof(draw.yPosition));
+    strcpy_s(draw.text, gxt);
+
+    CTheScripts::NumberOfIntroTextLinesThisFrame++;
+
+    return OR_CONTINUE;
+  }
+
+  // 2606=1,  load_fxt %1d%
+  static OpcodeResult __stdcall opcode_2606(CLEO::CRunningScript *thread) {
+    OPCODE_READ_PARAM_FILEPATH(filename);
+
+    size_t added = 0;
+    try {
+      std::ifstream stream(filename);
+      added = textManager.ParseFxtFile(stream, true, false);
+    } catch (std::exception &ex) {
+      LOG_WARNING(0, "Loading of FXT file '%s' failed: \n%s", filename,
+                  ex.what());
+    }
+
+    OPCODE_CONDITION_RESULT(added != 0);
+    return OR_CONTINUE;
+  }
+
+  // 2607=1,  unload_fxt %1d%
+  static OpcodeResult __stdcall opcode_2607(CLEO::CRunningScript *thread) {
+    OPCODE_READ_PARAM_FILEPATH(filename);
+
+    size_t removed = 0;
+    try {
+      std::ifstream stream(filename);
+      removed = textManager.ParseFxtFile(stream, true, true);
+    } catch (std::exception &ex) {
+      LOG_WARNING(0, "Unloading of FXT file '%s' failed: \n%s", filename,
+                  ex.what());
+    }
+
+    OPCODE_CONDITION_RESULT(removed != 0);
+    return OR_CONTINUE;
+  }
+
+  // 2608=3,get_text_length %1d% store_to %2d%
+  static OpcodeResult __stdcall opcode_2608(CLEO::CRunningScript *thread) {
+    OPCODE_READ_PARAM_STRING(str);
+
+    auto result = strlen(str);
+
+    OPCODE_WRITE_PARAM_INT(result);
+    return OR_CONTINUE;
+  }
+
+  // 2609=-1,add_text_label_formatted %1d% args %2d%
+  static OpcodeResult __stdcall opcode_2609(CLEO::CRunningScript *thread) {
+    OPCODE_READ_PARAM_STRING_LEN(gxt,
+                                 7); // GXT labels can be max 7 character long
+    OPCODE_READ_PARAM_STRING_FORMATTED(str);
+
+    textManager.AddFxt(gxt, str);
+
+    return OR_CONTINUE;
+  }
 } instance;
 
 ScriptDrawing Text::scriptDrawing;
@@ -644,7 +618,7 @@ WORD Text::genericLabelCounter;
 
 // exports
 
-extern "C" __declspec(dllexport) RwTexture * GetScriptTexture(CLEO::CRunningScript* script, DWORD slot)
-{
-	return instance.scriptDrawing.GetScriptTexture(script, slot);
+extern "C" __declspec(dllexport) RwTexture *
+GetScriptTexture(CLEO::CRunningScript *script, DWORD slot) {
+  return instance.scriptDrawing.GetScriptTexture(script, slot);
 }

--- a/cleo_plugins/Text/crc32.cpp
+++ b/cleo_plugins/Text/crc32.cpp
@@ -53,39 +53,33 @@ static const unsigned long crcTable[256] = {
     0xbdbdf21cUL, 0xcabac28aUL, 0x53b39330UL, 0x24b4a3a6UL, 0xbad03605UL,
     0xcdd70693UL, 0x54de5729UL, 0x23d967bfUL, 0xb3667a2eUL, 0xc4614ab8UL,
     0x5d681b02UL, 0x2a6f2b94UL, 0xb40bbe37UL, 0xc30c8ea1UL, 0x5a05df1bUL,
-    0x2d02ef8dUL
-};
+    0x2d02ef8dUL};
 
-unsigned long crc32FromUpcaseString(const char *str)
-{
-    unsigned long crc = 0xFFFFFFFF;
-    while (*str)
-        crc = crcTable[(crc^toupper(*str++)) & 0xff] ^ (crc >> 8);
-    return crc;
+unsigned long crc32FromUpcaseString(const char *str) {
+  unsigned long crc = 0xFFFFFFFF;
+  while (*str)
+    crc = crcTable[(crc ^ toupper(*str++)) & 0xff] ^ (crc >> 8);
+  return crc;
 }
 
-unsigned long crc32FromUpcaseStdString(const std::string& str)
-{
-    return crc32FromUpcaseString(str.c_str());
+unsigned long crc32FromUpcaseStdString(const std::string &str) {
+  return crc32FromUpcaseString(str.c_str());
 }
 
-unsigned long crc32FromString(const char *str)
-{
-    unsigned long crc = 0xFFFFFFFF;
-    while (*str)
-        crc = crcTable[(crc ^ (*str++)) & 0xff] ^ (crc >> 8);
-    return crc;
+unsigned long crc32FromString(const char *str) {
+  unsigned long crc = 0xFFFFFFFF;
+  while (*str)
+    crc = crcTable[(crc ^ (*str++)) & 0xff] ^ (crc >> 8);
+  return crc;
 }
 
-unsigned long crc32FromStdString(const std::string& str)
-{
-    return crc32FromString(str.c_str());
+unsigned long crc32FromStdString(const std::string &str) {
+  return crc32FromString(str.c_str());
 }
 
-unsigned long crc32(const unsigned char *buf, unsigned long len)
-{
-    unsigned long crc = 0xFFFFFFFF;
-    for (unsigned i = 0; i < len; i++)
-        crc = crcTable[(crc^buf[i]) & 0xFF] ^ (crc >> 8);
-    return crc;
+unsigned long crc32(const unsigned char *buf, unsigned long len) {
+  unsigned long crc = 0xFFFFFFFF;
+  for (unsigned i = 0; i < len; i++)
+    crc = crcTable[(crc ^ buf[i]) & 0xFF] ^ (crc >> 8);
+  return crc;
 }

--- a/cleo_plugins/Text/crc32.h
+++ b/cleo_plugins/Text/crc32.h
@@ -3,6 +3,6 @@
 
 unsigned long crc32(const unsigned char *buf, unsigned long len);
 unsigned long crc32FromUpcaseString(const char *str);
-unsigned long crc32FromUpcaseStdString(const std::string& str);
+unsigned long crc32FromUpcaseStdString(const std::string &str);
 unsigned long crc32FromString(const char *str);
-unsigned long crc32FromStdString(const std::string& str);
+unsigned long crc32FromStdString(const std::string &str);

--- a/cleo_sdk/CLEO.h
+++ b/cleo_sdk/CLEO.h
@@ -1,539 +1,706 @@
 /*
-	CLEO 5 header file
-	Copyright (c) 2025 Alien, Deji, Junior_Djjr, Miran, Seemann
+        CLEO 5 header file
+        Copyright (c) 2025 Alien, Deji, Junior_Djjr, Miran, Seemann
 */
 #pragma once
 
 #include <string>
 #include <wtypes.h>
 
-#define CLEO_VERSION_MAIN	5
-#define CLEO_VERSION_MAJOR	1
-#define CLEO_VERSION_MINOR	0
+#define CLEO_VERSION_MAIN 5
+#define CLEO_VERSION_MAJOR 1
+#define CLEO_VERSION_MINOR 0
 
-#define CLEO_VERSION ((CLEO_VERSION_MAIN << 24)|(CLEO_VERSION_MAJOR << 16)|(CLEO_VERSION_MINOR << 8)) // 0x0v0v0v00
+#define CLEO_VERSION                                                           \
+  ((CLEO_VERSION_MAIN << 24) | (CLEO_VERSION_MAJOR << 16) |                    \
+   (CLEO_VERSION_MINOR << 8)) // 0x0v0v0v00
 
 #define __TO_STR(x) #x
 #define TO_STR(x) __TO_STR(x)
-#define CLEO_VERSION_STR TO_STR(CLEO_VERSION_MAIN.CLEO_VERSION_MAJOR.CLEO_VERSION_MINOR) // "v.v.v"
+#define CLEO_VERSION_STR                                                       \
+  TO_STR(CLEO_VERSION_MAIN.CLEO_VERSION_MAJOR.CLEO_VERSION_MINOR) // "v.v.v"
 
-namespace CLEO
-{
+namespace CLEO {
 // result of CLEO_GetScriptVersion
-enum eCLEO_Version : DWORD
-{
-	CLEO_VER_3 = 0x03000000,
-	CLEO_VER_4_MIN = 0x04000000,
-	CLEO_VER_4_2 = 0x04020000,
-	CLEO_VER_4_3 = 0x04030000,
-	CLEO_VER_4_4 = 0x04040000,
-	CLEO_VER_4 = CLEO_VER_4_4,
-	CLEO_VER_5 = 0x05000000,
-	CLEO_VER_CUR = CLEO_VERSION
+enum eCLEO_Version : DWORD {
+  CLEO_VER_3 = 0x03000000,
+  CLEO_VER_4_MIN = 0x04000000,
+  CLEO_VER_4_2 = 0x04020000,
+  CLEO_VER_4_3 = 0x04030000,
+  CLEO_VER_4_4 = 0x04040000,
+  CLEO_VER_4 = CLEO_VER_4_4,
+  CLEO_VER_5 = 0x05000000,
+  CLEO_VER_CUR = CLEO_VERSION
 };
 
 // result of CLEO_GetGameVersion
-enum eGameVersion : int
-{
-	GV_US10 = 0, // 1.0 us
-	GV_US11 = 1, // 1.01 us - not supported
-	GV_EU10 = 2, // 1.0 eu
-	GV_EU11 = 3, // 1.01 eu
-	GV_STEAM,
-	GV_TOTAL,
-	GV_UNK = -1 // any other
+enum eGameVersion : int {
+  GV_US10 = 0, // 1.0 us
+  GV_US11 = 1, // 1.01 us - not supported
+  GV_EU10 = 2, // 1.0 eu
+  GV_EU11 = 3, // 1.01 eu
+  GV_STEAM,
+  GV_TOTAL,
+  GV_UNK = -1 // any other
 };
 
 // operand types
-enum eDataType : BYTE
-{
-	DT_END, // variable args end marker
-	DT_DWORD, // literal int 32
-	DT_VAR, // globalVar $
-	DT_LVAR, // localVar @
-	DT_BYTE, // literal int 8
-	DT_WORD, // literal int 16
-	DT_FLOAT, // literal float 32
-	DT_VAR_ARRAY, // globalArr $(,)
-	DT_LVAR_ARRAY, // localArr @(,)
-	DT_TEXTLABEL, // literal string up to 7 chars
-	DT_VAR_TEXTLABEL, // globalVarSString s$
-	DT_LVAR_TEXTLABEL, // localVarSString @s
-	DT_VAR_TEXTLABEL_ARRAY, // globalVarSStringArr s$(,)
-	DT_LVAR_TEXTLABEL_ARRAY, // localVarSStringArr @s(,)
-	DT_VARLEN_STRING, // literal vstring ""
-	DT_STRING, // literal string up to 15 chars
-	DT_VAR_STRING, // globalVarVString v$
-	DT_LVAR_STRING, // localVarVString @v
-	DT_VAR_STRING_ARRAY, // globalVarStringArr v$(,)
-	DT_LVAR_STRING_ARRAY, // localVarStringArr @v(,)
-	DT_INVALID = 0xFF // CLEO internal
+enum eDataType : BYTE {
+  DT_END,                  // variable args end marker
+  DT_DWORD,                // literal int 32
+  DT_VAR,                  // globalVar $
+  DT_LVAR,                 // localVar @
+  DT_BYTE,                 // literal int 8
+  DT_WORD,                 // literal int 16
+  DT_FLOAT,                // literal float 32
+  DT_VAR_ARRAY,            // globalArr $(,)
+  DT_LVAR_ARRAY,           // localArr @(,)
+  DT_TEXTLABEL,            // literal string up to 7 chars
+  DT_VAR_TEXTLABEL,        // globalVarSString s$
+  DT_LVAR_TEXTLABEL,       // localVarSString @s
+  DT_VAR_TEXTLABEL_ARRAY,  // globalVarSStringArr s$(,)
+  DT_LVAR_TEXTLABEL_ARRAY, // localVarSStringArr @s(,)
+  DT_VARLEN_STRING,        // literal vstring ""
+  DT_STRING,               // literal string up to 15 chars
+  DT_VAR_STRING,           // globalVarVString v$
+  DT_LVAR_STRING,          // localVarVString @v
+  DT_VAR_STRING_ARRAY,     // globalVarStringArr v$(,)
+  DT_LVAR_STRING_ARRAY,    // localVarStringArr @v(,)
+  DT_INVALID = 0xFF        // CLEO internal
 };
 
-enum eArrayDataType : BYTE
-{
-	ADT_INT, // variable with integer
-	ADT_FLOAT, // variable with integer
-	ADT_TEXTLABEL, // variable with short string (8 char)
-	ADT_STRING, // variable with long string (16 char)
-	ADT_NONE = 0xFF // CLEO internal
+enum eArrayDataType : BYTE {
+  ADT_INT,        // variable with integer
+  ADT_FLOAT,      // variable with integer
+  ADT_TEXTLABEL,  // variable with short string (8 char)
+  ADT_STRING,     // variable with long string (16 char)
+  ADT_NONE = 0xFF // CLEO internal
 };
-static const BYTE ArrayTypeMask = ADT_INT | ADT_FLOAT | ADT_TEXTLABEL | ADT_STRING; // array flags byte contains other info too. Type needs to be masked when read
+static const BYTE ArrayTypeMask =
+    ADT_INT | ADT_FLOAT | ADT_TEXTLABEL |
+    ADT_STRING; // array flags byte contains other info too. Type needs to be
+                // masked when read
 
-static const char* ToStr(eDataType type)
-{
-	switch (type)
-	{
-	case DT_END: return "VArgEnd"; break;
-	case DT_DWORD: return "Int32"; break;
-	case DT_VAR: return "GlobVar"; break;
-	case DT_LVAR: return "LocVar"; break;
-	case DT_BYTE: return "Int8"; break;
-	case DT_WORD: return "Int16"; break;
-	case DT_FLOAT: return "Float32"; break;
-	case DT_VAR_ARRAY: return "GlobVarArr"; break;
-	case DT_LVAR_ARRAY: return "LocVarArr"; break;
-	case DT_TEXTLABEL: return "STxt"; break;
-	case DT_VAR_TEXTLABEL: return "GlobVarSTxt"; break;
-	case DT_LVAR_TEXTLABEL: return "LocVarSTxt"; break;
-	case DT_VAR_TEXTLABEL_ARRAY: return "GlobVarSTxtArr"; break;
-	case DT_LVAR_TEXTLABEL_ARRAY: return "LocVarSTxtArr"; break;
-	case DT_VARLEN_STRING: return "Txt"; break;
-	case DT_STRING: return "LTxt"; break;
-	case DT_VAR_STRING: return "GlobVarLTxt"; break;
-	case DT_LVAR_STRING: return "LocVarLTxt"; break;
-	case DT_VAR_STRING_ARRAY: return "GlobVarLTxtArr"; break;
-	case DT_LVAR_STRING_ARRAY: return "LocVarLTxtArr"; break;
-	default: return "corrupted";
-	}
+static const char *ToStr(eDataType type) {
+  switch (type) {
+  case DT_END:
+    return "VArgEnd";
+    break;
+  case DT_DWORD:
+    return "Int32";
+    break;
+  case DT_VAR:
+    return "GlobVar";
+    break;
+  case DT_LVAR:
+    return "LocVar";
+    break;
+  case DT_BYTE:
+    return "Int8";
+    break;
+  case DT_WORD:
+    return "Int16";
+    break;
+  case DT_FLOAT:
+    return "Float32";
+    break;
+  case DT_VAR_ARRAY:
+    return "GlobVarArr";
+    break;
+  case DT_LVAR_ARRAY:
+    return "LocVarArr";
+    break;
+  case DT_TEXTLABEL:
+    return "STxt";
+    break;
+  case DT_VAR_TEXTLABEL:
+    return "GlobVarSTxt";
+    break;
+  case DT_LVAR_TEXTLABEL:
+    return "LocVarSTxt";
+    break;
+  case DT_VAR_TEXTLABEL_ARRAY:
+    return "GlobVarSTxtArr";
+    break;
+  case DT_LVAR_TEXTLABEL_ARRAY:
+    return "LocVarSTxtArr";
+    break;
+  case DT_VARLEN_STRING:
+    return "Txt";
+    break;
+  case DT_STRING:
+    return "LTxt";
+    break;
+  case DT_VAR_STRING:
+    return "GlobVarLTxt";
+    break;
+  case DT_LVAR_STRING:
+    return "LocVarLTxt";
+    break;
+  case DT_VAR_STRING_ARRAY:
+    return "GlobVarLTxtArr";
+    break;
+  case DT_LVAR_STRING_ARRAY:
+    return "LocVarLTxtArr";
+    break;
+  default:
+    return "corrupted";
+  }
 }
-static bool IsImmInteger(eDataType type) // immediate/literal integer in code like 42
+static bool
+IsImmInteger(eDataType type) // immediate/literal integer in code like 42
 {
-	switch (type)
-	{
-		case DT_BYTE:
-		case DT_WORD:
-		case DT_DWORD:
-			return true;
-	}
-	return false;
+  switch (type) {
+  case DT_BYTE:
+  case DT_WORD:
+  case DT_DWORD:
+    return true;
+  }
+  return false;
 }
-static bool IsImmFloat(eDataType type) // immediate/literal float in code like 42.0
+static bool
+IsImmFloat(eDataType type) // immediate/literal float in code like 42.0
 {
-	return type == DT_FLOAT;
+  return type == DT_FLOAT;
 }
-static bool IsImmString(eDataType type) // immediate/literal string in code like "text"
+static bool
+IsImmString(eDataType type) // immediate/literal string in code like "text"
 {
-	switch (type)
-	{
-		case DT_STRING:
-		case DT_TEXTLABEL:
-		case DT_VARLEN_STRING:
-			return true;
-	}
-	return false;
+  switch (type) {
+  case DT_STRING:
+  case DT_TEXTLABEL:
+  case DT_VARLEN_STRING:
+    return true;
+  }
+  return false;
 }
 static bool IsVarString(eDataType type) // string variable
 {
-	switch (type)
-	{
-		case DT_LVAR_TEXTLABEL:
-		case DT_LVAR_TEXTLABEL_ARRAY:
-		case DT_LVAR_STRING:
-		case DT_LVAR_STRING_ARRAY:
-		case DT_VAR_TEXTLABEL:
-		case DT_VAR_TEXTLABEL_ARRAY:
-		case DT_VAR_STRING:
-		case DT_VAR_STRING_ARRAY:
-			return true;
-	}
-	return false;
+  switch (type) {
+  case DT_LVAR_TEXTLABEL:
+  case DT_LVAR_TEXTLABEL_ARRAY:
+  case DT_LVAR_STRING:
+  case DT_LVAR_STRING_ARRAY:
+  case DT_VAR_TEXTLABEL:
+  case DT_VAR_TEXTLABEL_ARRAY:
+  case DT_VAR_STRING:
+  case DT_VAR_STRING_ARRAY:
+    return true;
+  }
+  return false;
 }
 static bool IsVariable(eDataType type) // can carry int, float, pointer to text
 {
-	switch (type)
-	{
-		case DT_VAR:
-		case DT_VAR_ARRAY:
-		case DT_LVAR:
-		case DT_LVAR_ARRAY:
-			return true;
-	}
-	return false;
+  switch (type) {
+  case DT_VAR:
+  case DT_VAR_ARRAY:
+  case DT_LVAR:
+  case DT_LVAR_ARRAY:
+    return true;
+  }
+  return false;
 }
-static bool IsArray(eDataType type)
-{
-	switch (type)
-	{
-		case DT_LVAR_TEXTLABEL_ARRAY:
-		case DT_LVAR_STRING_ARRAY:
-		case DT_VAR_TEXTLABEL_ARRAY:
-		case DT_VAR_STRING_ARRAY:
-		case DT_VAR_ARRAY:
-		case DT_LVAR_ARRAY:
-			return true;
-	}
-	return false;
+static bool IsArray(eDataType type) {
+  switch (type) {
+  case DT_LVAR_TEXTLABEL_ARRAY:
+  case DT_LVAR_STRING_ARRAY:
+  case DT_VAR_TEXTLABEL_ARRAY:
+  case DT_VAR_STRING_ARRAY:
+  case DT_VAR_ARRAY:
+  case DT_LVAR_ARRAY:
+    return true;
+  }
+  return false;
 }
-static const char* ToKindStr(eDataType type, eArrayDataType arrType = ADT_NONE)
-{
-	switch (type)
-	{
-		case DT_BYTE:
-		case DT_WORD:
-		case DT_DWORD:
-			return "int"; break;
+static const char *ToKindStr(eDataType type,
+                             eArrayDataType arrType = ADT_NONE) {
+  switch (type) {
+  case DT_BYTE:
+  case DT_WORD:
+  case DT_DWORD:
+    return "int";
+    break;
 
-		case DT_FLOAT:
-			return "float"; break;
+  case DT_FLOAT:
+    return "float";
+    break;
 
-		case DT_STRING:
-		case DT_TEXTLABEL:
-		case DT_LVAR_TEXTLABEL:
-		case DT_LVAR_TEXTLABEL_ARRAY:
-		case DT_LVAR_STRING:
-		case DT_LVAR_STRING_ARRAY:
-		case DT_VAR_TEXTLABEL:
-		case DT_VAR_TEXTLABEL_ARRAY:
-		case DT_VAR_STRING:
-		case DT_VAR_STRING_ARRAY:
-		case DT_VARLEN_STRING:
-			return "string"; break;
+  case DT_STRING:
+  case DT_TEXTLABEL:
+  case DT_LVAR_TEXTLABEL:
+  case DT_LVAR_TEXTLABEL_ARRAY:
+  case DT_LVAR_STRING:
+  case DT_LVAR_STRING_ARRAY:
+  case DT_VAR_TEXTLABEL:
+  case DT_VAR_TEXTLABEL_ARRAY:
+  case DT_VAR_STRING:
+  case DT_VAR_STRING_ARRAY:
+  case DT_VARLEN_STRING:
+    return "string";
+    break;
 
-		case DT_VAR:
-		case DT_LVAR:
-			return "variable"; break;
+  case DT_VAR:
+  case DT_LVAR:
+    return "variable";
+    break;
 
-		case DT_VAR_ARRAY:
-		case DT_LVAR_ARRAY:
-			switch(arrType)
-			{
-				case ADT_INT:
-					return "int"; break;
+  case DT_VAR_ARRAY:
+  case DT_LVAR_ARRAY:
+    switch (arrType) {
+    case ADT_INT:
+      return "int";
+      break;
 
-				case ADT_FLOAT:
-					return "float"; break;
+    case ADT_FLOAT:
+      return "float";
+      break;
 
-				case ADT_TEXTLABEL:
-				case ADT_STRING:
-					return "string"; break;
+    case ADT_TEXTLABEL:
+    case ADT_STRING:
+      return "string";
+      break;
 
-				default: return "variable";
-			}
+    default:
+      return "variable";
+    }
 
-		case DT_END:
-			return "varArgEnd"; break;
+  case DT_END:
+    return "varArgEnd";
+    break;
 
-		default:
-			return "corrupted"; break;
-	}
+  default:
+    return "corrupted";
+    break;
+  }
 }
 
 const size_t MAX_STR_LEN = 0xff; // max length of string type parameter
 
-union SCRIPT_VAR
-{
-	DWORD dwParam;
-	short wParam;
-	WORD usParam;
-	BYTE ucParam;
-	char cParam;
-	bool bParam;
-	int nParam;
-	float fParam;
-	void* pParam;
-	char* pcParam;
+union SCRIPT_VAR {
+  DWORD dwParam;
+  short wParam;
+  WORD usParam;
+  BYTE ucParam;
+  char cParam;
+  bool bParam;
+  int nParam;
+  float fParam;
+  void *pParam;
+  char *pcParam;
 };
 
-enum eLogicalOperation : WORD
-{
-	NONE = 0, // just replace
+enum eLogicalOperation : WORD {
+  NONE = 0, // just replace
 
-	ANDS_1 = 1, // count of 'and' keywords in the expression
-	ANDS_2,
-	ANDS_3,
-	ANDS_4,
-	ANDS_5,
-	ANDS_6,
-	ANDS_7,
-	ANDS_8,
-	AND_END,
-	
-	ORS_1 = 21, // count of 'or' keywords in the expression
-	ORS_2,
-	ORS_3,
-	ORS_4,
-	ORS_5,
-	ORS_6,
-	ORS_7,
-	ORS_8,
-	OR_END,
+  ANDS_1 = 1, // count of 'and' keywords in the expression
+  ANDS_2,
+  ANDS_3,
+  ANDS_4,
+  ANDS_5,
+  ANDS_6,
+  ANDS_7,
+  ANDS_8,
+  AND_END,
+
+  ORS_1 = 21, // count of 'or' keywords in the expression
+  ORS_2,
+  ORS_3,
+  ORS_4,
+  ORS_5,
+  ORS_6,
+  ORS_7,
+  ORS_8,
+  OR_END,
 };
-static eLogicalOperation& operator--(eLogicalOperation& o)
-{
-	if (o == eLogicalOperation::NONE) return o; // can not be decremented anymore
-	if (o == eLogicalOperation::ORS_1) return o = eLogicalOperation::NONE;
-	
-	auto val = static_cast<WORD>(o); // to number
-	val--;
-	return o = static_cast<eLogicalOperation>(val);
+static eLogicalOperation &operator--(eLogicalOperation &o) {
+  if (o == eLogicalOperation::NONE)
+    return o; // can not be decremented anymore
+  if (o == eLogicalOperation::ORS_1)
+    return o = eLogicalOperation::NONE;
+
+  auto val = static_cast<WORD>(o); // to number
+  val--;
+  return o = static_cast<eLogicalOperation>(val);
 }
 
 // CLEO virtual path prefixes. Expandable with CLEO_ResolvePath
-const char DIR_GAME[] = "root:"; // game root directory
-const char DIR_USER[] = "user:"; // game save directory
-const char DIR_SCRIPT[] = "."; // current script directory
-const char DIR_CLEO[] = "cleo:"; // game\cleo directory
+const char DIR_GAME[] = "root:";       // game root directory
+const char DIR_USER[] = "user:";       // game save directory
+const char DIR_SCRIPT[] = ".";         // current script directory
+const char DIR_CLEO[] = "cleo:";       // game\cleo directory
 const char DIR_MODULES[] = "modules:"; // game\cleo\modules directory
 
 // argument of CLEO_RegisterCallback
-enum class eCallbackId : DWORD
-{
-	GameBegin = 0, // void WINAPI OnGameBegin(DWORD saveSlot); // game session started. -1 if not started from save
-	GameProcessBefore = 1, // void WINAPI OnGameProcessBefore(); // called once every frame before game logic processing
-	GameProcessAfter = 14, // void WINAPI OnGameProcessAfter(); // called once every frame after game logic processing
-	GameEnd = 2, // void WINAPI OnGameEnd(); // game session ended
-	ScriptsLoaded = 3, // void WINAPI OnScriptsLoaded();
-	ScriptsFinalize = 4, // void WINAPI OnScriptsFinalize(); // called after all scripts has been deleted. Pointers to scripts are no longer valid!
-	ScriptRegister = 5, // void WINAPI OnScriptRegister(CRunningScript* pScript); // called after script creation
-	ScriptUnregister = 6, // void WINAPI OnScriptUnregister(CRunningScript* pScript); // called before script deletion
-	ScriptProcessBefore = 7, // bool WINAPI OnScriptProcessBefore(CRunningScript* pScript); // return false to skip this script processing
-	ScriptProcessAfter = 15, // void WINAPI OnScriptProcessAfter(CRunningScript* pScript);
-	ScriptOpcodeProcessBefore = 8, // OpcodeResult WINAPI OnScriptOpcodeProcessBefore(CRunningScript* pScript, DWORD opcode); // return other than OR_NONE to signal that opcode was handled in the callback
-	ScriptOpcodeProcessAfter = 9, // OpcodeResult WINAPI OnScriptOpcodeProcessAfter(CRunningScript* pScript, DWORD opcode, OpcodeResult result); // return other than OR_NONE to overwrite original result
-	ScriptDraw = 10, // void WINAPI OnScriptDraw(bool beforeFade);
-	DrawingFinished = 11, // void WINAPI OnDrawingFinished(); // called after game rendered everything and before presenting screen buffer
-	Log = 12, // void OnLog(eLogLevel level, const char* msg);
-	MainWindowFocus = 13, // void WINAPI OnMainWindowFocus(bool active); // called when game main window focus changes
+enum class eCallbackId : DWORD {
+  GameBegin = 0, // void WINAPI OnGameBegin(DWORD saveSlot); // game session
+                 // started. -1 if not started from save
+  GameProcessBefore = 1, // void WINAPI OnGameProcessBefore(); // called once
+                         // every frame before game logic processing
+  GameProcessAfter = 14, // void WINAPI OnGameProcessAfter(); // called once
+                         // every frame after game logic processing
+  GameEnd = 2,           // void WINAPI OnGameEnd(); // game session ended
+  ScriptsLoaded = 3,     // void WINAPI OnScriptsLoaded();
+  ScriptsFinalize =
+      4, // void WINAPI OnScriptsFinalize(); // called after all scripts has
+         // been deleted. Pointers to scripts are no longer valid!
+  ScriptRegister = 5, // void WINAPI OnScriptRegister(CRunningScript* pScript);
+                      // // called after script creation
+  ScriptUnregister = 6, // void WINAPI OnScriptUnregister(CRunningScript*
+                        // pScript); // called before script deletion
+  ScriptProcessBefore =
+      7, // bool WINAPI OnScriptProcessBefore(CRunningScript* pScript); //
+         // return false to skip this script processing
+  ScriptProcessAfter =
+      15, // void WINAPI OnScriptProcessAfter(CRunningScript* pScript);
+  ScriptOpcodeProcessBefore =
+      8, // OpcodeResult WINAPI OnScriptOpcodeProcessBefore(CRunningScript*
+         // pScript, DWORD opcode); // return other than OR_NONE to signal that
+         // opcode was handled in the callback
+  ScriptOpcodeProcessAfter =
+      9, // OpcodeResult WINAPI OnScriptOpcodeProcessAfter(CRunningScript*
+         // pScript, DWORD opcode, OpcodeResult result); // return other than
+         // OR_NONE to overwrite original result
+  ScriptDraw = 10, // void WINAPI OnScriptDraw(bool beforeFade);
+  DrawingFinished =
+      11,   // void WINAPI OnDrawingFinished(); // called after game rendered
+            // everything and before presenting screen buffer
+  Log = 12, // void OnLog(eLogLevel level, const char* msg);
+  MainWindowFocus = 13, // void WINAPI OnMainWindowFocus(bool active); // called
+                        // when game main window focus changes
 };
 
 // used by CLEO_Log and Log callback
-enum class eLogLevel : DWORD
-{
-	None,
-	Error, // errors and warnings
-	Debug, // debug mode / user traces
-	Default // all log messages
+enum class eLogLevel : DWORD {
+  None,
+  Error,  // errors and warnings
+  Debug,  // debug mode / user traces
+  Default // all log messages
 };
 
-enum OpcodeResult : char
-{
-	OR_NONE = -2,
-	OR_ERROR = -1,
-	OR_CONTINUE = 0,
-	OR_INTERRUPT = 1,
+enum OpcodeResult : char {
+  OR_NONE = -2,
+  OR_ERROR = -1,
+  OR_CONTINUE = 0,
+  OR_INTERRUPT = 1,
 };
 
 class CRunningScript;
-typedef OpcodeResult(__stdcall* CustomOpcodeHandler)(CRunningScript*);
+typedef OpcodeResult(__stdcall *CustomOpcodeHandler)(CRunningScript *);
 
 // exports
-extern "C"
-{
-	DWORD WINAPI CLEO_GetVersion();
-	LPCSTR WINAPI CLEO_GetVersionStr(); // for example "5.0.0-alpha.1"
-	eGameVersion WINAPI CLEO_GetGameVersion();
+extern "C" {
+DWORD WINAPI CLEO_GetVersion();
+LPCSTR WINAPI CLEO_GetVersionStr(); // for example "5.0.0-alpha.1"
+eGameVersion WINAPI CLEO_GetGameVersion();
 
-	BOOL WINAPI CLEO_RegisterOpcode(WORD opcode, CustomOpcodeHandler callback);
-	BOOL WINAPI CLEO_RegisterCommand(const char* commandName, CustomOpcodeHandler callback); // uses cleo\.CONFIG\sa.json to obtain opcode number from name
-	OpcodeResult WINAPI CLEO_CallNativeOpcode(CRunningScript* script, WORD opcode); // call original unhooked opcode handler
+BOOL WINAPI CLEO_RegisterOpcode(WORD opcode, CustomOpcodeHandler callback);
+BOOL WINAPI CLEO_RegisterCommand(
+    const char *commandName,
+    CustomOpcodeHandler callback); // uses cleo\.CONFIG\sa.json to obtain opcode
+                                   // number from name
+OpcodeResult WINAPI
+CLEO_CallNativeOpcode(CRunningScript *script,
+                      WORD opcode); // call original unhooked opcode handler
 
-	void WINAPI CLEO_RegisterCallback(eCallbackId id, void* func);
-	void WINAPI CLEO_UnregisterCallback(eCallbackId id, void* func);
+void WINAPI CLEO_RegisterCallback(eCallbackId id, void *func);
+void WINAPI CLEO_UnregisterCallback(eCallbackId id, void *func);
 
-	// scripts deletion callback
-	typedef void(*FuncScriptDeleteDelegateT) (CRunningScript* script);
-	void WINAPI CLEO_AddScriptDeleteDelegate(FuncScriptDeleteDelegateT func);
-	void WINAPI CLEO_RemoveScriptDeleteDelegate(FuncScriptDeleteDelegateT func);
+// scripts deletion callback
+typedef void (*FuncScriptDeleteDelegateT)(CRunningScript *script);
+void WINAPI CLEO_AddScriptDeleteDelegate(FuncScriptDeleteDelegateT func);
+void WINAPI CLEO_RemoveScriptDeleteDelegate(FuncScriptDeleteDelegateT func);
 
+// script utils
+BOOL WINAPI
+CLEO_IsScriptRunning(const CRunningScript *thread); // check if script is active
+void WINAPI CLEO_GetScriptInfoStr(
+    CRunningScript *thread, bool currLineInfo, char *buf,
+    DWORD bufSize); // short text for displaying in error\log messages
+void WINAPI CLEO_GetScriptParamInfoStr(
+    int idexOffset, char *buf,
+    DWORD bufSize); // short text with last processed + idexOffset opcode's
+                    // parameter info (index and name if available)
+DWORD WINAPI CLEO_GetScriptBaseRelativeOffset(
+    const CRunningScript *script,
+    const BYTE *codePos); // get offset within script source file
+eCLEO_Version WINAPI
+CLEO_GetScriptVersion(const CRunningScript *thread); // get compatible version
+void WINAPI CLEO_SetScriptVersion(
+    CRunningScript *thread, eCLEO_Version version); // set compatible version
+LPCSTR WINAPI CLEO_GetScriptFilename(
+    const CRunningScript
+        *thread); // returns nullptr if provided script ptr is not valid
 
-	// script utils
-	BOOL WINAPI CLEO_IsScriptRunning(const CRunningScript* thread); // check if script is active
-	void WINAPI CLEO_GetScriptInfoStr(CRunningScript* thread, bool currLineInfo, char* buf, DWORD bufSize); // short text for displaying in error\log messages
-	void WINAPI CLEO_GetScriptParamInfoStr(int idexOffset, char* buf, DWORD bufSize); // short text with last processed + idexOffset opcode's parameter info (index and name if available)
-	DWORD WINAPI CLEO_GetScriptBaseRelativeOffset(const CRunningScript* script, const BYTE* codePos); // get offset within script source file
-	eCLEO_Version WINAPI CLEO_GetScriptVersion(const CRunningScript* thread); // get compatible version
-	void WINAPI CLEO_SetScriptVersion(CRunningScript* thread, eCLEO_Version version); // set compatible version
-	LPCSTR WINAPI CLEO_GetScriptFilename(const CRunningScript* thread); // returns nullptr if provided script ptr is not valid
+LPCSTR WINAPI CLEO_GetScriptWorkDir(const CRunningScript *thread);
+void WINAPI CLEO_SetScriptWorkDir(CRunningScript *thread, const char *path);
 
-	LPCSTR WINAPI CLEO_GetScriptWorkDir(const CRunningScript* thread);
-	void WINAPI CLEO_SetScriptWorkDir(CRunningScript* thread, const char* path);
+void WINAPI CLEO_SetThreadCondResult(CRunningScript *thread, BOOL result);
+void WINAPI CLEO_ThreadJumpAtLabelPtr(CRunningScript *thread, int offset);
+void WINAPI CLEO_TerminateScript(CRunningScript *thread);
 
-	void WINAPI CLEO_SetThreadCondResult(CRunningScript* thread, BOOL result);
-	void WINAPI CLEO_ThreadJumpAtLabelPtr(CRunningScript* thread, int offset);
-	void WINAPI CLEO_TerminateScript(CRunningScript* thread);
+int WINAPI CLEO_GetOperandType(
+    const CRunningScript *thread); // peek parameter data type. Returns int for
+                                   // legacy reason, should be eDataType.
+DWORD WINAPI
+CLEO_GetVarArgCount(CRunningScript *thread); // peek remaining var-args count
 
-	int WINAPI CLEO_GetOperandType(const CRunningScript* thread); // peek parameter data type. Returns int for legacy reason, should be eDataType.
-	DWORD WINAPI CLEO_GetVarArgCount(CRunningScript* thread); // peek remaining var-args count
+extern SCRIPT_VAR *opcodeParams;
+extern SCRIPT_VAR *missionLocals;
+extern CRunningScript *staticThreads;
 
-	extern SCRIPT_VAR* opcodeParams;
-	extern SCRIPT_VAR* missionLocals;
-	extern CRunningScript* staticThreads;
+BYTE *WINAPI CLEO_GetScmMainData(); // get pointer to main script block.
+                                    // Supports limit adjusters
+SCRIPT_VAR *WINAPI
+CLEO_GetOpcodeParamsArray(); // get pointer to 'SCRIPT_VAR[32] opcodeParams'.
+                             // Used by Retrieve/Record opcode params functions
+BYTE WINAPI CLEO_GetParamsHandledCount(); // number of already read/written
+                                          // opcode parameters since current
+                                          // opcode handler was called
 
-	BYTE* WINAPI CLEO_GetScmMainData(); // get pointer to main script block. Supports limit adjusters
-	SCRIPT_VAR* WINAPI CLEO_GetOpcodeParamsArray(); // get pointer to 'SCRIPT_VAR[32] opcodeParams'. Used by Retrieve/Record opcode params functions
-	BYTE WINAPI CLEO_GetParamsHandledCount(); // number of already read/written opcode parameters since current opcode handler was called
+// param read
+SCRIPT_VAR *WINAPI CLEO_GetPointerToScriptVariable(
+    CRunningScript
+        *thread); // get pointer to the variable's data, nullptr if parameter is
+                  // not variable. Advances script to next param
+void WINAPI CLEO_RetrieveOpcodeParams(
+    CRunningScript *thread,
+    int count); // read multiple params. Stored in opcodeParams array
+DWORD WINAPI CLEO_GetIntOpcodeParam(CRunningScript *thread);
+float WINAPI CLEO_GetFloatOpcodeParam(CRunningScript *thread);
+LPCSTR WINAPI CLEO_ReadStringOpcodeParam(
+    CRunningScript *thread, char *buff = nullptr,
+    int buffSize =
+        0); // read always null-terminated string into buffer, clamped to its
+            // size. If no buffer provided then internal, globally shared by all
+            // CLEO_ReadStringOpcodeParam calls, is used. Returns pointer to the
+            // result buffer or nullptr on fail
+LPCSTR WINAPI CLEO_ReadStringPointerOpcodeParam(
+    CRunningScript *thread, char *buff = nullptr,
+    int buffSize =
+        0); // read always null-terminated string into buffer, clamped to its
+            // size. If no buffer provided then internal, globally shared by all
+            // CLEO_ReadStringPointerOpcodeParam calls, is used. WARNING:
+            // returned pointer may differ from buff and contain string longer
+            // than buffSize (ptr to original data source)
+void WINAPI CLEO_ReadStringParamWriteBuffer(
+    CRunningScript *thread, char **outBuf, int *outBufSize,
+    BOOL *outNeedsTerminator); // get info about the string opcode param, so it
+                               // can be written latter. If outNeedsTerminator
+                               // is not 0 then whole bufSize can be used as
+                               // text characters. Advances script to next param
+char *WINAPI CLEO_ReadParamsFormatted(
+    CRunningScript *thread, const char *format, char *buf = nullptr,
+    int bufSize = 0); // consumes all var-arg params and terminator
+// get param value without advancing the script
+DWORD WINAPI CLEO_PeekIntOpcodeParam(CRunningScript *thread);
+float WINAPI CLEO_PeekFloatOpcodeParam(CRunningScript *thread);
+SCRIPT_VAR *WINAPI CLEO_PeekPointerToScriptVariable(
+    CRunningScript *thread); // get pointer to the variable's data, nullptr if
+                             // parameter is not variable
 
-	// param read
-	SCRIPT_VAR* WINAPI CLEO_GetPointerToScriptVariable(CRunningScript* thread); // get pointer to the variable's data, nullptr if parameter is not variable. Advances script to next param
-	void WINAPI CLEO_RetrieveOpcodeParams(CRunningScript* thread, int count); // read multiple params. Stored in opcodeParams array
-	DWORD WINAPI CLEO_GetIntOpcodeParam(CRunningScript* thread);
-	float WINAPI CLEO_GetFloatOpcodeParam(CRunningScript* thread);
-	LPCSTR WINAPI CLEO_ReadStringOpcodeParam(CRunningScript* thread, char* buff = nullptr, int buffSize = 0); // read always null-terminated string into buffer, clamped to its size. If no buffer provided then internal, globally shared by all CLEO_ReadStringOpcodeParam calls, is used. Returns pointer to the result buffer or nullptr on fail
-	LPCSTR WINAPI CLEO_ReadStringPointerOpcodeParam(CRunningScript* thread, char* buff = nullptr, int buffSize = 0); // read always null-terminated string into buffer, clamped to its size. If no buffer provided then internal, globally shared by all CLEO_ReadStringPointerOpcodeParam calls, is used. WARNING: returned pointer may differ from buff and contain string longer than buffSize (ptr to original data source) 
-	void WINAPI CLEO_ReadStringParamWriteBuffer(CRunningScript* thread, char** outBuf, int* outBufSize, BOOL* outNeedsTerminator); // get info about the string opcode param, so it can be written latter. If outNeedsTerminator is not 0 then whole bufSize can be used as text characters. Advances script to next param
-	char* WINAPI CLEO_ReadParamsFormatted(CRunningScript* thread, const char* format, char* buf = nullptr, int bufSize = 0); // consumes all var-arg params and terminator
-	// get param value without advancing the script
-	DWORD WINAPI CLEO_PeekIntOpcodeParam(CRunningScript* thread);
-	float WINAPI CLEO_PeekFloatOpcodeParam(CRunningScript* thread);
-	SCRIPT_VAR* WINAPI CLEO_PeekPointerToScriptVariable(CRunningScript* thread); // get pointer to the variable's data, nullptr if parameter is not variable
+// param skip without reading
+void WINAPI CLEO_SkipOpcodeParams(CRunningScript *thread, int count);
+void WINAPI CLEO_SkipUnusedVarArgs(
+    CRunningScript
+        *thread); // for var-args opcodes. Should be called even when all params
+                  // were read (to skip var-arg terminator)
 
-	// param skip without reading
-	void WINAPI CLEO_SkipOpcodeParams(CRunningScript* thread, int count);
-	void WINAPI CLEO_SkipUnusedVarArgs(CRunningScript* thread); // for var-args opcodes. Should be called even when all params were read (to skip var-arg terminator)
+// param write
+void WINAPI CLEO_RecordOpcodeParams(
+    CRunningScript *thread,
+    int count); // write multiple params from opcodeParams array
+void WINAPI CLEO_SetIntOpcodeParam(CRunningScript *thread, DWORD value);
+void WINAPI CLEO_SetFloatOpcodeParam(CRunningScript *thread, float value);
+void WINAPI CLEO_WriteStringOpcodeParam(CRunningScript *thread,
+                                        const char *str);
 
-	// param write
-	void WINAPI CLEO_RecordOpcodeParams(CRunningScript* thread, int count); // write multiple params from opcodeParams array
-	void WINAPI CLEO_SetIntOpcodeParam(CRunningScript* thread, DWORD value);
-	void WINAPI CLEO_SetFloatOpcodeParam(CRunningScript* thread, float value);
-	void WINAPI CLEO_WriteStringOpcodeParam(CRunningScript* thread, const char* str);
+BOOL WINAPI CLEO_GetScriptDebugMode(
+    const CRunningScript
+        *thread); // debug mode features enabled for this script?
+void WINAPI CLEO_SetScriptDebugMode(CRunningScript *thread, BOOL enabled);
 
+CRunningScript *WINAPI CLEO_CreateCustomScript(CRunningScript *fromThread,
+                                               const char *filePath, int label);
+CRunningScript *WINAPI CLEO_GetLastCreatedCustomScript();
+CRunningScript *WINAPI CLEO_GetScriptByName(
+    const char *threadName, BOOL standardScripts, BOOL customScripts,
+    DWORD resultIndex = 0); // can be called multiple times to find more scripts
+                            // named threadName. resultIndex should be
+                            // incremented until the method returns nullptr
+CRunningScript *WINAPI CLEO_GetScriptByFilename(
+    const char *path,
+    DWORD resultIndex = 0); // can be absolute, partial path or just filename
 
-	BOOL WINAPI CLEO_GetScriptDebugMode(const CRunningScript* thread); // debug mode features enabled for this script?
-	void WINAPI CLEO_SetScriptDebugMode(CRunningScript* thread, BOOL enabled);
+DWORD WINAPI CLEO_GetScriptTextureById(CRunningScript *thread,
+                                       int id); // returns RwTexture*
 
-	CRunningScript* WINAPI CLEO_CreateCustomScript(CRunningScript* fromThread, const char* filePath, int label);
-	CRunningScript* WINAPI CLEO_GetLastCreatedCustomScript();
-	CRunningScript* WINAPI CLEO_GetScriptByName(const char* threadName, BOOL standardScripts, BOOL customScripts, DWORD resultIndex = 0); // can be called multiple times to find more scripts named threadName. resultIndex should be incremented until the method returns nullptr
-	CRunningScript* WINAPI CLEO_GetScriptByFilename(const char* path, DWORD resultIndex = 0); // can be absolute, partial path or just filename
+DWORD WINAPI CLEO_GetInternalAudioStream(
+    CRunningScript *unused,
+    DWORD scriptAudioStreamHandle); // returns BASS' HSTREAM
 
-	DWORD WINAPI CLEO_GetScriptTextureById(CRunningScript* thread, int id); // returns RwTexture*
+struct StringList {
+  DWORD count;
+  char **strings;
+};
+void WINAPI CLEO_StringListFree(
+    StringList list); // releases resources used by StringList container
 
-	DWORD WINAPI CLEO_GetInternalAudioStream(CRunningScript* unused, DWORD scriptAudioStreamHandle); // returns BASS' HSTREAM
+// Should be always used when working with files. Provides ModLoader
+// compatibility
+void WINAPI
+CLEO_ResolvePath(CRunningScript *thread, char *inOutPath,
+                 DWORD pathMaxLen); // convert to absolute (file system) path
+StringList WINAPI CLEO_ListDirectory(
+    CRunningScript *thread, const char *searchPath, BOOL listDirs,
+    BOOL listFiles); // thread can be null, searchPath can contain wildcards.
+                     // After use CLEO_StringListFree must be called on returned
+                     // StringList to free its resources
+LPCSTR WINAPI CLEO_GetGameDirectory(); // absolute game directory filepath
+                                       // without trailling path separator
+LPCSTR WINAPI
+CLEO_GetUserDirectory(); // absolute game user files directory filepath without
+                         // trailling path separator
 
-	struct StringList { DWORD count; char** strings; };
-	void WINAPI CLEO_StringListFree(StringList list); // releases resources used by StringList container
-
-	// Should be always used when working with files. Provides ModLoader compatibility
-	void WINAPI CLEO_ResolvePath(CRunningScript* thread, char* inOutPath, DWORD pathMaxLen); // convert to absolute (file system) path
-	StringList WINAPI CLEO_ListDirectory(CRunningScript* thread, const char* searchPath, BOOL listDirs, BOOL listFiles); // thread can be null, searchPath can contain wildcards. After use CLEO_StringListFree must be called on returned StringList to free its resources
-	LPCSTR WINAPI CLEO_GetGameDirectory(); // absolute game directory filepath without trailling path separator
-	LPCSTR WINAPI CLEO_GetUserDirectory(); // absolute game user files directory filepath without trailling path separator
-
-	void WINAPI CLEO_Log(eLogLevel level, const char* msg); // add message to log
+void WINAPI CLEO_Log(eLogLevel level, const char *msg); // add message to log
 }
 
-#pragma pack(push,1)
-class CRunningScript
-{
+#pragma pack(push, 1)
+class CRunningScript {
 public:
-	CRunningScript* Next;		// 0x00 next script in queue
-	CRunningScript* Previous;	// 0x04 previous script in queue
-	char Name[8];				// 0x08 name of script, given by 03A4 opcode
-	void* BaseIP;				// 0x10 pointer to begin of script in memory
-	BYTE* CurrentIP;			// 0x14 current instruction pointer
-	BYTE* Stack[8];				// 0x18 return stack for 0050, 0051
-	WORD SP;					// 0x38 current item in stack
-	BYTE _pad3A[2];				// 0x3A padding
-	SCRIPT_VAR LocalVar[32];	// 0x3C script's local variables
-	DWORD Timers[2];			// 0xBC script's timers
-	bool bIsActive;				// 0xC4 is script active
-	bool bCondResult;			// 0xC5 condition result. Use SetConditionResult to modify!
-	bool bUseMissionCleanup;	// 0xC6 clean mission
-	bool bIsExternal;			// 0xC7 is thread external (from script.img)
-	bool bTextBlockOverride;	// 0xC8
-	BYTE bExternalType;			// 0xC9
-	BYTE _padCA[2];				// 0xCA padding
-	DWORD WakeTime;				// 0xCC time, when script starts again after 0001 opcode
-	eLogicalOperation LogicalOp;// 0xD0 opcode 00D6 parameter
-	bool NotFlag;				// 0xD2 opcode & 0x8000 != 0
-	bool bWastedBustedCheck;	// 0xD3 wasted_or_busted check flag
-	bool bWastedOrBusted;		// 0xD4 is player wasted or busted
-	char _padD5[3];				// 0xD5 padding
-	void* SceneSkipIP;			// 0xD8 scene skip label ptr
-	bool bIsMission;			// 0xDC is this script mission
-	WORD ScmFunction;			// 0xDD CLEO's previous scmFunction id
-	bool bIsCustom;				// 0xDF is this CLEO script
+  CRunningScript *Next;     // 0x00 next script in queue
+  CRunningScript *Previous; // 0x04 previous script in queue
+  char Name[8];             // 0x08 name of script, given by 03A4 opcode
+  void *BaseIP;             // 0x10 pointer to begin of script in memory
+  BYTE *CurrentIP;          // 0x14 current instruction pointer
+  BYTE *Stack[8];           // 0x18 return stack for 0050, 0051
+  WORD SP;                  // 0x38 current item in stack
+  BYTE _pad3A[2];           // 0x3A padding
+  SCRIPT_VAR LocalVar[32];  // 0x3C script's local variables
+  DWORD Timers[2];          // 0xBC script's timers
+  bool bIsActive;           // 0xC4 is script active
+  bool bCondResult; // 0xC5 condition result. Use SetConditionResult to modify!
+  bool bUseMissionCleanup; // 0xC6 clean mission
+  bool bIsExternal;        // 0xC7 is thread external (from script.img)
+  bool bTextBlockOverride; // 0xC8
+  BYTE bExternalType;      // 0xC9
+  BYTE _padCA[2];          // 0xCA padding
+  DWORD WakeTime; // 0xCC time, when script starts again after 0001 opcode
+  eLogicalOperation LogicalOp; // 0xD0 opcode 00D6 parameter
+  bool NotFlag;                // 0xD2 opcode & 0x8000 != 0
+  bool bWastedBustedCheck;     // 0xD3 wasted_or_busted check flag
+  bool bWastedOrBusted;        // 0xD4 is player wasted or busted
+  char _padD5[3];              // 0xD5 padding
+  void *SceneSkipIP;           // 0xD8 scene skip label ptr
+  bool bIsMission;             // 0xDC is this script mission
+  WORD ScmFunction;            // 0xDD CLEO's previous scmFunction id
+  bool bIsCustom;              // 0xDF is this CLEO script
 
 public:
-	CRunningScript()
-	{
-		strcpy_s(Name, "noname");
-		BaseIP = 0;
-		Previous = 0;
-		Next = 0;
-		CurrentIP = 0;
-		memset(Stack, 0, sizeof(Stack));
-		SP = 0;
-		WakeTime = 0;
-		bIsActive = false;
-		bCondResult = false;
-		bUseMissionCleanup = false;
-		bIsExternal = false;
-		bTextBlockOverride = false;
-		bExternalType = -1;
-		memset(LocalVar, 0, sizeof(LocalVar));
-		LogicalOp = eLogicalOperation::NONE;
-		NotFlag = false;
-		bWastedBustedCheck = true;
-		bWastedOrBusted = false;
-		SceneSkipIP = 0;
-		bIsMission = false;
-		ScmFunction = 0;
-		bIsCustom = false;
-	}
+  CRunningScript() {
+    strcpy_s(Name, "noname");
+    BaseIP = 0;
+    Previous = 0;
+    Next = 0;
+    CurrentIP = 0;
+    memset(Stack, 0, sizeof(Stack));
+    SP = 0;
+    WakeTime = 0;
+    bIsActive = false;
+    bCondResult = false;
+    bUseMissionCleanup = false;
+    bIsExternal = false;
+    bTextBlockOverride = false;
+    bExternalType = -1;
+    memset(LocalVar, 0, sizeof(LocalVar));
+    LogicalOp = eLogicalOperation::NONE;
+    NotFlag = false;
+    bWastedBustedCheck = true;
+    bWastedOrBusted = false;
+    SceneSkipIP = 0;
+    bIsMission = false;
+    ScmFunction = 0;
+    bIsCustom = false;
+  }
 
-	bool IsActive() const { return bIsActive; }
-	bool IsExternal() const { return bIsExternal; }
-	bool IsMission() const { return bIsMission; }
-	bool IsCustom() const { return bIsCustom; } // is this CLEO Script?
-	std::string GetName() const { auto str = std::string(Name, Name + 8); str.resize(strlen(str.c_str())); return str; } // make sure it is always null terminated
-	BYTE* GetBasePointer() const { return (BYTE*)BaseIP; }
-	BYTE* GetBytePointer() const { return CurrentIP; }
-	void SetIp(void* ip) { CurrentIP = (BYTE*)ip; }
-	void SetBaseIp(void* ip) { BaseIP = ip; }
-	void Jump(int offset) { CLEO_ThreadJumpAtLabelPtr(this, offset); }
-	CRunningScript* GetNext() const { return Next; }
-	CRunningScript* GetPrev() const { return Previous; }
-	void SetIsExternal(bool b) { bIsExternal = b; }
-	void SetActive(bool b) { bIsActive = b; }
-	OpcodeResult Suspend() { WakeTime = 0xFFFFFFFF; return OpcodeResult::OR_INTERRUPT; } // suspend script execution forever
-	void SetNext(CRunningScript* v) { Next = v; }
-	void SetPrev(CRunningScript* v) { Previous = v; }
-	SCRIPT_VAR* GetVarPtr() { return LocalVar; }
-	SCRIPT_VAR* GetVarPtr(int i) { return &LocalVar[i]; }
-	int* GetIntVarPtr(int i) { return (int*)&LocalVar[i].dwParam; }
-	int GetIntVar(int i) const { return LocalVar[i].dwParam; }
-	void SetIntVar(int i, int v) { LocalVar[i].dwParam = v; }
-	void SetFloatVar(int i, float v) { LocalVar[i].fParam = v; }
-	char GetByteVar(int i) const { return LocalVar[i].bParam; }
-	bool GetConditionResult() const { return bCondResult != false; }
-	void SetConditionResult(bool result) { CLEO_SetThreadCondResult(this, result); }
-	bool GetNotFlag() const { return NotFlag; }
-	void SetNotFlag(bool state) { NotFlag = state; }
+  bool IsActive() const { return bIsActive; }
+  bool IsExternal() const { return bIsExternal; }
+  bool IsMission() const { return bIsMission; }
+  bool IsCustom() const { return bIsCustom; } // is this CLEO Script?
+  std::string GetName() const {
+    auto str = std::string(Name, Name + 8);
+    str.resize(strlen(str.c_str()));
+    return str;
+  } // make sure it is always null terminated
+  BYTE *GetBasePointer() const { return (BYTE *)BaseIP; }
+  BYTE *GetBytePointer() const { return CurrentIP; }
+  void SetIp(void *ip) { CurrentIP = (BYTE *)ip; }
+  void SetBaseIp(void *ip) { BaseIP = ip; }
+  void Jump(int offset) { CLEO_ThreadJumpAtLabelPtr(this, offset); }
+  CRunningScript *GetNext() const { return Next; }
+  CRunningScript *GetPrev() const { return Previous; }
+  void SetIsExternal(bool b) { bIsExternal = b; }
+  void SetActive(bool b) { bIsActive = b; }
+  OpcodeResult Suspend() {
+    WakeTime = 0xFFFFFFFF;
+    return OpcodeResult::OR_INTERRUPT;
+  } // suspend script execution forever
+  void SetNext(CRunningScript *v) { Next = v; }
+  void SetPrev(CRunningScript *v) { Previous = v; }
+  SCRIPT_VAR *GetVarPtr() { return LocalVar; }
+  SCRIPT_VAR *GetVarPtr(int i) { return &LocalVar[i]; }
+  int *GetIntVarPtr(int i) { return (int *)&LocalVar[i].dwParam; }
+  int GetIntVar(int i) const { return LocalVar[i].dwParam; }
+  void SetIntVar(int i, int v) { LocalVar[i].dwParam = v; }
+  void SetFloatVar(int i, float v) { LocalVar[i].fParam = v; }
+  char GetByteVar(int i) const { return LocalVar[i].bParam; }
+  bool GetConditionResult() const { return bCondResult != false; }
+  void SetConditionResult(bool result) {
+    CLEO_SetThreadCondResult(this, result);
+  }
+  bool GetNotFlag() const { return NotFlag; }
+  void SetNotFlag(bool state) { NotFlag = state; }
 
-	eDataType PeekDataType() const { return *(eDataType*)CurrentIP; }
-	eDataType ReadDataType() { return (eDataType)ReadByte(); }
+  eDataType PeekDataType() const { return *(eDataType *)CurrentIP; }
+  eDataType ReadDataType() { return (eDataType)ReadByte(); }
 
-	eArrayDataType PeekArrayType() const { return (eArrayDataType)(!IsArray(PeekDataType()) ? ADT_NONE : *(CurrentIP + 1 + 2 + 2 + 1) & ArrayTypeMask); }
-	WORD ReadVarIndex() { return ReadWord(); }
-	WORD ReadArrayOffset() { return ReadWord(); }
-	WORD ReadArrayIndexVarIndex() { return ReadWord(); } // index of variable sotring array element index
-	BYTE ReadArraySize() { return ReadByte(); }
-	BYTE ReadArrayFlags() { return ReadByte(); }
+  eArrayDataType PeekArrayType() const {
+    return (eArrayDataType)(!IsArray(PeekDataType())
+                                ? ADT_NONE
+                                : *(CurrentIP + 1 + 2 + 2 + 1) & ArrayTypeMask);
+  }
+  WORD ReadVarIndex() { return ReadWord(); }
+  WORD ReadArrayOffset() { return ReadWord(); }
+  WORD ReadArrayIndexVarIndex() {
+    return ReadWord();
+  } // index of variable sotring array element index
+  BYTE ReadArraySize() { return ReadByte(); }
+  BYTE ReadArrayFlags() { return ReadByte(); }
 
-	void IncPtr(int n = 1) { CurrentIP += n; }
-	BYTE ReadByte() { BYTE b = *CurrentIP; CurrentIP += sizeof(BYTE); return b; }
-	WORD ReadWord() { WORD v = *(WORD*)CurrentIP; CurrentIP += sizeof(WORD); return v; }
-	DWORD ReadDword() { DWORD i = *(DWORD*)CurrentIP; CurrentIP += sizeof(DWORD); return i; }
+  void IncPtr(int n = 1) { CurrentIP += n; }
+  BYTE ReadByte() {
+    BYTE b = *CurrentIP;
+    CurrentIP += sizeof(BYTE);
+    return b;
+  }
+  WORD ReadWord() {
+    WORD v = *(WORD *)CurrentIP;
+    CurrentIP += sizeof(WORD);
+    return v;
+  }
+  DWORD ReadDword() {
+    DWORD i = *(DWORD *)CurrentIP;
+    CurrentIP += sizeof(DWORD);
+    return i;
+  }
 
-	void PushStack(BYTE* ptr) { Stack[SP++] = ptr; }
-	BYTE* PopStack() { return Stack[--SP]; }
+  void PushStack(BYTE *ptr) { Stack[SP++] = ptr; }
+  BYTE *PopStack() { return Stack[--SP]; }
 
-	WORD GetScmFunction() const { return ScmFunction; }
-	void SetScmFunction(WORD id) { ScmFunction = id; }
+  WORD GetScmFunction() const { return ScmFunction; }
+  void SetScmFunction(WORD id) { ScmFunction = id; }
 };
 #pragma pack(pop)
-static_assert(sizeof(CRunningScript) == 0xE0, "Invalid size of CRunningScript!");
+static_assert(sizeof(CRunningScript) == 0xE0,
+              "Invalid size of CRunningScript!");
 
-} // CLEO namespace
+} // namespace CLEO

--- a/cleo_sdk/CLEO_Utils.h
+++ b/cleo_sdk/CLEO_Utils.h
@@ -4,16 +4,17 @@
 //   $(PLUGIN_SDK_DIR)\plugin_sa\
 //   $(PLUGIN_SDK_DIR)\shared\game\
 //   $(PLUGIN_SDK_DIR)\plugin_sa\game_sa\
-// 
-// Add following lines to "Preprocesor Definitions": 
+//
+// Add following lines to "Preprocesor Definitions":
 //   GTASA
 //   TARGET_NAME=R"($(TargetName))"
-// 
-// Depending on used functions, may require adding "CPools.cpp" from GTA Plugin SDK to the project files
+//
+// Depending on used functions, may require adding "CPools.cpp" from GTA Plugin
+// SDK to the project files
 
 #pragma once
 #include "CLEO.h"
-#include "CPools.h" // from GTA Plugin SDK
+#include "CPools.h"   // from GTA Plugin SDK
 #include "shellapi.h" // game window minimize/maximize support
 #include <algorithm>
 #include <filesystem>
@@ -22,872 +23,1216 @@
 #include <vector>
 #include <wtypes.h>
 
-namespace CLEO
-{
-    /*
-    TRACE(format,...) // log to file. Can be displayed on screen with change in DebugUtils.ini
-    LOG_WARNING(script, format, ...) // warning text on screen and in log file. Not displayed for scripts in 'legacy' mode
-    SHOW_ERROR(a,...) // message box, log to file
-
-    Macros to use inside opcode handler functions. Performs types validation, printing warnings and suspending script on critical errors.
-    Please mind those expand into multiple lines, so CAN NOT be used in places where single code line is expected! (like 'if' condition body without brackets)
-    
-    OPCODE_CONDITION_RESULT(value) // set command logical result
-
-    OPCODE_SKIP_PARAMS(count) // ignore X params
-    OPCODE_SKIP_VARARG_PARAMS(count) // ignore remaining variable arguments, including varArg terminator
-
-    OPCODE_PEEK_PARAM_TYPE() // get param type without advancing the script
-    OPCODE_PEEK_VARARG_COUNT() // get count of remaining variable arguments (not including varArg terminator)
-    
-    // reading opcode input arguments
-    OPCODE_READ_PARAM_BOOL()
-    OPCODE_READ_PARAM_INT8()
-    OPCODE_READ_PARAM_UINT8()
-    OPCODE_READ_PARAM_INT16()
-    OPCODE_READ_PARAM_UINT16()
-    OPCODE_READ_PARAM_INT()
-    OPCODE_READ_PARAM_UINT()
-    OPCODE_READ_PARAM_FLOAT()
-    OPCODE_READ_PARAM_ANY32() // get raw data of any simple-type value (practically integers and floats)
-    OPCODE_READ_PARAM_STRING(varName) // reads param and creates const char* variable named 'varName' with pointer to null-terminated string
-    OPCODE_READ_PARAM_STRING_LEN(varName, maxLength) // same as above, but text length is clamped to maxLength
-    OPCODE_READ_PARAM_STRING_FORMATTED(varName) // reads "format" string argument, then all var-args. Creates variable named 'varName' containing formatted text. Creates 'varNameOk' variable with pointer to the text, or nullptr if user provided invalid arguments
-    OPCODE_READ_PARAMS_FORMATTED(format, varName) // reads all var-args and tries to put them into formatted string. Creates variable named 'varName' containing formatted text. Creates 'varNameOk' variable with pointer to the text, or nullptr if user provided invalid arguments
-    OPCODE_READ_PARAM_FILEPATH(varName) // reads param and creates const char* variable named 'varName' with pointer to resolved, null-terminated, filepath
-    OPCODE_READ_PARAM_PTR() // read and validate memory address argument
-    OPCODE_READ_PARAM_OBJECT_HANDLE() // read and validate game object handle
-    OPCODE_READ_PARAM_PED_HANDLE() // read and validate character (ped/actor) handle
-    OPCODE_READ_PARAM_PLAYER_ID() // read and validate player id
-    OPCODE_READ_PARAM_VEHICLE_HANDLE() // read and validate vehicle handle
-
-    // for opcodes with mixed params order, where 'strore_to' occurs before input arguments 
-    OPCODE_READ_PARAM_OUTPUT_VAR_INT() // get pointer to integer variable param to write result later
-    OPCODE_READ_PARAM_OUTPUT_VAR_FLOAT() // get pointer to float variable param to write result later
-    OPCODE_READ_PARAM_OUTPUT_VAR_ANY32() // get pointer to simple-type variable param to write result later
-    OPCODE_READ_PARAM_OUTPUT_VAR_STRING() // returns instance of StringParamBufferInfo used to write string param later
-
-    // writing opcode output/result data
-    OPCODE_WRITE_PARAM_BOOL(value)
-    OPCODE_WRITE_PARAM_INT8(value)
-    OPCODE_WRITE_PARAM_UINT8(value)
-    OPCODE_WRITE_PARAM_INT16(value)
-    OPCODE_WRITE_PARAM_UINT16(value)
-    OPCODE_WRITE_PARAM_INT(value)
-    OPCODE_WRITE_PARAM_UINT(value)
-    OPCODE_WRITE_PARAM_FLOAT(value)
-    OPCODE_WRITE_PARAM_ANY32(value) // write raw data into simple-type variable (practically integers and floats)
-    OPCODE_WRITE_PARAM_STRING(value)
-    OPCODE_WRITE_PARAM_STRING_INFO(info, value) // write param using info object revceived from OPCODE_READ_PARAM_OUTPUT_VAR_STRING
-    OPCODE_WRITE_PARAM_PTR(value) // memory address
-    */
-
-    static bool IsLegacyScript(CLEO::CRunningScript* thread)
-    {
-        return CLEO_GetScriptVersion(thread) < CLEO_VER_5;
-    }
-
-    static std::string StringPrintf(const char* format, ...)
-    {
-        va_list args;
-
-        va_start(args, format);
-        auto len = std::vsnprintf(nullptr, 0, format, args);
-        va_end(args);
-
-        if (len <= 0) return {}; // empty or encoding error
-
-        std::string result;
-        result.resize(len);
-
-        va_start(args, format);
-        std::vsnprintf(result.data(), result.length() + 1, format, args);
-        va_end(args);
-
-        return result;
-    }
-
-    static bool StringStartsWith(const std::string_view str, const std::string_view prefix, bool caseSensitive = true)
-    {
-        if (str.length() < prefix.length())
-        {
-            return false;
-        }
-
-        if (caseSensitive)
-        {
-            return strncmp(str.data(), prefix.data(), prefix.length()) == 0;
-        }
-        else
-        {
-            return _strnicmp(str.data(), prefix.data(), prefix.length()) == 0;
-        }
-    }
-
-    static bool StringEndsWith(const std::string_view str, const std::string_view suffix, bool caseSensitive = true)
-    {
-        if (str.length() < suffix.length())
-        {
-            return false;
-        }
-
-        if (caseSensitive)
-        {
-            return strncmp(&str.back() + 1 - suffix.length(), suffix.data(), suffix.length()) == 0;
-        }
-        else
-        {
-            return _strnicmp(&str.back() + 1 - suffix.length(), suffix.data(), suffix.length()) == 0;
-        }
-    }
-
-    static void StringSplit(const std::string_view str, const std::string_view delimiters, std::vector<std::string>& output)
-    {
-        size_t prevPos = 0;
-        while (true)
-        {
-            size_t pos = str.find_first_of(delimiters, prevPos);
-
-            if (pos == std::string::npos)
-            {
-                if (strlen(str.data() + prevPos) > 0)
-                {
-                    output.emplace_back(str.data() + prevPos);
-                }
-                break;
-            }
-            else
-            {
-                if (pos - prevPos > 0)
-                {
-                    output.emplace_back(str.data() + prevPos, pos - prevPos);
-                }
-                prevPos = pos + 1;
-            }
-        }
-    }
-  
-    // erase GTA's text formatting sequences like ~r~
-    static void StringRemoveFormatting(std::string& str)
-    {
-        size_t pos = 0;
-        while (true)
-        {
-            pos = str.find('~', pos);
-            if (pos == std::string::npos || 
-                (pos + 2) >= str.length()) // not enought characters left for formatting sequence
-            {
-                break;
-            }
-
-            if (str[pos + 2] != '~')
-            {
-                pos++;
-                continue;
-            }
-
-            switch (str[pos + 1])
-            {
-                case 'n':
-                case 'N':
-                    str.replace(pos, 3, "\n");
-                    break;
-                
-                default:
-                    str.erase(pos, 3);
-                    break;
-            }
-        }
-    }
-
-    static void StringToLower(std::string& str)
-    {
-        std::transform(str.begin(), str.end(), str.begin(), [](unsigned char c) { return tolower(c); });
-    }
-
-    static std::string ScriptInfoStr(CLEO::CRunningScript* thread)
-    {
-        std::string info(1024, '\0');
-        CLEO_GetScriptInfoStr(thread, true, info.data(), info.length());
-        return std::move(info);
-    }
-
-    // Normalize filepath, collapse all parent directory references, trim path separators at front and back. Input should be path without expandable %variables%
-    static void FilepathNormalize(std::string& path, bool normalizeCase = true)
-    {
-        if (path.empty()) return;
-
-        std::replace(path.begin(), path.end(), '/', '\\');
-
-        // remove doubled separators
-        size_t pos;
-        while ((pos = path.find("\\\\")) != std::string::npos)
-        {
-            path.erase(pos, 1);
-        }
-
-        if (normalizeCase) StringToLower(path);
-
-        // collapse references to parent directory
-        const auto ParentRef = "\\..\\";
-        const auto ParentRefLen = 4;
-
-        size_t refPos = path.find(ParentRef);
-        while (refPos != std::string::npos && refPos > 0)
-        {
-            size_t parentPos = path.rfind('\\', refPos - 1); // find start of parent dir name
-
-            if (parentPos == std::string::npos) // no more separators, so parent has to be root dir
-            {
-                parentPos = 0;
-                refPos += 1; // remove following separator too
-            }
-
-            if (_strnicmp(path.c_str() + parentPos, "..\\", 3) == 0)
-            {
-                break; // parent directory is reference to parent directory too
-            }
-
-            path.replace(parentPos, (refPos - parentPos) + ParentRefLen - 1, ""); // remove parent dir along with following \\..
-
-            refPos = path.find(ParentRef); // find next
-        }
-
-        // trim separators
-        while (path.front() == '\\') path.erase(0, 1);
-        while (path.back() == '\\') path.pop_back();
-    }
-
-    // strip parent prefix from filepath if present
-    // 1. FilepathRemoveParent("C:\game\cleo\1.cs", "C:\game") => cleo\1.cs
-    // 2. FilepathRemoveParent("C:cleo\1.cs", "C:") => cleo\1.cs
-    static void FilepathRemoveParent(std::string& path, const std::string_view base)
-    {
-        if (path.length() < base.length()) return; // can not hold that prefix
-        if (!StringStartsWith(path, base, false)) return;
-        if (path.length() > base.length() && path[base.length()] != '\\' && path[base.length()-1] != ':') return; // just similar base
-
-        auto to = base.length();
-        if (path[to] == '\\')
-        {
-            // remove path separator too if present
-            to += 1;
-        }
-        path.replace(0, to, ""); 
-    }
-
-    // get path without last file/directory element
-    static const std::string_view FilepathGetParent(const std::string_view str)
-    {
-        auto separatorPos = str.find_last_of('\\');
-
-        if (separatorPos == std::string::npos)
-        {
-            return {};
-        }
-
-        return std::string_view(str.data(), separatorPos);
-    }
-
-    // this plugin's config file
-    static std::string GetConfigFilename()
-    {
-        std::string path = CLEO_GetGameDirectory();
-        path += "\\cleo\\cleo_plugins\\";
-        path += TARGET_NAME;
-        path += ".ini";
-        return path;
-    }
-
-    // does normalized file path points inside game directories? (game root or user files)
-    static bool FilepathIsSafe(CLEO::CRunningScript* thread, const char* path)
-    {
-        if (strchr(path, '%') != nullptr)
-        {
-            return false; // do not allow paths containing expandable variables
-        }
-
-        std::string absolute;
-        if (!std::filesystem::path(path).is_absolute())
-        {
-            absolute = CLEO_GetScriptWorkDir(thread);
-            if (!absolute.empty())
-            {
-                absolute += '\\';
-                absolute += path;
-                FilepathNormalize(absolute, false);
-                path = absolute.c_str();
-            }
-        }
-
-        if (!StringStartsWith(path, CLEO_GetGameDirectory(), false) &&
-            !StringStartsWith(path, CLEO_GetUserDirectory(), false))
-        {
-            if (StringStartsWith(path, "..")) // relative path trying to escape game's directory
-                return false;
-        }
-
-        return true;
-    }
-
-    static bool IsObjectHandleValid(DWORD handle)
-    {
-        // get handle info
-        auto flags = handle & 0xFF;
-        auto index = handle >> 8;
-
-        if (index >= (DWORD)CPools::ms_pObjectPool->m_nSize)
-            return false; // index out of bounds
-
-        if (CPools::ms_pObjectPool->m_byteMap[index].IntValue() != flags)
-            return false; // flags mismatch
-
-        return true;
-    }
-
-    static bool IsPedHandleValid(DWORD handle)
-    {
-        // get handle info
-        auto flags = handle & 0xFF;
-        auto index = handle >> 8;
-
-        if (index >= (DWORD)CPools::ms_pPedPool->m_nSize)
-            return false; // index out of bounds
-
-        if (CPools::ms_pPedPool->m_byteMap[index].IntValue() != flags)
-            return false; // flags mismatch
-
-        return true;
-    }
-
-    static bool IsVehicleHandleValid(DWORD handle)
-    {
-        // get handle info
-        auto flags = handle & 0xFF;
-        auto index = handle >> 8;
-
-        if (index >= (DWORD)CPools::ms_pVehiclePool->m_nSize)
-            return false; // index out of bounds
-
-        if (CPools::ms_pVehiclePool->m_byteMap[index].IntValue() != flags)
-            return false; // flags mismatch
-
-        return true;
-    }
-
-    static bool IsPlayerIdValid(int id)
-    {
-        switch (id)
-        {
-            case -1: // player in focus
-            case 0: // player 1
-            case 1: // player 2
-                return true;
-        }
-
-        return false;
-    }
-
-    static const char* TraceVArg(CLEO::eLogLevel level, const char* format, va_list args)
-    {
-        static char szBuf[1024];
-        vsprintf_s(szBuf, format, args); // put params into format
-        CLEO_Log(level, szBuf);
-        return szBuf;
-    }
-
-    static void Trace(CLEO::eLogLevel level, const char* format, ...)
-    {
-        va_list args;
-        va_start(args, format);
-        TraceVArg(level, format, args);
-        va_end(args);
-    }
-
-    static void Trace(const CLEO::CRunningScript* thread, CLEO::eLogLevel level, const char* format, ...)
-    {
-        if (thread != nullptr && CLEO_GetScriptVersion(thread) < CLEO::eCLEO_Version::CLEO_VER_5)
-        {
-            return; // do not log this in older versions
-        }
-
-        va_list args;
-        va_start(args, format);
-        TraceVArg(level, format, args);
-        va_end(args);
-    }
-
-    static void ShowError(const char* format, ...)
-    {
-        va_list args;
-        va_start(args, format);
-        auto msg = TraceVArg(CLEO::eLogLevel::Error, format, args);
-        va_end(args);
-
-        auto mainWnd = (HWND*)0x00C8CF88; // PluginSDK: RsGlobal.ps->window
-        auto style = GetWindowLong(*mainWnd, GWL_STYLE);
-        bool fullscreen = (style & (WS_BORDER | WS_CAPTION)) == 0;
-
-        if (fullscreen)
-        {
-            PostMessage(*mainWnd, WM_SYSCOMMAND, SC_MINIMIZE, 0);
-            ShowWindow(*mainWnd, SW_MINIMIZE);
-        }
-
-        auto caption = StringPrintf("CLEO v%s", CLEO_GetVersionStr());
-        MessageBoxA(NULL, msg, caption.c_str(), MB_SYSTEMMODAL | MB_TOPMOST | MB_ICONERROR | MB_OK);
-
-        if (fullscreen)
-        {
-            PostMessage(*mainWnd, WM_SYSCOMMAND, SC_RESTORE, 0);
-            ShowWindow(*mainWnd, SW_RESTORE);
-        }
-    }
-
-    static bool PluginCheckCleoVersion()
-    {
-        auto ver = CLEO_GetVersion();
-
-        if (ver < CLEO_VERSION)
-        {
-            ShowError("%s.cleo plugin requires CLEO.asi version %s or later! \nCurrent version is %s", TARGET_NAME, CLEO_VERSION_STR, CLEO_GetVersionStr());
-            return false;
-        }
-
-        return true;
-    }
-
-    static std::string GetParamInfo(int offset = 0)
-    {
-        std::string info;
-        info.resize(32);
-        CLEO_GetScriptParamInfoStr(offset, info.data(), info.length());
-        return info;
-    }
-
-    struct StringParamBufferInfo
-    {
-        char* data = nullptr;
-        int size = 0;
-        BOOL needTerminator = false;
-    };
-
-    class MemPatch
-    {
-        void* address = nullptr;
-        std::vector<char> buffer;
-
-    public:
-        MemPatch() = default;
-
-        MemPatch(void* src, size_t size) : address(src), buffer(size)
-        {
-            memcpy(buffer.data(), src, size);
-        }
-
-        void Apply()
-        {
-            if (!buffer.empty())
-            {
-                memcpy(address, buffer.data(), buffer.size());
-            }
-        }
-    };
-
-    static MemPatch MemPatchJump(size_t position, void* jumpTarget)
-    {
-        MemPatch original((void*)position, 5);
-
-        *(BYTE*)position = 0xE9; // asm: jmp
-        position += sizeof(BYTE);
-
-        *(DWORD*)position = (DWORD)jumpTarget - position - 4;
-
-        return original;
-    }
-
-    static void* MemPatchCall(size_t position, void* newFunction)
-    {
-        *(BYTE*)position = 0xE8; // asm: call
-        position += sizeof(BYTE);
-
-        DWORD original = *(DWORD*)position + position + 4;
-        *(DWORD*)position = (DWORD)newFunction - position - 4;
-
-        return (void*)original;
-    }
-
-    template <typename T>
-    static StringList CreateStringList(const T& container)
-    {
-        StringList result;
-        result.count = 0;
-        result.strings = nullptr;
-
-        if (container.size() > 0)
-        {
-            result.strings = (char**)malloc(container.size() * sizeof(DWORD)); // array of pointers
-            for (const std::string& s : container)
-            {
-                auto size = s.length() + 1; // and terminator character
-                auto str = (char*)malloc(size);
-                memcpy(str, s.c_str(), size);
-
-                result.strings[result.count] = str;
-                result.count++;
-            }
-        }
-
-        return result;
-    }
-
-    #define TRACE(format,...) {CLEO::Trace(CLEO::eLogLevel::Default, format, __VA_ARGS__);}
-    #define LOG_WARNING(script, format, ...) {CLEO::Trace(script, CLEO::eLogLevel::Error, format, __VA_ARGS__);}
-    #define SHOW_ERROR(a,...) {CLEO::ShowError(a, __VA_ARGS__);}
-
-    #define COMPAT_MODE_TIP(MSG) MSG ## " \n\nThis error can be ignored in legacy mode by changing script extension to '.cs4'"
-    #define SHOW_ERROR_COMPAT(a,...) {CLEO::ShowError(COMPAT_MODE_TIP(a), __VA_ARGS__);}
-
-    const size_t MinValidAddress = 0x10000; // used for validation of pointers received from scripts. First 64kb are for sure reserved by Windows.
-    #define OPCODE_VALIDATE_POINTER(x) if((size_t)x <= MinValidAddress) { SHOW_ERROR("Invalid '0x%X' pointer argument in script %s \nScript suspended.", x, ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
-
-    #define OPCODE_CONDITION_RESULT(value) CLEO_SetThreadCondResult(thread, value);
-
-    // opcode param handling utils internal
-    static SCRIPT_VAR* _paramsArray = nullptr;
-    static eDataType _lastParamType = eDataType::DT_END;
-    static eArrayDataType _lastParamArrayType = eArrayDataType::ADT_NONE;
-
-    static SCRIPT_VAR& _readParam(CRunningScript* thread)
-    {
-        _lastParamType = thread->PeekDataType();
-        _lastParamArrayType = thread->PeekArrayType();
-
-        CLEO_RetrieveOpcodeParams(thread, 1);
-        if (_paramsArray == nullptr) _paramsArray = CLEO_GetOpcodeParamsArray();
-        return _paramsArray[0];
-    }
-
-    static SCRIPT_VAR& _readParamFloat(CRunningScript* thread)
-    {
-        auto& var = _readParam(thread);
-
-        // people tend to use '0' instead '0.0' when providing literal float params in scripts
-        // binary these are equal, so can be allowed
-        if (var.dwParam == 0)
-        {
-            // pretend it was float type
-            if (IsImmInteger(_lastParamType)) _lastParamType = eDataType::DT_FLOAT;
-            if (_lastParamArrayType == eArrayDataType::ADT_INT) _lastParamArrayType = eArrayDataType::ADT_FLOAT;
-        }
-
-        return var;
-    }
-
-    static SCRIPT_VAR* _readParamVariable(CRunningScript* thread)
-    {
-        _lastParamType = thread->PeekDataType();
-        _lastParamArrayType = thread->PeekArrayType();
-
-        return CLEO_GetPointerToScriptVariable(thread);
-    }
-
-    static StringParamBufferInfo _readParamStringInfo(CRunningScript* thread)
-    {
-        _lastParamType = thread->PeekDataType();
-        _lastParamArrayType = thread->PeekArrayType();
-
-        StringParamBufferInfo result;
-        CLEO_ReadStringParamWriteBuffer(thread, &result.data, &result.size, &result.needTerminator);
-        return result;
-    }
-
-    static void _writeParamPtr(CRunningScript* thread, void* valuePtr)
-    {
-        _lastParamType = thread->PeekDataType();
-        _lastParamArrayType = thread->PeekArrayType();
-
-        if (_paramsArray == nullptr) _paramsArray = CLEO_GetOpcodeParamsArray();
-        _paramsArray[0].pParam = valuePtr;
-        CLEO_RecordOpcodeParams(thread, 1);
-    }
-
-    template<typename T> static void _writeParam(CRunningScript* thread, T value)
-    {
-        _lastParamType = thread->PeekDataType();
-        _lastParamArrayType = thread->PeekArrayType();
-
-        if (_paramsArray == nullptr) _paramsArray = CLEO_GetOpcodeParamsArray();
-        _paramsArray[0].dwParam = 0;
-        memcpy(&_paramsArray[0], &value, sizeof(T));
-        CLEO_RecordOpcodeParams(thread, 1);
-    }
-
-    static inline bool _paramWasInt(bool output = false)
-    {
-        if (_lastParamArrayType != eArrayDataType::ADT_NONE) return _lastParamArrayType == eArrayDataType::ADT_INT;
-        if (IsVariable(_lastParamType)) return true;
-        if (!output && IsImmInteger(_lastParamType)) return true;
-        return false;
-    }
-
-    static inline bool _paramWasFloat(bool output = false)
-    {
-        if (_lastParamArrayType != eArrayDataType::ADT_NONE) return _lastParamArrayType == eArrayDataType::ADT_FLOAT;
-        if (IsVariable(_lastParamType)) return true;
-        if (!output && IsImmFloat(_lastParamType)) return true;
-        return false;
-    }
-
-    static inline bool _paramWasString(bool output = false)
-    {
-        if (_lastParamArrayType != eArrayDataType::ADT_NONE)
-        {
-            return _lastParamArrayType == eArrayDataType::ADT_STRING ||
-                _lastParamArrayType == eArrayDataType::ADT_TEXTLABEL ||
-                _lastParamArrayType == eArrayDataType::ADT_INT; // pointer to output buffer
-        }
-
-        if (IsVarString(_lastParamType)) return true;
-        if (output && IsImmInteger(_lastParamType)) return true; // allow writing strings into const addresses
-        if (!output && IsImmString(_lastParamType)) return true;
-
-        // pointer to output buffer
-        if (IsVariable(_lastParamType)) return true; 
-
-        return false;
-    }
-
-    static inline bool _paramWasVariable()
-    {
-        return IsVariable(_lastParamType);
-    }
-
-    static const char* _readParamText(CRunningScript* thread, char* buffer, size_t bufferSize)
-    {
-        _lastParamType = thread->PeekDataType();
-        _lastParamArrayType = thread->PeekArrayType();
-
-        if (!_paramWasString())
-        {
-            SHOW_ERROR("Input argument %s expected to be string, got %s in script %s\nScript suspended.", GetParamInfo(1).c_str(), ToKindStr(_lastParamType, _lastParamArrayType), ScriptInfoStr(thread).c_str());
-            thread->Suspend();
-            _lastParamType = DT_INVALID; // mark error
-            return nullptr;
-        }
-
-        auto str = CLEO_ReadStringPointerOpcodeParam(thread, buffer, bufferSize); // returns pointer to source data whenever possible
-        
-        if (str == nullptr) // reading string failed
-        {
-            auto isVariableInt = IsVariable(_lastParamType) && (_lastParamArrayType == eArrayDataType::ADT_NONE || _lastParamArrayType == eArrayDataType::ADT_INT);
-            if ((IsImmInteger(_lastParamType) || isVariableInt) && // pointer argument type?
-                CLEO_GetOpcodeParamsArray()->dwParam <= MinValidAddress)
-            {
-                SHOW_ERROR("Invalid '0x%X' pointer of input string argument %s in script %s", CLEO_GetOpcodeParamsArray()->dwParam, GetParamInfo().c_str(), ScriptInfoStr(thread).c_str());
-            }
-            else
-            {
-                // other error
-                SHOW_ERROR("Invalid input argument %s in script %s\nScript suspended.", GetParamInfo().c_str(), ScriptInfoStr(thread).c_str());
-            }
-
-            thread->Suspend();
-            _lastParamType = DT_INVALID; // mark error
-            return nullptr;
-        }
-
-        return str;
-    }
-
-    static bool _writeParamText(CLEO::CRunningScript* thread, const StringParamBufferInfo& target, const char* str)
-    {
-        if (str != nullptr && (size_t)str <= MinValidAddress)
-        {
-            SHOW_ERROR("Invalid '0x%X' source pointer of output string argument %s in script %s \nScript suspended.", str, GetParamInfo(1).c_str(), ScriptInfoStr(thread).c_str());
-            thread->Suspend();
-            return false;
-        }
-
-        if ((size_t)target.data <= MinValidAddress)
-        {
-            SHOW_ERROR("Invalid '0x%X' target pointer of output string argument in script %s \nScript suspended.", target.data, ScriptInfoStr(thread).c_str());
-            thread->Suspend();
-            return false;
-        }
-
-        if (target.size == 0)
-        {
-            return true; // done
-        }
-
-        bool addTerminator = target.needTerminator;
-        size_t buffLen = target.size - addTerminator;
-        size_t length = str == nullptr ? 0 : strlen(str);
-
-        if (buffLen > length) addTerminator = true; // there is space left for terminator
-
-        length = std::min<size_t>(length, buffLen);
-        if (length > 0) std::memcpy(target.data, str, length);
-        if (addTerminator) target.data[length] = '\0';
-
-        return true;
-    }
-
-    static bool _writeParamText(CRunningScript* thread, const char* str)
-    {
-        _lastParamType = thread->PeekDataType();
-        _lastParamArrayType = thread->PeekArrayType();
-
-        if (str != nullptr && (size_t)str <= MinValidAddress)
-        {
-            SHOW_ERROR("Invalid '0x%X' source pointer of output string argument %s in script %s \nScript suspended.", str, GetParamInfo(1).c_str(), ScriptInfoStr(thread).c_str());
-            thread->Suspend();
-            return false;
-        }
-
-        if (!_paramWasString(true))
-        {
-            SHOW_ERROR("Output argument %s expected to be variable string, got %s in script %s\nScript suspended.", GetParamInfo(1).c_str(), ToKindStr(_lastParamType, _lastParamArrayType), ScriptInfoStr(thread).c_str());
-            thread->Suspend();
-            return false;
-        }
-
-        if (IsImmInteger(_lastParamType) || IsVariable(_lastParamType)) // pointer to buffer
-        {
-            auto ptr = CLEO_PeekIntOpcodeParam(thread);
-
-            if ((size_t)ptr <= MinValidAddress)
-            {
-                SHOW_ERROR("Invalid '0x%X' pointer of output string argument %s in script %s \nScript suspended.", ptr, GetParamInfo(1).c_str(), ScriptInfoStr(thread).c_str());
-                thread->Suspend();
-                return false;
-            }
-        }
-        
-        StringParamBufferInfo info;
-        CLEO_ReadStringParamWriteBuffer(thread, &info.data, &info.size, &info.needTerminator);
-        return _writeParamText(thread, info, str); // done
-    }
-
-    #define OPCODE_SKIP_PARAMS(_count) CLEO_SkipOpcodeParams(thread, _count)
-    #define OPCODE_SKIP_VARARG_PARAMS() CLEO_SkipUnusedVarArgs(thread)
-
-    #define OPCODE_PEEK_PARAM_TYPE() thread->PeekDataType()
-    #define OPCODE_PEEK_VARARG_COUNT() CLEO_GetVarArgCount(thread)
-
-    // macros for reading opcode input params. Performs type validation, throws error and suspends script if user provided invalid argument type
-    // TOD: add range checks for limited size types?
-
-    #define OPCODE_READ_PARAM_BOOL() _readParam(thread).dwParam != false; \
-        if (!_paramWasInt()) { SHOW_ERROR("Input argument %s expected to be integer, got %s in script %s\nScript suspended.", GetParamInfo().c_str(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
-
-    #define OPCODE_READ_PARAM_INT8() _readParam(thread).cParam; \
-        if (!_paramWasInt()) { SHOW_ERROR("Input argument %s expected to be integer, got %s in script %s\nScript suspended.", GetParamInfo().c_str(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
-
-    #define OPCODE_READ_PARAM_UINT8() _readParam(thread).ucParam; \
-        if (!_paramWasInt()) { SHOW_ERROR("Input argument %s expected to be integer, got %s in script %s\nScript suspended.", GetParamInfo().c_str(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
-
-    #define OPCODE_READ_PARAM_INT16() _readParam(thread).wParam; \
-        if (!_paramWasInt()) { SHOW_ERROR("Input argument %s expected to be integer, got %s in script %s\nScript suspended.", GetParamInfo().c_str(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
-
-    #define OPCODE_READ_PARAM_UINT16() _readParam(thread).usParam; \
-        if (!_paramWasInt()) { SHOW_ERROR("Input argument %s expected to be integer, got %s in script %s\nScript suspended.", GetParamInfo().c_str(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
-
-    #define OPCODE_READ_PARAM_INT() _readParam(thread).nParam; \
-        if (!_paramWasInt()) { SHOW_ERROR("Input argument %s expected to be integer, got %s in script %s\nScript suspended.", GetParamInfo().c_str(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
-
-    #define OPCODE_READ_PARAM_UINT() _readParam(thread).dwParam; \
-        if (!_paramWasInt()) { SHOW_ERROR("Input argument %s expected to be integer, got %s in script %s\nScript suspended.", GetParamInfo().c_str(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
-
-    #define OPCODE_READ_PARAM_FLOAT() _readParamFloat(thread).fParam; \
-        if (!IsLegacyScript(thread) && !_paramWasFloat()) { SHOW_ERROR_COMPAT("Input argument %s expected to be float, got %s in script %s\nScript suspended.", GetParamInfo().c_str(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
-
-    #define OPCODE_READ_PARAM_ANY32() _readParam(thread); \
-        if (!_paramWasInt() && !_paramWasFloat()) { SHOW_ERROR("Input argument %s expected to be int or float, got %s in script %s\nScript suspended.", GetParamInfo().c_str(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
-
-    #define OPCODE_READ_PARAM_STRING(_varName) char _buff_##_varName[MAX_STR_LEN + 1]; const char* ##_varName = _readParamText(thread, _buff_##_varName, MAX_STR_LEN + 1); if(!_paramWasString()) { return OpcodeResult::OR_INTERRUPT; }
-
-    #define OPCODE_READ_PARAM_STRING_LEN(_varName, _maxLen) char _buff_##_varName[_maxLen + 1]; const char* ##_varName = _readParamText(thread, _buff_##_varName, _maxLen + 1); if(##_varName != nullptr) ##_varName = _buff_##_varName; if(!_paramWasString()) { return OpcodeResult::OR_INTERRUPT; }
-
-    #define OPCODE_READ_PARAM_STRING_FORMATTED(_varName) char _buff_format_##_varName[MAX_STR_LEN + 1]; const char* _format_##_varName = _readParamText(thread, _buff_format_##_varName, MAX_STR_LEN + 1); if(!_paramWasString()) { return OpcodeResult::OR_INTERRUPT; } \
-        char _varName[2 * MAX_STR_LEN + 1]; char* _varName##Ok = CLEO_ReadParamsFormatted(thread, _buff_format_##_varName, _varName, sizeof(_varName)); \
-        if(_varName##Ok == nullptr) { SHOW_ERROR("Invalid formatted string in script %s \nScript suspended.", CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
-
-    #define OPCODE_READ_PARAMS_FORMATTED(_format, _varName) char _varName[2 * MAX_STR_LEN + 1]; char* _varName##Ok = CLEO_ReadParamsFormatted(thread, _format, _varName, sizeof(_varName)); \
-        if(_varName##Ok == nullptr) { SHOW_ERROR("Invalid formatted string in script %s \nScript suspended.", CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
-
-    #define OPCODE_READ_PARAM_FILEPATH(_varName) char _buff_##_varName[512]; const char* ##_varName = _readParamText(thread, _buff_##_varName, 512); if(##_varName != nullptr) ##_varName = _buff_##_varName; if(_paramWasString()) CLEO_ResolvePath(thread, _buff_##_varName, 512); else return OpcodeResult::OR_INTERRUPT; \
-        if(!FilepathIsSafe(thread, ##_varName)) { SHOW_ERROR("Forbidden file path '%s' outside game directories in script %s \nScript suspended.", ##_varName, ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
-
-    #define OPCODE_READ_PARAM_PTR() _readParam(thread).pParam; \
-        if (!_paramWasInt()) { SHOW_ERROR("Input argument %s expected to be integer, got %s in script %s\nScript suspended.", GetParamInfo().c_str(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); } \
-        else if (_paramsArray[0].dwParam <= MinValidAddress) { SHOW_ERROR("Invalid pointer '0x%X' input argument %s in script %s \nScript suspended.", _paramsArray[0].dwParam, GetParamInfo().c_str(), ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
-
-    #define OPCODE_READ_PARAM_OBJECT_HANDLE() _readParam(thread).dwParam; \
-        if (!_paramWasInt()) { SHOW_ERROR("Input argument %s expected to be integer, got %s in script %s\nScript suspended.", GetParamInfo().c_str(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); } \
-        else if (!IsObjectHandleValid(_paramsArray[0].dwParam)) { SHOW_ERROR("Invalid object handle '0x%X' input argument %s in script %s \nScript suspended.", _paramsArray[0].dwParam, GetParamInfo().c_str(), ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
-
-    #define OPCODE_READ_PARAM_PED_HANDLE() _readParam(thread).dwParam; \
-        if (!_paramWasInt()) { SHOW_ERROR("Input argument %s expected to be integer, got %s in script %s\nScript suspended.", GetParamInfo().c_str(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); } \
-        else if (!IsPedHandleValid(_paramsArray[0].dwParam)) { SHOW_ERROR("Invalid character handle '0x%X' input argument %s in script %s \nScript suspended.", _paramsArray[0].dwParam, GetParamInfo().c_str(), ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
-
-    #define OPCODE_READ_PARAM_VEHICLE_HANDLE() _readParam(thread).dwParam; \
-        if (!_paramWasInt()) { SHOW_ERROR("Input argument %s expected to be integer, got %s in script %s\nScript suspended.", GetParamInfo().c_str(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); } \
-        else if (!IsVehicleHandleValid(_paramsArray[0].dwParam)) { SHOW_ERROR("Invalid vehicle handle '0x%X' input argument %s in script %s \nScript suspended.", _paramsArray[0].dwParam, GetParamInfo().c_str(), ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
-
-    #define OPCODE_READ_PARAM_PLAYER_ID() _readParam(thread).dwParam; \
-        if (!_paramWasInt()) { SHOW_ERROR("Input argument %s expected to be integer, got %s in script %s\nScript suspended.", GetParamInfo().c_str(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); } \
-        else if (!IsPlayerIdValid(_paramsArray[0].dwParam)) { SHOW_ERROR("Invalid player id '0x%X' input argument %s in script %s \nScript suspended.", _paramsArray[0].dwParam, GetParamInfo().c_str(), ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
-
-    #define OPCODE_READ_PARAM_OUTPUT_VAR_ANY32() _readParamVariable(thread); \
-        if (!_paramWasVariable()) { SHOW_ERROR("Output argument %s expected to be variable int or float, got %s in script %s\nScript suspended.", GetParamInfo().c_str(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
-
-    #define OPCODE_READ_PARAM_OUTPUT_VAR_INT() (int*)_readParamVariable(thread); \
-        if (!_paramWasVariable()) { SHOW_ERROR("Output argument %s expected to be variable int, got %s in script %s\nScript suspended.", GetParamInfo().c_str(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); } \
-        if (!_paramWasInt(true)) { SHOW_ERROR("Output argument %s expected to be variable int, got %s in script %s\nScript suspended.", GetParamInfo().c_str(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
-
-    #define OPCODE_READ_PARAM_OUTPUT_VAR_FLOAT() (float*)_readParamVariable(thread); \
-        if (!_paramWasVariable()) { SHOW_ERROR("Output argument %s expected to be variable float, got %s in script %s\nScript suspended.", GetParamInfo().c_str(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); } \
-        if (!IsLegacyScript(thread) && !_paramWasFloat(true)) { SHOW_ERROR_COMPAT("Output argument %s expected to be variable float, got %s in script %s\nScript suspended.", GetParamInfo().c_str(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
-
-    #define OPCODE_READ_PARAM_OUTPUT_VAR_STRING() _readParamStringInfo(thread); \
-        if (!_paramWasString(true)) { SHOW_ERROR("Output argument %s expected to be variable string, got %s in script %s\nScript suspended.", GetParamInfo().c_str(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
-
-
-    // macros for writing opcode output params. Performs type validation, throws error and suspends script if user provided invalid argument type
-
-    #define OPCODE_WRITE_PARAM_BOOL(_value) _writeParam(thread, _value); \
-        if (!_paramWasInt(true)) { SHOW_ERROR("Output argument %s expected to be variable int, got %s in script %s\nScript suspended.", GetParamInfo().c_str(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
-
-    #define OPCODE_WRITE_PARAM_INT8(_value) _writeParam(thread, _value); \
-        if (!_paramWasInt(true)) { SHOW_ERROR("Output argument %s expected to be variable int, got %s in script %s\nScript suspended.", GetParamInfo().c_str(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
-
-    #define OPCODE_WRITE_PARAM_UINT8(_value) _writeParam(thread, _value); \
-        if (!_paramWasInt(true)) { SHOW_ERROR("Output argument %s expected to be variable int, got %s in script %s\nScript suspended.", GetParamInfo().c_str(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
-
-    #define OPCODE_WRITE_PARAM_INT16(_value) _writeParam(thread, _value); \
-        if (!_paramWasInt(true)) { SHOW_ERROR("Output argument %s expected to be variable int, got %s in script %s\nScript suspended.", GetParamInfo().c_str(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
-
-    #define OPCODE_WRITE_PARAM_UINT16(_value) _writeParam(thread, _value); \
-        if (!_paramWasInt(true)) { SHOW_ERROR("Output argument %s expected to be variable int, got %s in script %s\nScript suspended.", GetParamInfo().c_str(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
-
-    #define OPCODE_WRITE_PARAM_INT(_value) _writeParam(thread, _value); \
-        if (!_paramWasInt(true)) { SHOW_ERROR("Output argument %s expected to be variable int, got %s in script %s\nScript suspended.", GetParamInfo().c_str(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
-
-    #define OPCODE_WRITE_PARAM_UINT(_value) _writeParam(thread, _value); \
-        if (!_paramWasInt(true)) { SHOW_ERROR("Output argument %s expected to be variable int, got %s in script %s\nScript suspended.", GetParamInfo().c_str(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
-
-    #define OPCODE_WRITE_PARAM_ANY32(_value) _writeParam(thread, _value); \
-        if (!_paramWasInt(true) && !_paramWasFloat(true)) { SHOW_ERROR("Output argument %s expected to be int or float variable, got %s in script %s\nScript suspended.", GetParamInfo().c_str(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
-
-    #define OPCODE_WRITE_PARAM_FLOAT(_value) _writeParam(thread, _value); \
-        if (!IsLegacyScript(thread) && !_paramWasFloat(true)) { SHOW_ERROR_COMPAT("Output argument %s expected to be variable float, got %s in script %s\nScript suspended.", GetParamInfo().c_str(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
-
-    #define OPCODE_WRITE_PARAM_STRING(_value) if(!_writeParamText(thread, _value)) { return OpcodeResult::OR_INTERRUPT; }
-
-    #define OPCODE_WRITE_PARAM_VAR_STRING(_info, _value) if(!_writeParamText(thread, _info, _value)) { return OpcodeResult::OR_INTERRUPT; }
-
-    #define OPCODE_WRITE_PARAM_PTR(_value) _writeParamPtr(thread, (void*)_value); \
-        if (!_paramWasInt(true)) { SHOW_ERROR("Output argument %s expected to be variable int, got %s in script %s\nScript suspended.", GetParamInfo().c_str(), CLEO::ToKindStr(_lastParamType, _lastParamArrayType), CLEO::ScriptInfoStr(thread).c_str()); return thread->Suspend(); }
+namespace CLEO {
+/*
+TRACE(format,...) // log to file. Can be displayed on screen with change in
+DebugUtils.ini LOG_WARNING(script, format, ...) // warning text on screen and in
+log file. Not displayed for scripts in 'legacy' mode SHOW_ERROR(a,...) //
+message box, log to file
+
+Macros to use inside opcode handler functions. Performs types validation,
+printing warnings and suspending script on critical errors. Please mind those
+expand into multiple lines, so CAN NOT be used in places where single code line
+is expected! (like 'if' condition body without brackets)
+
+OPCODE_CONDITION_RESULT(value) // set command logical result
+
+OPCODE_SKIP_PARAMS(count) // ignore X params
+OPCODE_SKIP_VARARG_PARAMS(count) // ignore remaining variable arguments,
+including varArg terminator
+
+OPCODE_PEEK_PARAM_TYPE() // get param type without advancing the script
+OPCODE_PEEK_VARARG_COUNT() // get count of remaining variable arguments (not
+including varArg terminator)
+
+// reading opcode input arguments
+OPCODE_READ_PARAM_BOOL()
+OPCODE_READ_PARAM_INT8()
+OPCODE_READ_PARAM_UINT8()
+OPCODE_READ_PARAM_INT16()
+OPCODE_READ_PARAM_UINT16()
+OPCODE_READ_PARAM_INT()
+OPCODE_READ_PARAM_UINT()
+OPCODE_READ_PARAM_FLOAT()
+OPCODE_READ_PARAM_ANY32() // get raw data of any simple-type value (practically
+integers and floats) OPCODE_READ_PARAM_STRING(varName) // reads param and
+creates const char* variable named 'varName' with pointer to null-terminated
+string OPCODE_READ_PARAM_STRING_LEN(varName, maxLength) // same as above, but
+text length is clamped to maxLength OPCODE_READ_PARAM_STRING_FORMATTED(varName)
+// reads "format" string argument, then all var-args. Creates variable named
+'varName' containing formatted text. Creates 'varNameOk' variable with pointer
+to the text, or nullptr if user provided invalid arguments
+OPCODE_READ_PARAMS_FORMATTED(format, varName) // reads all var-args and tries to
+put them into formatted string. Creates variable named 'varName' containing
+formatted text. Creates 'varNameOk' variable with pointer to the text, or
+nullptr if user provided invalid arguments OPCODE_READ_PARAM_FILEPATH(varName)
+// reads param and creates const char* variable named 'varName' with pointer to
+resolved, null-terminated, filepath OPCODE_READ_PARAM_PTR() // read and validate
+memory address argument OPCODE_READ_PARAM_OBJECT_HANDLE() // read and validate
+game object handle OPCODE_READ_PARAM_PED_HANDLE() // read and validate character
+(ped/actor) handle OPCODE_READ_PARAM_PLAYER_ID() // read and validate player id
+OPCODE_READ_PARAM_VEHICLE_HANDLE() // read and validate vehicle handle
+
+// for opcodes with mixed params order, where 'strore_to' occurs before input
+arguments OPCODE_READ_PARAM_OUTPUT_VAR_INT() // get pointer to integer variable
+param to write result later OPCODE_READ_PARAM_OUTPUT_VAR_FLOAT() // get pointer
+to float variable param to write result later
+OPCODE_READ_PARAM_OUTPUT_VAR_ANY32() // get pointer to simple-type variable
+param to write result later OPCODE_READ_PARAM_OUTPUT_VAR_STRING() // returns
+instance of StringParamBufferInfo used to write string param later
+
+// writing opcode output/result data
+OPCODE_WRITE_PARAM_BOOL(value)
+OPCODE_WRITE_PARAM_INT8(value)
+OPCODE_WRITE_PARAM_UINT8(value)
+OPCODE_WRITE_PARAM_INT16(value)
+OPCODE_WRITE_PARAM_UINT16(value)
+OPCODE_WRITE_PARAM_INT(value)
+OPCODE_WRITE_PARAM_UINT(value)
+OPCODE_WRITE_PARAM_FLOAT(value)
+OPCODE_WRITE_PARAM_ANY32(value) // write raw data into simple-type variable
+(practically integers and floats) OPCODE_WRITE_PARAM_STRING(value)
+OPCODE_WRITE_PARAM_STRING_INFO(info, value) // write param using info object
+revceived from OPCODE_READ_PARAM_OUTPUT_VAR_STRING OPCODE_WRITE_PARAM_PTR(value)
+// memory address
+*/
+
+static bool IsLegacyScript(CLEO::CRunningScript *thread) {
+  return CLEO_GetScriptVersion(thread) < CLEO_VER_5;
 }
+
+static std::string StringPrintf(const char *format, ...) {
+  va_list args;
+
+  va_start(args, format);
+  auto len = std::vsnprintf(nullptr, 0, format, args);
+  va_end(args);
+
+  if (len <= 0)
+    return {}; // empty or encoding error
+
+  std::string result;
+  result.resize(len);
+
+  va_start(args, format);
+  std::vsnprintf(result.data(), result.length() + 1, format, args);
+  va_end(args);
+
+  return result;
+}
+
+static bool StringStartsWith(const std::string_view str,
+                             const std::string_view prefix,
+                             bool caseSensitive = true) {
+  if (str.length() < prefix.length()) {
+    return false;
+  }
+
+  if (caseSensitive) {
+    return strncmp(str.data(), prefix.data(), prefix.length()) == 0;
+  } else {
+    return _strnicmp(str.data(), prefix.data(), prefix.length()) == 0;
+  }
+}
+
+static bool StringEndsWith(const std::string_view str,
+                           const std::string_view suffix,
+                           bool caseSensitive = true) {
+  if (str.length() < suffix.length()) {
+    return false;
+  }
+
+  if (caseSensitive) {
+    return strncmp(&str.back() + 1 - suffix.length(), suffix.data(),
+                   suffix.length()) == 0;
+  } else {
+    return _strnicmp(&str.back() + 1 - suffix.length(), suffix.data(),
+                     suffix.length()) == 0;
+  }
+}
+
+static void StringSplit(const std::string_view str,
+                        const std::string_view delimiters,
+                        std::vector<std::string> &output) {
+  size_t prevPos = 0;
+  while (true) {
+    size_t pos = str.find_first_of(delimiters, prevPos);
+
+    if (pos == std::string::npos) {
+      if (strlen(str.data() + prevPos) > 0) {
+        output.emplace_back(str.data() + prevPos);
+      }
+      break;
+    } else {
+      if (pos - prevPos > 0) {
+        output.emplace_back(str.data() + prevPos, pos - prevPos);
+      }
+      prevPos = pos + 1;
+    }
+  }
+}
+
+// erase GTA's text formatting sequences like ~r~
+static void StringRemoveFormatting(std::string &str) {
+  size_t pos = 0;
+  while (true) {
+    pos = str.find('~', pos);
+    if (pos == std::string::npos ||
+        (pos + 2) >=
+            str.length()) // not enought characters left for formatting sequence
+    {
+      break;
+    }
+
+    if (str[pos + 2] != '~') {
+      pos++;
+      continue;
+    }
+
+    switch (str[pos + 1]) {
+    case 'n':
+    case 'N':
+      str.replace(pos, 3, "\n");
+      break;
+
+    default:
+      str.erase(pos, 3);
+      break;
+    }
+  }
+}
+
+static void StringToLower(std::string &str) {
+  std::transform(str.begin(), str.end(), str.begin(),
+                 [](unsigned char c) { return tolower(c); });
+}
+
+static std::string ScriptInfoStr(CLEO::CRunningScript *thread) {
+  std::string info(1024, '\0');
+  CLEO_GetScriptInfoStr(thread, true, info.data(), info.length());
+  return std::move(info);
+}
+
+// Normalize filepath, collapse all parent directory references, trim path
+// separators at front and back. Input should be path without expandable
+// %variables%
+static void FilepathNormalize(std::string &path, bool normalizeCase = true) {
+  if (path.empty())
+    return;
+
+  std::replace(path.begin(), path.end(), '/', '\\');
+
+  // remove doubled separators
+  size_t pos;
+  while ((pos = path.find("\\\\")) != std::string::npos) {
+    path.erase(pos, 1);
+  }
+
+  if (normalizeCase)
+    StringToLower(path);
+
+  // collapse references to parent directory
+  const auto ParentRef = "\\..\\";
+  const auto ParentRefLen = 4;
+
+  size_t refPos = path.find(ParentRef);
+  while (refPos != std::string::npos && refPos > 0) {
+    size_t parentPos =
+        path.rfind('\\', refPos - 1); // find start of parent dir name
+
+    if (parentPos ==
+        std::string::npos) // no more separators, so parent has to be root dir
+    {
+      parentPos = 0;
+      refPos += 1; // remove following separator too
+    }
+
+    if (_strnicmp(path.c_str() + parentPos, "..\\", 3) == 0) {
+      break; // parent directory is reference to parent directory too
+    }
+
+    path.replace(parentPos, (refPos - parentPos) + ParentRefLen - 1,
+                 ""); // remove parent dir along with following \\..
+
+    refPos = path.find(ParentRef); // find next
+  }
+
+  // trim separators
+  while (path.front() == '\\')
+    path.erase(0, 1);
+  while (path.back() == '\\')
+    path.pop_back();
+}
+
+// strip parent prefix from filepath if present
+// 1. FilepathRemoveParent("C:\game\cleo\1.cs", "C:\game") => cleo\1.cs
+// 2. FilepathRemoveParent("C:cleo\1.cs", "C:") => cleo\1.cs
+static void FilepathRemoveParent(std::string &path,
+                                 const std::string_view base) {
+  if (path.length() < base.length())
+    return; // can not hold that prefix
+  if (!StringStartsWith(path, base, false))
+    return;
+  if (path.length() > base.length() && path[base.length()] != '\\' &&
+      path[base.length() - 1] != ':')
+    return; // just similar base
+
+  auto to = base.length();
+  if (path[to] == '\\') {
+    // remove path separator too if present
+    to += 1;
+  }
+  path.replace(0, to, "");
+}
+
+// get path without last file/directory element
+static const std::string_view FilepathGetParent(const std::string_view str) {
+  auto separatorPos = str.find_last_of('\\');
+
+  if (separatorPos == std::string::npos) {
+    return {};
+  }
+
+  return std::string_view(str.data(), separatorPos);
+}
+
+// this plugin's config file
+static std::string GetConfigFilename() {
+  std::string path = CLEO_GetGameDirectory();
+  path += "\\cleo\\cleo_plugins\\";
+  path += TARGET_NAME;
+  path += ".ini";
+  return path;
+}
+
+// does normalized file path points inside game directories? (game root or user
+// files)
+static bool FilepathIsSafe(CLEO::CRunningScript *thread, const char *path) {
+  if (strchr(path, '%') != nullptr) {
+    return false; // do not allow paths containing expandable variables
+  }
+
+  std::string absolute;
+  if (!std::filesystem::path(path).is_absolute()) {
+    absolute = CLEO_GetScriptWorkDir(thread);
+    if (!absolute.empty()) {
+      absolute += '\\';
+      absolute += path;
+      FilepathNormalize(absolute, false);
+      path = absolute.c_str();
+    }
+  }
+
+  if (!StringStartsWith(path, CLEO_GetGameDirectory(), false) &&
+      !StringStartsWith(path, CLEO_GetUserDirectory(), false)) {
+    if (StringStartsWith(
+            path, "..")) // relative path trying to escape game's directory
+      return false;
+  }
+
+  return true;
+}
+
+static bool IsObjectHandleValid(DWORD handle) {
+  // get handle info
+  auto flags = handle & 0xFF;
+  auto index = handle >> 8;
+
+  if (index >= (DWORD)CPools::ms_pObjectPool->m_nSize)
+    return false; // index out of bounds
+
+  if (CPools::ms_pObjectPool->m_byteMap[index].IntValue() != flags)
+    return false; // flags mismatch
+
+  return true;
+}
+
+static bool IsPedHandleValid(DWORD handle) {
+  // get handle info
+  auto flags = handle & 0xFF;
+  auto index = handle >> 8;
+
+  if (index >= (DWORD)CPools::ms_pPedPool->m_nSize)
+    return false; // index out of bounds
+
+  if (CPools::ms_pPedPool->m_byteMap[index].IntValue() != flags)
+    return false; // flags mismatch
+
+  return true;
+}
+
+static bool IsVehicleHandleValid(DWORD handle) {
+  // get handle info
+  auto flags = handle & 0xFF;
+  auto index = handle >> 8;
+
+  if (index >= (DWORD)CPools::ms_pVehiclePool->m_nSize)
+    return false; // index out of bounds
+
+  if (CPools::ms_pVehiclePool->m_byteMap[index].IntValue() != flags)
+    return false; // flags mismatch
+
+  return true;
+}
+
+static bool IsPlayerIdValid(int id) {
+  switch (id) {
+  case -1: // player in focus
+  case 0:  // player 1
+  case 1:  // player 2
+    return true;
+  }
+
+  return false;
+}
+
+static const char *TraceVArg(CLEO::eLogLevel level, const char *format,
+                             va_list args) {
+  static char szBuf[1024];
+  vsprintf_s(szBuf, format, args); // put params into format
+  CLEO_Log(level, szBuf);
+  return szBuf;
+}
+
+static void Trace(CLEO::eLogLevel level, const char *format, ...) {
+  va_list args;
+  va_start(args, format);
+  TraceVArg(level, format, args);
+  va_end(args);
+}
+
+static void Trace(const CLEO::CRunningScript *thread, CLEO::eLogLevel level,
+                  const char *format, ...) {
+  if (thread != nullptr &&
+      CLEO_GetScriptVersion(thread) < CLEO::eCLEO_Version::CLEO_VER_5) {
+    return; // do not log this in older versions
+  }
+
+  va_list args;
+  va_start(args, format);
+  TraceVArg(level, format, args);
+  va_end(args);
+}
+
+static void ShowError(const char *format, ...) {
+  va_list args;
+  va_start(args, format);
+  auto msg = TraceVArg(CLEO::eLogLevel::Error, format, args);
+  va_end(args);
+
+  auto mainWnd = (HWND *)0x00C8CF88; // PluginSDK: RsGlobal.ps->window
+  auto style = GetWindowLong(*mainWnd, GWL_STYLE);
+  bool fullscreen = (style & (WS_BORDER | WS_CAPTION)) == 0;
+
+  if (fullscreen) {
+    PostMessage(*mainWnd, WM_SYSCOMMAND, SC_MINIMIZE, 0);
+    ShowWindow(*mainWnd, SW_MINIMIZE);
+  }
+
+  auto caption = StringPrintf("CLEO v%s", CLEO_GetVersionStr());
+  MessageBoxA(NULL, msg, caption.c_str(),
+              MB_SYSTEMMODAL | MB_TOPMOST | MB_ICONERROR | MB_OK);
+
+  if (fullscreen) {
+    PostMessage(*mainWnd, WM_SYSCOMMAND, SC_RESTORE, 0);
+    ShowWindow(*mainWnd, SW_RESTORE);
+  }
+}
+
+static bool PluginCheckCleoVersion() {
+  auto ver = CLEO_GetVersion();
+
+  if (ver < CLEO_VERSION) {
+    ShowError("%s.cleo plugin requires CLEO.asi version %s or later! \nCurrent "
+              "version is %s",
+              TARGET_NAME, CLEO_VERSION_STR, CLEO_GetVersionStr());
+    return false;
+  }
+
+  return true;
+}
+
+static std::string GetParamInfo(int offset = 0) {
+  std::string info;
+  info.resize(32);
+  CLEO_GetScriptParamInfoStr(offset, info.data(), info.length());
+  return info;
+}
+
+struct StringParamBufferInfo {
+  char *data = nullptr;
+  int size = 0;
+  BOOL needTerminator = false;
+};
+
+class MemPatch {
+  void *address = nullptr;
+  std::vector<char> buffer;
+
+public:
+  MemPatch() = default;
+
+  MemPatch(void *src, size_t size) : address(src), buffer(size) {
+    memcpy(buffer.data(), src, size);
+  }
+
+  void Apply() {
+    if (!buffer.empty()) {
+      memcpy(address, buffer.data(), buffer.size());
+    }
+  }
+};
+
+static MemPatch MemPatchJump(size_t position, void *jumpTarget) {
+  MemPatch original((void *)position, 5);
+
+  *(BYTE *)position = 0xE9; // asm: jmp
+  position += sizeof(BYTE);
+
+  *(DWORD *)position = (DWORD)jumpTarget - position - 4;
+
+  return original;
+}
+
+static void *MemPatchCall(size_t position, void *newFunction) {
+  *(BYTE *)position = 0xE8; // asm: call
+  position += sizeof(BYTE);
+
+  DWORD original = *(DWORD *)position + position + 4;
+  *(DWORD *)position = (DWORD)newFunction - position - 4;
+
+  return (void *)original;
+}
+
+template <typename T> static StringList CreateStringList(const T &container) {
+  StringList result;
+  result.count = 0;
+  result.strings = nullptr;
+
+  if (container.size() > 0) {
+    result.strings =
+        (char **)malloc(container.size() * sizeof(DWORD)); // array of pointers
+    for (const std::string &s : container) {
+      auto size = s.length() + 1; // and terminator character
+      auto str = (char *)malloc(size);
+      memcpy(str, s.c_str(), size);
+
+      result.strings[result.count] = str;
+      result.count++;
+    }
+  }
+
+  return result;
+}
+
+#define TRACE(format, ...)                                                     \
+  {                                                                            \
+    CLEO::Trace(CLEO::eLogLevel::Default, format, __VA_ARGS__);                \
+  }
+#define LOG_WARNING(script, format, ...)                                       \
+  {                                                                            \
+    CLEO::Trace(script, CLEO::eLogLevel::Error, format, __VA_ARGS__);          \
+  }
+#define SHOW_ERROR(a, ...)                                                     \
+  {                                                                            \
+    CLEO::ShowError(a, __VA_ARGS__);                                           \
+  }
+
+#define COMPAT_MODE_TIP(MSG)                                                   \
+  MSG##" \n\nThis error can be ignored in legacy mode by changing script "     \
+       "extension to '.cs4'"
+#define SHOW_ERROR_COMPAT(a, ...)                                              \
+  {                                                                            \
+    CLEO::ShowError(COMPAT_MODE_TIP(a), __VA_ARGS__);                          \
+  }
+
+const size_t MinValidAddress =
+    0x10000; // used for validation of pointers received from scripts. First
+             // 64kb are for sure reserved by Windows.
+#define OPCODE_VALIDATE_POINTER(x)                                             \
+  if ((size_t)x <= MinValidAddress) {                                          \
+    SHOW_ERROR(                                                                \
+        "Invalid '0x%X' pointer argument in script %s \nScript suspended.", x, \
+        ScriptInfoStr(thread).c_str());                                        \
+    return thread->Suspend();                                                  \
+  }
+
+#define OPCODE_CONDITION_RESULT(value) CLEO_SetThreadCondResult(thread, value);
+
+// opcode param handling utils internal
+static SCRIPT_VAR *_paramsArray = nullptr;
+static eDataType _lastParamType = eDataType::DT_END;
+static eArrayDataType _lastParamArrayType = eArrayDataType::ADT_NONE;
+
+static SCRIPT_VAR &_readParam(CRunningScript *thread) {
+  _lastParamType = thread->PeekDataType();
+  _lastParamArrayType = thread->PeekArrayType();
+
+  CLEO_RetrieveOpcodeParams(thread, 1);
+  if (_paramsArray == nullptr)
+    _paramsArray = CLEO_GetOpcodeParamsArray();
+  return _paramsArray[0];
+}
+
+static SCRIPT_VAR &_readParamFloat(CRunningScript *thread) {
+  auto &var = _readParam(thread);
+
+  // people tend to use '0' instead '0.0' when providing literal float params in
+  // scripts binary these are equal, so can be allowed
+  if (var.dwParam == 0) {
+    // pretend it was float type
+    if (IsImmInteger(_lastParamType))
+      _lastParamType = eDataType::DT_FLOAT;
+    if (_lastParamArrayType == eArrayDataType::ADT_INT)
+      _lastParamArrayType = eArrayDataType::ADT_FLOAT;
+  }
+
+  return var;
+}
+
+static SCRIPT_VAR *_readParamVariable(CRunningScript *thread) {
+  _lastParamType = thread->PeekDataType();
+  _lastParamArrayType = thread->PeekArrayType();
+
+  return CLEO_GetPointerToScriptVariable(thread);
+}
+
+static StringParamBufferInfo _readParamStringInfo(CRunningScript *thread) {
+  _lastParamType = thread->PeekDataType();
+  _lastParamArrayType = thread->PeekArrayType();
+
+  StringParamBufferInfo result;
+  CLEO_ReadStringParamWriteBuffer(thread, &result.data, &result.size,
+                                  &result.needTerminator);
+  return result;
+}
+
+static void _writeParamPtr(CRunningScript *thread, void *valuePtr) {
+  _lastParamType = thread->PeekDataType();
+  _lastParamArrayType = thread->PeekArrayType();
+
+  if (_paramsArray == nullptr)
+    _paramsArray = CLEO_GetOpcodeParamsArray();
+  _paramsArray[0].pParam = valuePtr;
+  CLEO_RecordOpcodeParams(thread, 1);
+}
+
+template <typename T> static void _writeParam(CRunningScript *thread, T value) {
+  _lastParamType = thread->PeekDataType();
+  _lastParamArrayType = thread->PeekArrayType();
+
+  if (_paramsArray == nullptr)
+    _paramsArray = CLEO_GetOpcodeParamsArray();
+  _paramsArray[0].dwParam = 0;
+  memcpy(&_paramsArray[0], &value, sizeof(T));
+  CLEO_RecordOpcodeParams(thread, 1);
+}
+
+static inline bool _paramWasInt(bool output = false) {
+  if (_lastParamArrayType != eArrayDataType::ADT_NONE)
+    return _lastParamArrayType == eArrayDataType::ADT_INT;
+  if (IsVariable(_lastParamType))
+    return true;
+  if (!output && IsImmInteger(_lastParamType))
+    return true;
+  return false;
+}
+
+static inline bool _paramWasFloat(bool output = false) {
+  if (_lastParamArrayType != eArrayDataType::ADT_NONE)
+    return _lastParamArrayType == eArrayDataType::ADT_FLOAT;
+  if (IsVariable(_lastParamType))
+    return true;
+  if (!output && IsImmFloat(_lastParamType))
+    return true;
+  return false;
+}
+
+static inline bool _paramWasString(bool output = false) {
+  if (_lastParamArrayType != eArrayDataType::ADT_NONE) {
+    return _lastParamArrayType == eArrayDataType::ADT_STRING ||
+           _lastParamArrayType == eArrayDataType::ADT_TEXTLABEL ||
+           _lastParamArrayType ==
+               eArrayDataType::ADT_INT; // pointer to output buffer
+  }
+
+  if (IsVarString(_lastParamType))
+    return true;
+  if (output && IsImmInteger(_lastParamType))
+    return true; // allow writing strings into const addresses
+  if (!output && IsImmString(_lastParamType))
+    return true;
+
+  // pointer to output buffer
+  if (IsVariable(_lastParamType))
+    return true;
+
+  return false;
+}
+
+static inline bool _paramWasVariable() { return IsVariable(_lastParamType); }
+
+static const char *_readParamText(CRunningScript *thread, char *buffer,
+                                  size_t bufferSize) {
+  _lastParamType = thread->PeekDataType();
+  _lastParamArrayType = thread->PeekArrayType();
+
+  if (!_paramWasString()) {
+    SHOW_ERROR("Input argument %s expected to be string, got %s in script "
+               "%s\nScript suspended.",
+               GetParamInfo(1).c_str(),
+               ToKindStr(_lastParamType, _lastParamArrayType),
+               ScriptInfoStr(thread).c_str());
+    thread->Suspend();
+    _lastParamType = DT_INVALID; // mark error
+    return nullptr;
+  }
+
+  auto str = CLEO_ReadStringPointerOpcodeParam(
+      thread, buffer,
+      bufferSize); // returns pointer to source data whenever possible
+
+  if (str == nullptr) // reading string failed
+  {
+    auto isVariableInt = IsVariable(_lastParamType) &&
+                         (_lastParamArrayType == eArrayDataType::ADT_NONE ||
+                          _lastParamArrayType == eArrayDataType::ADT_INT);
+    if ((IsImmInteger(_lastParamType) ||
+         isVariableInt) && // pointer argument type?
+        CLEO_GetOpcodeParamsArray()->dwParam <= MinValidAddress) {
+      SHOW_ERROR(
+          "Invalid '0x%X' pointer of input string argument %s in script %s",
+          CLEO_GetOpcodeParamsArray()->dwParam, GetParamInfo().c_str(),
+          ScriptInfoStr(thread).c_str());
+    } else {
+      // other error
+      SHOW_ERROR("Invalid input argument %s in script %s\nScript suspended.",
+                 GetParamInfo().c_str(), ScriptInfoStr(thread).c_str());
+    }
+
+    thread->Suspend();
+    _lastParamType = DT_INVALID; // mark error
+    return nullptr;
+  }
+
+  return str;
+}
+
+static bool _writeParamText(CLEO::CRunningScript *thread,
+                            const StringParamBufferInfo &target,
+                            const char *str) {
+  if (str != nullptr && (size_t)str <= MinValidAddress) {
+    SHOW_ERROR("Invalid '0x%X' source pointer of output string argument %s in "
+               "script %s \nScript suspended.",
+               str, GetParamInfo(1).c_str(), ScriptInfoStr(thread).c_str());
+    thread->Suspend();
+    return false;
+  }
+
+  if ((size_t)target.data <= MinValidAddress) {
+    SHOW_ERROR("Invalid '0x%X' target pointer of output string argument in "
+               "script %s \nScript suspended.",
+               target.data, ScriptInfoStr(thread).c_str());
+    thread->Suspend();
+    return false;
+  }
+
+  if (target.size == 0) {
+    return true; // done
+  }
+
+  bool addTerminator = target.needTerminator;
+  size_t buffLen = target.size - addTerminator;
+  size_t length = str == nullptr ? 0 : strlen(str);
+
+  if (buffLen > length)
+    addTerminator = true; // there is space left for terminator
+
+  length = std::min<size_t>(length, buffLen);
+  if (length > 0)
+    std::memcpy(target.data, str, length);
+  if (addTerminator)
+    target.data[length] = '\0';
+
+  return true;
+}
+
+static bool _writeParamText(CRunningScript *thread, const char *str) {
+  _lastParamType = thread->PeekDataType();
+  _lastParamArrayType = thread->PeekArrayType();
+
+  if (str != nullptr && (size_t)str <= MinValidAddress) {
+    SHOW_ERROR("Invalid '0x%X' source pointer of output string argument %s in "
+               "script %s \nScript suspended.",
+               str, GetParamInfo(1).c_str(), ScriptInfoStr(thread).c_str());
+    thread->Suspend();
+    return false;
+  }
+
+  if (!_paramWasString(true)) {
+    SHOW_ERROR("Output argument %s expected to be variable string, got %s in "
+               "script %s\nScript suspended.",
+               GetParamInfo(1).c_str(),
+               ToKindStr(_lastParamType, _lastParamArrayType),
+               ScriptInfoStr(thread).c_str());
+    thread->Suspend();
+    return false;
+  }
+
+  if (IsImmInteger(_lastParamType) ||
+      IsVariable(_lastParamType)) // pointer to buffer
+  {
+    auto ptr = CLEO_PeekIntOpcodeParam(thread);
+
+    if ((size_t)ptr <= MinValidAddress) {
+      SHOW_ERROR("Invalid '0x%X' pointer of output string argument %s in "
+                 "script %s \nScript suspended.",
+                 ptr, GetParamInfo(1).c_str(), ScriptInfoStr(thread).c_str());
+      thread->Suspend();
+      return false;
+    }
+  }
+
+  StringParamBufferInfo info;
+  CLEO_ReadStringParamWriteBuffer(thread, &info.data, &info.size,
+                                  &info.needTerminator);
+  return _writeParamText(thread, info, str); // done
+}
+
+#define OPCODE_SKIP_PARAMS(_count) CLEO_SkipOpcodeParams(thread, _count)
+#define OPCODE_SKIP_VARARG_PARAMS() CLEO_SkipUnusedVarArgs(thread)
+
+#define OPCODE_PEEK_PARAM_TYPE() thread->PeekDataType()
+#define OPCODE_PEEK_VARARG_COUNT() CLEO_GetVarArgCount(thread)
+
+// macros for reading opcode input params. Performs type validation, throws
+// error and suspends script if user provided invalid argument type TOD: add
+// range checks for limited size types?
+
+#define OPCODE_READ_PARAM_BOOL()                                               \
+  _readParam(thread).dwParam != false;                                         \
+  if (!_paramWasInt()) {                                                       \
+    SHOW_ERROR("Input argument %s expected to be integer, got %s in script "   \
+               "%s\nScript suspended.",                                        \
+               GetParamInfo().c_str(),                                         \
+               CLEO::ToKindStr(_lastParamType, _lastParamArrayType),           \
+               CLEO::ScriptInfoStr(thread).c_str());                           \
+    return thread->Suspend();                                                  \
+  }
+
+#define OPCODE_READ_PARAM_INT8()                                               \
+  _readParam(thread).cParam;                                                   \
+  if (!_paramWasInt()) {                                                       \
+    SHOW_ERROR("Input argument %s expected to be integer, got %s in script "   \
+               "%s\nScript suspended.",                                        \
+               GetParamInfo().c_str(),                                         \
+               CLEO::ToKindStr(_lastParamType, _lastParamArrayType),           \
+               CLEO::ScriptInfoStr(thread).c_str());                           \
+    return thread->Suspend();                                                  \
+  }
+
+#define OPCODE_READ_PARAM_UINT8()                                              \
+  _readParam(thread).ucParam;                                                  \
+  if (!_paramWasInt()) {                                                       \
+    SHOW_ERROR("Input argument %s expected to be integer, got %s in script "   \
+               "%s\nScript suspended.",                                        \
+               GetParamInfo().c_str(),                                         \
+               CLEO::ToKindStr(_lastParamType, _lastParamArrayType),           \
+               CLEO::ScriptInfoStr(thread).c_str());                           \
+    return thread->Suspend();                                                  \
+  }
+
+#define OPCODE_READ_PARAM_INT16()                                              \
+  _readParam(thread).wParam;                                                   \
+  if (!_paramWasInt()) {                                                       \
+    SHOW_ERROR("Input argument %s expected to be integer, got %s in script "   \
+               "%s\nScript suspended.",                                        \
+               GetParamInfo().c_str(),                                         \
+               CLEO::ToKindStr(_lastParamType, _lastParamArrayType),           \
+               CLEO::ScriptInfoStr(thread).c_str());                           \
+    return thread->Suspend();                                                  \
+  }
+
+#define OPCODE_READ_PARAM_UINT16()                                             \
+  _readParam(thread).usParam;                                                  \
+  if (!_paramWasInt()) {                                                       \
+    SHOW_ERROR("Input argument %s expected to be integer, got %s in script "   \
+               "%s\nScript suspended.",                                        \
+               GetParamInfo().c_str(),                                         \
+               CLEO::ToKindStr(_lastParamType, _lastParamArrayType),           \
+               CLEO::ScriptInfoStr(thread).c_str());                           \
+    return thread->Suspend();                                                  \
+  }
+
+#define OPCODE_READ_PARAM_INT()                                                \
+  _readParam(thread).nParam;                                                   \
+  if (!_paramWasInt()) {                                                       \
+    SHOW_ERROR("Input argument %s expected to be integer, got %s in script "   \
+               "%s\nScript suspended.",                                        \
+               GetParamInfo().c_str(),                                         \
+               CLEO::ToKindStr(_lastParamType, _lastParamArrayType),           \
+               CLEO::ScriptInfoStr(thread).c_str());                           \
+    return thread->Suspend();                                                  \
+  }
+
+#define OPCODE_READ_PARAM_UINT()                                               \
+  _readParam(thread).dwParam;                                                  \
+  if (!_paramWasInt()) {                                                       \
+    SHOW_ERROR("Input argument %s expected to be integer, got %s in script "   \
+               "%s\nScript suspended.",                                        \
+               GetParamInfo().c_str(),                                         \
+               CLEO::ToKindStr(_lastParamType, _lastParamArrayType),           \
+               CLEO::ScriptInfoStr(thread).c_str());                           \
+    return thread->Suspend();                                                  \
+  }
+
+#define OPCODE_READ_PARAM_FLOAT()                                              \
+  _readParamFloat(thread).fParam;                                              \
+  if (!IsLegacyScript(thread) && !_paramWasFloat()) {                          \
+    SHOW_ERROR_COMPAT("Input argument %s expected to be float, got %s in "     \
+                      "script %s\nScript suspended.",                          \
+                      GetParamInfo().c_str(),                                  \
+                      CLEO::ToKindStr(_lastParamType, _lastParamArrayType),    \
+                      CLEO::ScriptInfoStr(thread).c_str());                    \
+    return thread->Suspend();                                                  \
+  }
+
+#define OPCODE_READ_PARAM_ANY32()                                              \
+  _readParam(thread);                                                          \
+  if (!_paramWasInt() && !_paramWasFloat()) {                                  \
+    SHOW_ERROR("Input argument %s expected to be int or float, got %s in "     \
+               "script %s\nScript suspended.",                                 \
+               GetParamInfo().c_str(),                                         \
+               CLEO::ToKindStr(_lastParamType, _lastParamArrayType),           \
+               CLEO::ScriptInfoStr(thread).c_str());                           \
+    return thread->Suspend();                                                  \
+  }
+
+#define OPCODE_READ_PARAM_STRING(_varName)                                     \
+  char _buff_##_varName[MAX_STR_LEN + 1];                                      \
+  const char *##_varName =                                                     \
+      _readParamText(thread, _buff_##_varName, MAX_STR_LEN + 1);               \
+  if (!_paramWasString()) {                                                    \
+    return OpcodeResult::OR_INTERRUPT;                                         \
+  }
+
+#define OPCODE_READ_PARAM_STRING_LEN(_varName, _maxLen)                        \
+  char _buff_##_varName[_maxLen + 1];                                          \
+  const char *##_varName =                                                     \
+      _readParamText(thread, _buff_##_varName, _maxLen + 1);                   \
+  if (##_varName != nullptr)                                                   \
+    ##_varName = _buff_##_varName;                                             \
+  if (!_paramWasString()) {                                                    \
+    return OpcodeResult::OR_INTERRUPT;                                         \
+  }
+
+#define OPCODE_READ_PARAM_STRING_FORMATTED(_varName)                           \
+  char _buff_format_##_varName[MAX_STR_LEN + 1];                               \
+  const char *_format_##_varName =                                             \
+      _readParamText(thread, _buff_format_##_varName, MAX_STR_LEN + 1);        \
+  if (!_paramWasString()) {                                                    \
+    return OpcodeResult::OR_INTERRUPT;                                         \
+  }                                                                            \
+  char _varName[2 * MAX_STR_LEN + 1];                                          \
+  char *_varName##Ok = CLEO_ReadParamsFormatted(                               \
+      thread, _buff_format_##_varName, _varName, sizeof(_varName));            \
+  if (_varName##Ok == nullptr) {                                               \
+    SHOW_ERROR("Invalid formatted string in script %s \nScript suspended.",    \
+               CLEO::ScriptInfoStr(thread).c_str());                           \
+    return thread->Suspend();                                                  \
+  }
+
+#define OPCODE_READ_PARAMS_FORMATTED(_format, _varName)                        \
+  char _varName[2 * MAX_STR_LEN + 1];                                          \
+  char *_varName##Ok =                                                         \
+      CLEO_ReadParamsFormatted(thread, _format, _varName, sizeof(_varName));   \
+  if (_varName##Ok == nullptr) {                                               \
+    SHOW_ERROR("Invalid formatted string in script %s \nScript suspended.",    \
+               CLEO::ScriptInfoStr(thread).c_str());                           \
+    return thread->Suspend();                                                  \
+  }
+
+#define OPCODE_READ_PARAM_FILEPATH(_varName)                                   \
+  char _buff_##_varName[512];                                                  \
+  const char *##_varName = _readParamText(thread, _buff_##_varName, 512);      \
+  if (##_varName != nullptr)                                                   \
+    ##_varName = _buff_##_varName;                                             \
+  if (_paramWasString())                                                       \
+    CLEO_ResolvePath(thread, _buff_##_varName, 512);                           \
+  else                                                                         \
+    return OpcodeResult::OR_INTERRUPT;                                         \
+  if (!FilepathIsSafe(thread, ##_varName)) {                                   \
+    SHOW_ERROR("Forbidden file path '%s' outside game directories in script "  \
+               "%s \nScript suspended.",                                       \
+               ##_varName, ScriptInfoStr(thread).c_str());                     \
+    return thread->Suspend();                                                  \
+  }
+
+#define OPCODE_READ_PARAM_PTR()                                                \
+  _readParam(thread).pParam;                                                   \
+  if (!_paramWasInt()) {                                                       \
+    SHOW_ERROR("Input argument %s expected to be integer, got %s in script "   \
+               "%s\nScript suspended.",                                        \
+               GetParamInfo().c_str(),                                         \
+               CLEO::ToKindStr(_lastParamType, _lastParamArrayType),           \
+               CLEO::ScriptInfoStr(thread).c_str());                           \
+    return thread->Suspend();                                                  \
+  } else if (_paramsArray[0].dwParam <= MinValidAddress) {                     \
+    SHOW_ERROR("Invalid pointer '0x%X' input argument %s in script %s "        \
+               "\nScript suspended.",                                          \
+               _paramsArray[0].dwParam, GetParamInfo().c_str(),                \
+               ScriptInfoStr(thread).c_str());                                 \
+    return thread->Suspend();                                                  \
+  }
+
+#define OPCODE_READ_PARAM_OBJECT_HANDLE()                                      \
+  _readParam(thread).dwParam;                                                  \
+  if (!_paramWasInt()) {                                                       \
+    SHOW_ERROR("Input argument %s expected to be integer, got %s in script "   \
+               "%s\nScript suspended.",                                        \
+               GetParamInfo().c_str(),                                         \
+               CLEO::ToKindStr(_lastParamType, _lastParamArrayType),           \
+               CLEO::ScriptInfoStr(thread).c_str());                           \
+    return thread->Suspend();                                                  \
+  } else if (!IsObjectHandleValid(_paramsArray[0].dwParam)) {                  \
+    SHOW_ERROR("Invalid object handle '0x%X' input argument %s in script %s "  \
+               "\nScript suspended.",                                          \
+               _paramsArray[0].dwParam, GetParamInfo().c_str(),                \
+               ScriptInfoStr(thread).c_str());                                 \
+    return thread->Suspend();                                                  \
+  }
+
+#define OPCODE_READ_PARAM_PED_HANDLE()                                         \
+  _readParam(thread).dwParam;                                                  \
+  if (!_paramWasInt()) {                                                       \
+    SHOW_ERROR("Input argument %s expected to be integer, got %s in script "   \
+               "%s\nScript suspended.",                                        \
+               GetParamInfo().c_str(),                                         \
+               CLEO::ToKindStr(_lastParamType, _lastParamArrayType),           \
+               CLEO::ScriptInfoStr(thread).c_str());                           \
+    return thread->Suspend();                                                  \
+  } else if (!IsPedHandleValid(_paramsArray[0].dwParam)) {                     \
+    SHOW_ERROR("Invalid character handle '0x%X' input argument %s in script "  \
+               "%s \nScript suspended.",                                       \
+               _paramsArray[0].dwParam, GetParamInfo().c_str(),                \
+               ScriptInfoStr(thread).c_str());                                 \
+    return thread->Suspend();                                                  \
+  }
+
+#define OPCODE_READ_PARAM_VEHICLE_HANDLE()                                     \
+  _readParam(thread).dwParam;                                                  \
+  if (!_paramWasInt()) {                                                       \
+    SHOW_ERROR("Input argument %s expected to be integer, got %s in script "   \
+               "%s\nScript suspended.",                                        \
+               GetParamInfo().c_str(),                                         \
+               CLEO::ToKindStr(_lastParamType, _lastParamArrayType),           \
+               CLEO::ScriptInfoStr(thread).c_str());                           \
+    return thread->Suspend();                                                  \
+  } else if (!IsVehicleHandleValid(_paramsArray[0].dwParam)) {                 \
+    SHOW_ERROR("Invalid vehicle handle '0x%X' input argument %s in script %s " \
+               "\nScript suspended.",                                          \
+               _paramsArray[0].dwParam, GetParamInfo().c_str(),                \
+               ScriptInfoStr(thread).c_str());                                 \
+    return thread->Suspend();                                                  \
+  }
+
+#define OPCODE_READ_PARAM_PLAYER_ID()                                          \
+  _readParam(thread).dwParam;                                                  \
+  if (!_paramWasInt()) {                                                       \
+    SHOW_ERROR("Input argument %s expected to be integer, got %s in script "   \
+               "%s\nScript suspended.",                                        \
+               GetParamInfo().c_str(),                                         \
+               CLEO::ToKindStr(_lastParamType, _lastParamArrayType),           \
+               CLEO::ScriptInfoStr(thread).c_str());                           \
+    return thread->Suspend();                                                  \
+  } else if (!IsPlayerIdValid(_paramsArray[0].dwParam)) {                      \
+    SHOW_ERROR("Invalid player id '0x%X' input argument %s in script %s "      \
+               "\nScript suspended.",                                          \
+               _paramsArray[0].dwParam, GetParamInfo().c_str(),                \
+               ScriptInfoStr(thread).c_str());                                 \
+    return thread->Suspend();                                                  \
+  }
+
+#define OPCODE_READ_PARAM_OUTPUT_VAR_ANY32()                                   \
+  _readParamVariable(thread);                                                  \
+  if (!_paramWasVariable()) {                                                  \
+    SHOW_ERROR("Output argument %s expected to be variable int or float, got " \
+               "%s in script %s\nScript suspended.",                           \
+               GetParamInfo().c_str(),                                         \
+               CLEO::ToKindStr(_lastParamType, _lastParamArrayType),           \
+               CLEO::ScriptInfoStr(thread).c_str());                           \
+    return thread->Suspend();                                                  \
+  }
+
+#define OPCODE_READ_PARAM_OUTPUT_VAR_INT()                                     \
+  (int *)_readParamVariable(thread);                                           \
+  if (!_paramWasVariable()) {                                                  \
+    SHOW_ERROR("Output argument %s expected to be variable int, got %s in "    \
+               "script %s\nScript suspended.",                                 \
+               GetParamInfo().c_str(),                                         \
+               CLEO::ToKindStr(_lastParamType, _lastParamArrayType),           \
+               CLEO::ScriptInfoStr(thread).c_str());                           \
+    return thread->Suspend();                                                  \
+  }                                                                            \
+  if (!_paramWasInt(true)) {                                                   \
+    SHOW_ERROR("Output argument %s expected to be variable int, got %s in "    \
+               "script %s\nScript suspended.",                                 \
+               GetParamInfo().c_str(),                                         \
+               CLEO::ToKindStr(_lastParamType, _lastParamArrayType),           \
+               CLEO::ScriptInfoStr(thread).c_str());                           \
+    return thread->Suspend();                                                  \
+  }
+
+#define OPCODE_READ_PARAM_OUTPUT_VAR_FLOAT()                                   \
+  (float *)_readParamVariable(thread);                                         \
+  if (!_paramWasVariable()) {                                                  \
+    SHOW_ERROR("Output argument %s expected to be variable float, got %s in "  \
+               "script %s\nScript suspended.",                                 \
+               GetParamInfo().c_str(),                                         \
+               CLEO::ToKindStr(_lastParamType, _lastParamArrayType),           \
+               CLEO::ScriptInfoStr(thread).c_str());                           \
+    return thread->Suspend();                                                  \
+  }                                                                            \
+  if (!IsLegacyScript(thread) && !_paramWasFloat(true)) {                      \
+    SHOW_ERROR_COMPAT("Output argument %s expected to be variable float, got " \
+                      "%s in script %s\nScript suspended.",                    \
+                      GetParamInfo().c_str(),                                  \
+                      CLEO::ToKindStr(_lastParamType, _lastParamArrayType),    \
+                      CLEO::ScriptInfoStr(thread).c_str());                    \
+    return thread->Suspend();                                                  \
+  }
+
+#define OPCODE_READ_PARAM_OUTPUT_VAR_STRING()                                  \
+  _readParamStringInfo(thread);                                                \
+  if (!_paramWasString(true)) {                                                \
+    SHOW_ERROR("Output argument %s expected to be variable string, got %s in " \
+               "script %s\nScript suspended.",                                 \
+               GetParamInfo().c_str(),                                         \
+               CLEO::ToKindStr(_lastParamType, _lastParamArrayType),           \
+               CLEO::ScriptInfoStr(thread).c_str());                           \
+    return thread->Suspend();                                                  \
+  }
+
+// macros for writing opcode output params. Performs type validation, throws
+// error and suspends script if user provided invalid argument type
+
+#define OPCODE_WRITE_PARAM_BOOL(_value)                                        \
+  _writeParam(thread, _value);                                                 \
+  if (!_paramWasInt(true)) {                                                   \
+    SHOW_ERROR("Output argument %s expected to be variable int, got %s in "    \
+               "script %s\nScript suspended.",                                 \
+               GetParamInfo().c_str(),                                         \
+               CLEO::ToKindStr(_lastParamType, _lastParamArrayType),           \
+               CLEO::ScriptInfoStr(thread).c_str());                           \
+    return thread->Suspend();                                                  \
+  }
+
+#define OPCODE_WRITE_PARAM_INT8(_value)                                        \
+  _writeParam(thread, _value);                                                 \
+  if (!_paramWasInt(true)) {                                                   \
+    SHOW_ERROR("Output argument %s expected to be variable int, got %s in "    \
+               "script %s\nScript suspended.",                                 \
+               GetParamInfo().c_str(),                                         \
+               CLEO::ToKindStr(_lastParamType, _lastParamArrayType),           \
+               CLEO::ScriptInfoStr(thread).c_str());                           \
+    return thread->Suspend();                                                  \
+  }
+
+#define OPCODE_WRITE_PARAM_UINT8(_value)                                       \
+  _writeParam(thread, _value);                                                 \
+  if (!_paramWasInt(true)) {                                                   \
+    SHOW_ERROR("Output argument %s expected to be variable int, got %s in "    \
+               "script %s\nScript suspended.",                                 \
+               GetParamInfo().c_str(),                                         \
+               CLEO::ToKindStr(_lastParamType, _lastParamArrayType),           \
+               CLEO::ScriptInfoStr(thread).c_str());                           \
+    return thread->Suspend();                                                  \
+  }
+
+#define OPCODE_WRITE_PARAM_INT16(_value)                                       \
+  _writeParam(thread, _value);                                                 \
+  if (!_paramWasInt(true)) {                                                   \
+    SHOW_ERROR("Output argument %s expected to be variable int, got %s in "    \
+               "script %s\nScript suspended.",                                 \
+               GetParamInfo().c_str(),                                         \
+               CLEO::ToKindStr(_lastParamType, _lastParamArrayType),           \
+               CLEO::ScriptInfoStr(thread).c_str());                           \
+    return thread->Suspend();                                                  \
+  }
+
+#define OPCODE_WRITE_PARAM_UINT16(_value)                                      \
+  _writeParam(thread, _value);                                                 \
+  if (!_paramWasInt(true)) {                                                   \
+    SHOW_ERROR("Output argument %s expected to be variable int, got %s in "    \
+               "script %s\nScript suspended.",                                 \
+               GetParamInfo().c_str(),                                         \
+               CLEO::ToKindStr(_lastParamType, _lastParamArrayType),           \
+               CLEO::ScriptInfoStr(thread).c_str());                           \
+    return thread->Suspend();                                                  \
+  }
+
+#define OPCODE_WRITE_PARAM_INT(_value)                                         \
+  _writeParam(thread, _value);                                                 \
+  if (!_paramWasInt(true)) {                                                   \
+    SHOW_ERROR("Output argument %s expected to be variable int, got %s in "    \
+               "script %s\nScript suspended.",                                 \
+               GetParamInfo().c_str(),                                         \
+               CLEO::ToKindStr(_lastParamType, _lastParamArrayType),           \
+               CLEO::ScriptInfoStr(thread).c_str());                           \
+    return thread->Suspend();                                                  \
+  }
+
+#define OPCODE_WRITE_PARAM_UINT(_value)                                        \
+  _writeParam(thread, _value);                                                 \
+  if (!_paramWasInt(true)) {                                                   \
+    SHOW_ERROR("Output argument %s expected to be variable int, got %s in "    \
+               "script %s\nScript suspended.",                                 \
+               GetParamInfo().c_str(),                                         \
+               CLEO::ToKindStr(_lastParamType, _lastParamArrayType),           \
+               CLEO::ScriptInfoStr(thread).c_str());                           \
+    return thread->Suspend();                                                  \
+  }
+
+#define OPCODE_WRITE_PARAM_ANY32(_value)                                       \
+  _writeParam(thread, _value);                                                 \
+  if (!_paramWasInt(true) && !_paramWasFloat(true)) {                          \
+    SHOW_ERROR("Output argument %s expected to be int or float variable, got " \
+               "%s in script %s\nScript suspended.",                           \
+               GetParamInfo().c_str(),                                         \
+               CLEO::ToKindStr(_lastParamType, _lastParamArrayType),           \
+               CLEO::ScriptInfoStr(thread).c_str());                           \
+    return thread->Suspend();                                                  \
+  }
+
+#define OPCODE_WRITE_PARAM_FLOAT(_value)                                       \
+  _writeParam(thread, _value);                                                 \
+  if (!IsLegacyScript(thread) && !_paramWasFloat(true)) {                      \
+    SHOW_ERROR_COMPAT("Output argument %s expected to be variable float, got " \
+                      "%s in script %s\nScript suspended.",                    \
+                      GetParamInfo().c_str(),                                  \
+                      CLEO::ToKindStr(_lastParamType, _lastParamArrayType),    \
+                      CLEO::ScriptInfoStr(thread).c_str());                    \
+    return thread->Suspend();                                                  \
+  }
+
+#define OPCODE_WRITE_PARAM_STRING(_value)                                      \
+  if (!_writeParamText(thread, _value)) {                                      \
+    return OpcodeResult::OR_INTERRUPT;                                         \
+  }
+
+#define OPCODE_WRITE_PARAM_VAR_STRING(_info, _value)                           \
+  if (!_writeParamText(thread, _info, _value)) {                               \
+    return OpcodeResult::OR_INTERRUPT;                                         \
+  }
+
+#define OPCODE_WRITE_PARAM_PTR(_value)                                         \
+  _writeParamPtr(thread, (void *)_value);                                      \
+  if (!_paramWasInt(true)) {                                                   \
+    SHOW_ERROR("Output argument %s expected to be variable int, got %s in "    \
+               "script %s\nScript suspended.",                                 \
+               GetParamInfo().c_str(),                                         \
+               CLEO::ToKindStr(_lastParamType, _lastParamArrayType),           \
+               CLEO::ScriptInfoStr(thread).c_str());                           \
+    return thread->Suspend();                                                  \
+  }
+} // namespace CLEO

--- a/source/CCodeInjector.cpp
+++ b/source/CCodeInjector.cpp
@@ -1,73 +1,72 @@
-#include "stdafx.h"
-#include "CleoBase.h"
-#include "CDebug.h"
 #include "CCodeInjector.h"
+#include "CDebug.h"
+#include "CleoBase.h"
+#include "stdafx.h"
 
-namespace CLEO
-{
-    void CCodeInjector::OpenReadWriteAccess()
-    {
-        if (bAccessOpen) return;
+namespace CLEO {
+void CCodeInjector::OpenReadWriteAccess() {
+  if (bAccessOpen)
+    return;
 
-        TRACE(""); // separator
-        TRACE("Opening memory access...");
+  TRACE(""); // separator
+  TRACE("Opening memory access...");
 
-        auto dwLoadOffset = static_cast<memory_pointer>(GetModuleHandle(nullptr));
+  auto dwLoadOffset = static_cast<memory_pointer>(GetModuleHandle(nullptr));
 
-        // Unprotect image - make .text and .rdata section writeable
-        auto pImageBase = (BYTE *)dwLoadOffset;
-        auto pDosHeader = (PIMAGE_DOS_HEADER)dwLoadOffset;
-        auto pNtHeader = (PIMAGE_NT_HEADERS)(pImageBase + pDosHeader->e_lfanew);
-        auto pSection = IMAGE_FIRST_SECTION(pNtHeader);
+  // Unprotect image - make .text and .rdata section writeable
+  auto pImageBase = (BYTE *)dwLoadOffset;
+  auto pDosHeader = (PIMAGE_DOS_HEADER)dwLoadOffset;
+  auto pNtHeader = (PIMAGE_NT_HEADERS)(pImageBase + pDosHeader->e_lfanew);
+  auto pSection = IMAGE_FIRST_SECTION(pNtHeader);
 
-        for (int i = pNtHeader->FileHeader.NumberOfSections; i; i--, pSection++)
-        {
-            if (!strcmp((char*)pSection->Name, ".text") || !strcmp((char*)pSection->Name, ".rdata"))
-            {
-                DWORD dwPhysSize = (pSection->Misc.VirtualSize + 4095) & ~4095;
-                TRACE(" Unprotecting memory region '%s': 0x%08X (size: 0x%08X)",
-                    pSection->Name,
-                    (DWORD)pSection->VirtualAddress,
-                    (DWORD)dwPhysSize
-                );
-                DWORD oldProtect, newProtect = (pSection->Characteristics & IMAGE_SCN_MEM_EXECUTE) ? PAGE_EXECUTE_READWRITE : PAGE_READWRITE;
-                if (!VirtualProtect(pImageBase + pSection->VirtualAddress, dwPhysSize, newProtect, &oldProtect))
-                    SHOW_ERROR("Virtual protect error");
-            }
-        }
-        TRACE(""); // separator
-
-        bAccessOpen = true;
+  for (int i = pNtHeader->FileHeader.NumberOfSections; i; i--, pSection++) {
+    if (!strcmp((char *)pSection->Name, ".text") ||
+        !strcmp((char *)pSection->Name, ".rdata")) {
+      DWORD dwPhysSize = (pSection->Misc.VirtualSize + 4095) & ~4095;
+      TRACE(" Unprotecting memory region '%s': 0x%08X (size: 0x%08X)",
+            pSection->Name, (DWORD)pSection->VirtualAddress, (DWORD)dwPhysSize);
+      DWORD oldProtect,
+          newProtect = (pSection->Characteristics & IMAGE_SCN_MEM_EXECUTE)
+                           ? PAGE_EXECUTE_READWRITE
+                           : PAGE_READWRITE;
+      if (!VirtualProtect(pImageBase + pSection->VirtualAddress, dwPhysSize,
+                          newProtect, &oldProtect))
+        SHOW_ERROR("Virtual protect error");
     }
+  }
+  TRACE(""); // separator
 
-    void CCodeInjector::CloseReadWriteAccess()
-    {
-        if (!bAccessOpen) return;
-
-        auto dwLoadOffset = static_cast<memory_pointer>(GetModuleHandle(nullptr));
-
-        // Unprotect image - make .text and .rdata section writeable
-        auto pImageBase = (BYTE *)dwLoadOffset;
-        auto pDosHeader = (PIMAGE_DOS_HEADER)dwLoadOffset;
-        auto pNtHeader = (PIMAGE_NT_HEADERS)(pImageBase + pDosHeader->e_lfanew);
-        auto pSection = IMAGE_FIRST_SECTION(pNtHeader);
-
-        for (int i = pNtHeader->FileHeader.NumberOfSections; i; i--, pSection++)
-        {
-            if (!strcmp((char*)pSection->Name, ".text") || !strcmp((char*)pSection->Name, ".rdata"))
-            {
-                DWORD dwPhysSize = (pSection->Misc.VirtualSize + 4095) & ~4095;
-                TRACE("Reprotecting memory region '%s': 0x%08X (size: 0x%08X)",
-                    pSection->Name,
-                    (DWORD)pSection->VirtualAddress,
-                    (DWORD)dwPhysSize
-                );
-                DWORD oldProtect, newProtect = (pSection->Characteristics & IMAGE_SCN_MEM_EXECUTE) ? PAGE_EXECUTE_READWRITE : PAGE_READWRITE;
-                if (!VirtualProtect(pImageBase + pSection->VirtualAddress, dwPhysSize, newProtect, &oldProtect))
-                    SHOW_ERROR("Virtual protect error");
-            }
-        }
-
-        bAccessOpen = false;
-    }
+  bAccessOpen = true;
 }
+
+void CCodeInjector::CloseReadWriteAccess() {
+  if (!bAccessOpen)
+    return;
+
+  auto dwLoadOffset = static_cast<memory_pointer>(GetModuleHandle(nullptr));
+
+  // Unprotect image - make .text and .rdata section writeable
+  auto pImageBase = (BYTE *)dwLoadOffset;
+  auto pDosHeader = (PIMAGE_DOS_HEADER)dwLoadOffset;
+  auto pNtHeader = (PIMAGE_NT_HEADERS)(pImageBase + pDosHeader->e_lfanew);
+  auto pSection = IMAGE_FIRST_SECTION(pNtHeader);
+
+  for (int i = pNtHeader->FileHeader.NumberOfSections; i; i--, pSection++) {
+    if (!strcmp((char *)pSection->Name, ".text") ||
+        !strcmp((char *)pSection->Name, ".rdata")) {
+      DWORD dwPhysSize = (pSection->Misc.VirtualSize + 4095) & ~4095;
+      TRACE("Reprotecting memory region '%s': 0x%08X (size: 0x%08X)",
+            pSection->Name, (DWORD)pSection->VirtualAddress, (DWORD)dwPhysSize);
+      DWORD oldProtect,
+          newProtect = (pSection->Characteristics & IMAGE_SCN_MEM_EXECUTE)
+                           ? PAGE_EXECUTE_READWRITE
+                           : PAGE_READWRITE;
+      if (!VirtualProtect(pImageBase + pSection->VirtualAddress, dwPhysSize,
+                          newProtect, &oldProtect))
+        SHOW_ERROR("Virtual protect error");
+    }
+  }
+
+  bAccessOpen = false;
+}
+} // namespace CLEO

--- a/source/CCodeInjector.h
+++ b/source/CCodeInjector.h
@@ -2,131 +2,157 @@
 #include "CDebug.h"
 #include "Mem.h"
 
-namespace CLEO
-{
-    // a pointer automatically convertible to integral types
-    union memory_pointer
-    {
-        size_t address;
-        void *pointer;
+namespace CLEO {
+// a pointer automatically convertible to integral types
+union memory_pointer {
+  size_t address;
+  void *pointer;
 
-        inline memory_pointer(void *p) : pointer(p) { }
-        inline memory_pointer(size_t a) : address(a) { }
-        inline operator void *() { return pointer; }
-        inline operator size_t() { return address; }
-        inline memory_pointer& operator=(void* p) { address = (size_t)p; return *this; }
-        inline memory_pointer& operator=(size_t p) { address = (size_t)p; return *this; }
+  inline memory_pointer(void *p) : pointer(p) {}
+  inline memory_pointer(size_t a) : address(a) {}
+  inline operator void *() { return pointer; }
+  inline operator size_t() { return address; }
+  inline memory_pointer &operator=(void *p) {
+    address = (size_t)p;
+    return *this;
+  }
+  inline memory_pointer &operator=(size_t p) {
+    address = (size_t)p;
+    return *this;
+  }
 
-        inline bool operator==(const void* p) const { return address == (size_t)p; }
-        inline bool operator!=(const void* p) const { return address != (size_t)p; }
-        inline bool operator==(const memory_pointer& p) const { return address == p.address; }
-        inline bool operator!=(const memory_pointer& p) const { return address != p.address; }
+  inline bool operator==(const void *p) const { return address == (size_t)p; }
+  inline bool operator!=(const void *p) const { return address != (size_t)p; }
+  inline bool operator==(const memory_pointer &p) const {
+    return address == p.address;
+  }
+  inline bool operator!=(const memory_pointer &p) const {
+    return address != p.address;
+  }
 
-        // conversion to/from any-type pointer
-        template<typename T>
-        inline memory_pointer(T *p) : pointer(reinterpret_cast<void *>(p)) {}
-        template<typename T>
-        inline operator T *() { return reinterpret_cast<T *>(pointer); }
-        template<typename T>
-        inline memory_pointer& operator=(T *p) { return *this = reinterpret_cast<void *>(p); }
-    };
+  // conversion to/from any-type pointer
+  template <typename T>
+  inline memory_pointer(T *p) : pointer(reinterpret_cast<void *>(p)) {}
+  template <typename T> inline operator T *() {
+    return reinterpret_cast<T *>(pointer);
+  }
+  template <typename T> inline memory_pointer &operator=(T *p) {
+    return *this = reinterpret_cast<void *>(p);
+  }
+};
 
-    VALIDATE_SIZE(memory_pointer, 4);
+VALIDATE_SIZE(memory_pointer, 4);
 
-    const memory_pointer memory_und = nullptr;
+const memory_pointer memory_und = nullptr;
 
-    // Implements dirty tricks for low-level memory managemant
-    class CCodeInjector
-    {
-        bool bAccessOpen;
+// Implements dirty tricks for low-level memory managemant
+class CCodeInjector {
+  bool bAccessOpen;
 
-    public:
-        CCodeInjector() 
-        {
-            bAccessOpen = false;
-            OpenReadWriteAccess(); // moved here so that access is open for plugins
-        }
+public:
+  CCodeInjector() {
+    bAccessOpen = false;
+    OpenReadWriteAccess(); // moved here so that access is open for plugins
+  }
 
-        ~CCodeInjector() = default;
+  ~CCodeInjector() = default;
 
-        void OpenReadWriteAccess();
-        void CloseReadWriteAccess();
+  void OpenReadWriteAccess();
+  void CloseReadWriteAccess();
 
-        template<typename T>
-        void ReplaceFunction(T *funcPtr, memory_pointer position, T** origFuncPtr = nullptr)
-        {
-            MemCall((size_t)position, (size_t)funcPtr, (size_t*)origFuncPtr);
+  template <typename T>
+  void ReplaceFunction(T *funcPtr, memory_pointer position,
+                       T **origFuncPtr = nullptr) {
+    MemCall((size_t)position, (size_t)funcPtr, (size_t *)origFuncPtr);
 
-            if (origFuncPtr == nullptr) { TRACE("Replaced call at: 0x%08X", (DWORD)position); }
-            else { TRACE("Replaced call at: 0x%08X, original function was: 0x%08X", (DWORD)position, (DWORD)*origFuncPtr); }
-        }
+    if (origFuncPtr == nullptr) {
+      TRACE("Replaced call at: 0x%08X", (DWORD)position);
+    } else {
+      TRACE("Replaced call at: 0x%08X, original function was: 0x%08X",
+            (DWORD)position, (DWORD)*origFuncPtr);
+    }
+  }
 
-        void ReplaceJump(memory_pointer newJumpDst, memory_pointer position, memory_pointer* origJumpDest = nullptr)
-        {
-            MemJump((size_t)position, (size_t)newJumpDst, (size_t*)origJumpDest);
+  void ReplaceJump(memory_pointer newJumpDst, memory_pointer position,
+                   memory_pointer *origJumpDest = nullptr) {
+    MemJump((size_t)position, (size_t)newJumpDst, (size_t *)origJumpDest);
 
-            if (origJumpDest == nullptr) { TRACE("Replaced jump at: 0x%08X", (DWORD)position); }
-            else { TRACE("Replaced jump at: 0x%08X, original destination was: 0x%08X", (DWORD)position, (DWORD)origJumpDest->address); }
-        }
+    if (origJumpDest == nullptr) {
+      TRACE("Replaced jump at: 0x%08X", (DWORD)position);
+    } else {
+      TRACE("Replaced jump at: 0x%08X, original destination was: 0x%08X",
+            (DWORD)position, (DWORD)origJumpDest->address);
+    }
+  }
 
-        template<typename T>
-        void InjectFunction(T *funcPtr, memory_pointer position)
-        {
-            TRACE("Injecting function at: 0x%08X", (DWORD)position);
-            MemJump((size_t)position, (size_t)funcPtr);
-        }
+  template <typename T>
+  void InjectFunction(T *funcPtr, memory_pointer position) {
+    TRACE("Injecting function at: 0x%08X", (DWORD)position);
+    MemJump((size_t)position, (size_t)funcPtr);
+  }
 
-        void Nop(memory_pointer addr, size_t size)
-        {
-            MemFill(addr, OP_NOP, size);
-        }
+  void Nop(memory_pointer addr, size_t size) { MemFill(addr, OP_NOP, size); }
 
-        template<typename T> void MemoryReadOffset(memory_pointer addr, T& result, bool force_vp = false)
-        {
-            DWORD oldProtect;
-            bool vp = force_vp;
-            if (vp) VirtualProtect(addr, sizeof(T), PAGE_EXECUTE_READWRITE, &oldProtect);
-            result = MemReadOffsetPtr<T>(addr.address);
-            //if (vp) VirtualProtect(addr, sizeof(T), oldProtect, &oldProtect);
-        }
+  template <typename T>
+  void MemoryReadOffset(memory_pointer addr, T &result, bool force_vp = false) {
+    DWORD oldProtect;
+    bool vp = force_vp;
+    if (vp)
+      VirtualProtect(addr, sizeof(T), PAGE_EXECUTE_READWRITE, &oldProtect);
+    result = MemReadOffsetPtr<T>(addr.address);
+    // if (vp) VirtualProtect(addr, sizeof(T), oldProtect, &oldProtect);
+  }
 
-        // copies object given by memory address @addr to the @result object
-        template<typename T> void MemoryRead(memory_pointer addr, T& result, bool force_vp = false)
-        {
-            DWORD oldProtect;
-            bool vp = force_vp;
-            if (vp) VirtualProtect(addr, sizeof(T), PAGE_EXECUTE_READWRITE, &oldProtect);
-            result = MemRead<T>(addr);
-            //if (vp) VirtualProtect(addr, sizeof(T), oldProtect, &oldProtect);
-        }
+  // copies object given by memory address @addr to the @result object
+  template <typename T>
+  void MemoryRead(memory_pointer addr, T &result, bool force_vp = false) {
+    DWORD oldProtect;
+    bool vp = force_vp;
+    if (vp)
+      VirtualProtect(addr, sizeof(T), PAGE_EXECUTE_READWRITE, &oldProtect);
+    result = MemRead<T>(addr);
+    // if (vp) VirtualProtect(addr, sizeof(T), oldProtect, &oldProtect);
+  }
 
-        // copies array of objects given by memory address @addr to the @result array of length @cnt
-        template<typename T> void MemoryRead(memory_pointer addr, T *result, size_t n, bool force_vp = false)
-        {
-            DWORD oldProtect;
-            bool vp = force_vp;
-            if (vp) VirtualProtect(addr, sizeof(T) * n, PAGE_EXECUTE_READWRITE, &oldProtect);
-            MemCopy(result, addr, n);
-            //if (vp) VirtualProtect(addr, sizeof(T) * n, oldProtect, &oldProtect);
-        }
+  // copies array of objects given by memory address @addr to the @result array
+  // of length @cnt
+  template <typename T>
+  void MemoryRead(memory_pointer addr, T *result, size_t n,
+                  bool force_vp = false) {
+    DWORD oldProtect;
+    bool vp = force_vp;
+    if (vp)
+      VirtualProtect(addr, sizeof(T) * n, PAGE_EXECUTE_READWRITE, &oldProtect);
+    MemCopy(result, addr, n);
+    // if (vp) VirtualProtect(addr, sizeof(T) * n, oldProtect, &oldProtect);
+  }
 
-        // copies @proto object to the object given by memory address @addr
-        template<typename T> void MemoryWrite(memory_pointer addr, const T& proto, bool force_vp = false, size_t n = 1)
-        {
-            DWORD oldProtect;
-            if (force_vp) VirtualProtect(addr, sizeof(T) * n, PAGE_EXECUTE_READWRITE, &oldProtect);
-            if (n != 1) MemFill(addr, proto, n);
-            else MemWrite(addr, proto);
-            //if(force_vp) VirtualProtect(addr, sizeof(T) * n, oldProtect, &oldProtect);
-        }
+  // copies @proto object to the object given by memory address @addr
+  template <typename T>
+  void MemoryWrite(memory_pointer addr, const T &proto, bool force_vp = false,
+                   size_t n = 1) {
+    DWORD oldProtect;
+    if (force_vp)
+      VirtualProtect(addr, sizeof(T) * n, PAGE_EXECUTE_READWRITE, &oldProtect);
+    if (n != 1)
+      MemFill(addr, proto, n);
+    else
+      MemWrite(addr, proto);
+    // if(force_vp) VirtualProtect(addr, sizeof(T) * n, oldProtect,
+    // &oldProtect);
+  }
 
-        // copies array of objects @proto of length @cnt to array of objects given by memory address @addr
-        template<typename T> void MemoryWrite(memory_pointer addr, const T *proto, size_t n, bool force_vp = false)
-        {
-            DWORD oldProtect;
-            if (force_vp) VirtualProtect(addr, sizeof(T) * n, PAGE_EXECUTE_READWRITE, &oldProtect);
-            MemCopy(addr, proto, n);
-            //if(force_vp) VirtualProtect(addr, sizeof(T) * n, oldProtect, &oldProtect);
-        }
-    };
-}
+  // copies array of objects @proto of length @cnt to array of objects given by
+  // memory address @addr
+  template <typename T>
+  void MemoryWrite(memory_pointer addr, const T *proto, size_t n,
+                   bool force_vp = false) {
+    DWORD oldProtect;
+    if (force_vp)
+      VirtualProtect(addr, sizeof(T) * n, PAGE_EXECUTE_READWRITE, &oldProtect);
+    MemCopy(addr, proto, n);
+    // if(force_vp) VirtualProtect(addr, sizeof(T) * n, oldProtect,
+    // &oldProtect);
+  }
+};
+} // namespace CLEO

--- a/source/CCustomOpcodeSystem.cpp
+++ b/source/CCustomOpcodeSystem.cpp
@@ -1,1094 +1,1114 @@
-#include "stdafx.h"
-#include "CleoBase.h"
-#include "CGameVersionManager.h"
 #include "CCustomOpcodeSystem.h"
+#include "CGameVersionManager.h"
+#include "CleoBase.h"
 #include "ScmFunction.h"
+#include "stdafx.h"
 
+namespace CLEO {
+CRunningScript *CCustomOpcodeSystem::lastScript = nullptr;
+WORD CCustomOpcodeSystem::lastOpcode = 0xFFFF;
+WORD *CCustomOpcodeSystem::lastOpcodePtr = nullptr;
+WORD CCustomOpcodeSystem::lastCustomOpcode = 0;
+std::string CCustomOpcodeSystem::lastErrorMsg = {};
+WORD CCustomOpcodeSystem::prevOpcode = 0xFFFF;
+BYTE CCustomOpcodeSystem::handledParamCount = 0;
 
-namespace CLEO
-{
-	CRunningScript* CCustomOpcodeSystem::lastScript = nullptr;
-	WORD CCustomOpcodeSystem::lastOpcode = 0xFFFF;
-	WORD* CCustomOpcodeSystem::lastOpcodePtr = nullptr;
-	WORD CCustomOpcodeSystem::lastCustomOpcode = 0;
-	std::string CCustomOpcodeSystem::lastErrorMsg = {};
-	WORD CCustomOpcodeSystem::prevOpcode = 0xFFFF;
-	BYTE CCustomOpcodeSystem::handledParamCount = 0;
+// opcode handler for custom opcodes
+OpcodeResult __fastcall CCustomOpcodeSystem::customOpcodeHandler(
+    CRunningScript *thread, int dummy, WORD opcode) {
+  OpcodeResult result = OR_NONE;
 
-	// opcode handler for custom opcodes
-	OpcodeResult __fastcall CCustomOpcodeSystem::customOpcodeHandler(CRunningScript *thread, int dummy, WORD opcode)
-	{
-		OpcodeResult result = OR_NONE;
+  auto AfterOpcodeExecuted = [&]() {
+    // execute registered callbacks
+    OpcodeResult callbackResult = OR_NONE;
+    for (void *func :
+         CleoInstance.GetCallbacks(eCallbackId::ScriptOpcodeProcessAfter)) {
+      typedef OpcodeResult WINAPI callback(CRunningScript *, DWORD,
+                                           OpcodeResult);
+      auto res = ((callback *)func)(thread, opcode, result);
 
-		auto AfterOpcodeExecuted = [&]()
-		{
-			// execute registered callbacks
-			OpcodeResult callbackResult = OR_NONE;
-			for (void* func : CleoInstance.GetCallbacks(eCallbackId::ScriptOpcodeProcessAfter))
-			{
-				typedef OpcodeResult WINAPI callback(CRunningScript*, DWORD, OpcodeResult);
-				auto res = ((callback*)func)(thread, opcode, result);
+      callbackResult = std::max(
+          res,
+          callbackResult); // store result with highest value from all callbacks
+    }
 
-				callbackResult = std::max(res, callbackResult); // store result with highest value from all callbacks
-			}
+    return (callbackResult != OR_NONE) ? callbackResult : result;
+  };
 
-			return (callbackResult != OR_NONE) ? callbackResult : result;
-		};
+  prevOpcode = (thread != lastScript) ? 0xFFFF : lastOpcode;
+  lastScript = thread;
+  lastOpcode = opcode;
+  lastOpcodePtr =
+      (WORD *)thread->GetBytePointer() - 1; // rewind to the opcode start
+  handledParamCount = 0;
 
-		prevOpcode = (thread != lastScript) ? 0xFFFF : lastOpcode;
-		lastScript = thread;
-		lastOpcode = opcode;
-		lastOpcodePtr = (WORD*)thread->GetBytePointer() - 1; // rewind to the opcode start
-		handledParamCount = 0;
+  // prevent past code execution
+  if (thread->IsCustom() && !IsLegacyScript(thread)) {
+    auto cs = (CCustomScript *)thread;
+    auto endPos = cs->GetBasePointer() + cs->GetCodeSize();
+    if ((BYTE *)lastOpcodePtr == endPos ||
+        (BYTE *)lastOpcodePtr ==
+            (endPos - 1)) // consider script can end with incomplete opcode
+    {
+      SHOW_ERROR_COMPAT(
+          "Code execution past script end in script %s\nThis usually happens "
+          "when [004E] command is missing.\nScript suspended.",
+          ScriptInfoStr(thread).c_str());
+      result = thread->Suspend();
+      return AfterOpcodeExecuted();
+    }
+  }
 
-		// prevent past code execution
-		if (thread->IsCustom() && !IsLegacyScript(thread))
-		{
-			auto cs = (CCustomScript*)thread;
-			auto endPos = cs->GetBasePointer() + cs->GetCodeSize();
-			if ((BYTE*)lastOpcodePtr == endPos || (BYTE*)lastOpcodePtr == (endPos - 1)) // consider script can end with incomplete opcode
-			{
-				SHOW_ERROR_COMPAT("Code execution past script end in script %s\nThis usually happens when [004E] command is missing.\nScript suspended.", ScriptInfoStr(thread).c_str());
-				result = thread->Suspend();
-				return AfterOpcodeExecuted();
-			}
-		}
+  // execute registered callbacks
+  for (void *func :
+       CleoInstance.GetCallbacks(eCallbackId::ScriptOpcodeProcessBefore)) {
+    typedef OpcodeResult WINAPI callback(CRunningScript *, DWORD);
+    result = ((callback *)func)(thread, opcode);
 
-		// execute registered callbacks
-		for (void* func : CleoInstance.GetCallbacks(eCallbackId::ScriptOpcodeProcessBefore))
-		{
-			typedef OpcodeResult WINAPI callback(CRunningScript*, DWORD);
-			result = ((callback*)func)(thread, opcode);
+    if (result != OR_NONE)
+      break; // processed
+  }
 
-			if(result != OR_NONE)
-				break; // processed
-		}
+  if (result == OR_NONE) // opcode not proccessed yet
+  {
+    if (opcode > Opcode_Max) {
+      SHOW_ERROR("Opcode [%04X] out of supported range! \nCalled in script "
+                 "%s\nScript suspended.",
+                 opcode, ScriptInfoStr(thread).c_str());
+      result = thread->Suspend();
+      return AfterOpcodeExecuted();
+    }
 
-		if (result == OR_NONE) // opcode not proccessed yet
-		{
-			if(opcode > Opcode_Max)
-			{
-				SHOW_ERROR("Opcode [%04X] out of supported range! \nCalled in script %s\nScript suspended.", opcode, ScriptInfoStr(thread).c_str());
-				result = thread->Suspend();
-				return AfterOpcodeExecuted();
-			}
+    CustomOpcodeHandler handler = customOpcodeProc[opcode];
+    if (handler != nullptr) {
+      lastCustomOpcode = opcode;
+      result = handler(thread);
+      return AfterOpcodeExecuted();
+    }
 
-			CustomOpcodeHandler handler = customOpcodeProc[opcode];
-			if (handler != nullptr)
-			{
-				lastCustomOpcode = opcode;
-				result = handler(thread);
-				return AfterOpcodeExecuted();
-			}
+    // Not registered as custom opcode. Call game's original handler
+    result = CallNativeOpcode(thread, opcode);
+    if (result == OR_ERROR) {
+      auto extensionMsg =
+          CleoInstance.OpcodeInfoDb.GetExtensionMissingMessage(opcode);
+      if (!extensionMsg.empty())
+        extensionMsg = " " + extensionMsg;
 
-			// Not registered as custom opcode. Call game's original handler
-			result = CallNativeOpcode(thread, opcode);
-			if(result == OR_ERROR)
-			{
-				auto extensionMsg = CleoInstance.OpcodeInfoDb.GetExtensionMissingMessage(opcode);
-				if (!extensionMsg.empty()) extensionMsg = " " + extensionMsg;
+      SHOW_ERROR(
+          "Opcode [%04X] not found!%s\nCalled in script %s\nScript suspended.",
+          opcode, extensionMsg.c_str(), ScriptInfoStr(thread).c_str());
 
-				SHOW_ERROR("Opcode [%04X] not found!%s\nCalled in script %s\nScript suspended.",
-					opcode,
-					extensionMsg.c_str(),
-					ScriptInfoStr(thread).c_str());
+      result = thread->Suspend();
+      return AfterOpcodeExecuted();
+    }
+  }
 
-				result = thread->Suspend();
-				return AfterOpcodeExecuted();
-			}
-		}
+  return AfterOpcodeExecuted();
+}
 
-		return AfterOpcodeExecuted();
-	}
+void CCustomOpcodeSystem::FinalizeScriptObjects() {
+  TRACE("Cleaning up script data...");
 
-	void CCustomOpcodeSystem::FinalizeScriptObjects()
-	{
-		TRACE("Cleaning up script data...");
+  CleoInstance.CallCallbacks(eCallbackId::ScriptsFinalize);
 
-		CleoInstance.CallCallbacks(eCallbackId::ScriptsFinalize);
+  // clean up after opcode_0AB1
+  ScmFunction::Clear();
+}
 
-		// clean up after opcode_0AB1
-		ScmFunction::Clear();
-	}
+void CCustomOpcodeSystem::Inject(CCodeInjector &inj) {
+  TRACE("Injecting CustomOpcodeSystem...");
+  CGameVersionManager &gvm = CleoInstance.VersionManager;
 
-	void CCustomOpcodeSystem::Inject(CCodeInjector& inj)
-	{
-		TRACE("Injecting CustomOpcodeSystem...");
-		CGameVersionManager& gvm = CleoInstance.VersionManager;
+  // replace all handlers in original table
+  // store original opcode handlers for later use
+  auto handlersTable = (OpcodeHandler *)::CRunningScript::CommandHandlerTable;
+  for (size_t i = 0; i < OriginalOpcodeHandlersCount; i++) {
+    originalOpcodeHandlers[i] = handlersTable[i];
+    handlersTable[i] = (OpcodeHandler)customOpcodeHandler;
+  }
 
-		// replace all handlers in original table
-		// store original opcode handlers for later use
-		auto handlersTable = (OpcodeHandler*)::CRunningScript::CommandHandlerTable;
-		for(size_t i = 0; i < OriginalOpcodeHandlersCount; i++)
-		{
-			originalOpcodeHandlers[i] = handlersTable[i];
-			handlersTable[i] = (OpcodeHandler)customOpcodeHandler;
-		}
+  // initialize and apply new handlers table
+  for (size_t i = 0; i < CustomOpcodeHandlersCount; i++) {
+    customOpcodeHandlers[i] = (OpcodeHandler)customOpcodeHandler;
+  }
 
-		// initialize and apply new handlers table
-		for (size_t i = 0; i < CustomOpcodeHandlersCount; i++)
-		{
-			customOpcodeHandlers[i] = (OpcodeHandler)customOpcodeHandler;
-		}
+  inj.MemoryWrite(gvm.TranslateMemoryAddress(MA_OPCODE_HANDLER_REF_1),
+                  &customOpcodeHandlers);
+  inj.MemoryWrite(gvm.TranslateMemoryAddress(MA_OPCODE_HANDLER_REF_2),
+                  &customOpcodeHandlers);
+}
 
-		inj.MemoryWrite(gvm.TranslateMemoryAddress(MA_OPCODE_HANDLER_REF_1), &customOpcodeHandlers);
-		inj.MemoryWrite(gvm.TranslateMemoryAddress(MA_OPCODE_HANDLER_REF_2), &customOpcodeHandlers);
-	}
+void CCustomOpcodeSystem::Init() {
+  if (initialized)
+    return;
 
-	void CCustomOpcodeSystem::Init()
-	{
-		if (initialized) return;
+  TRACE(""); // separator
+  TRACE("Initializing CLEO core opcodes...");
 
-		TRACE(""); // separator
-		TRACE("Initializing CLEO core opcodes...");
+  CLEO_RegisterOpcode(0x004E, opcode_004E);
+  CLEO_RegisterOpcode(0x0051, opcode_0051);
+  CLEO_RegisterOpcode(0x0417, opcode_0417);
+  CLEO_RegisterOpcode(0x0A92, opcode_0A92);
+  CLEO_RegisterOpcode(0x0A93, opcode_0A93);
+  CLEO_RegisterOpcode(0x0A94, opcode_0A94);
+  CLEO_RegisterOpcode(0x0A95, opcode_0A95);
+  CLEO_RegisterOpcode(0x0AA0, opcode_0AA0);
+  CLEO_RegisterOpcode(0x0AA1, opcode_0AA1);
+  CLEO_RegisterOpcode(0x0AA9, opcode_0AA9);
+  CLEO_RegisterOpcode(0x0AB1, opcode_0AB1);
+  CLEO_RegisterOpcode(0x0AB2, opcode_0AB2);
+  CLEO_RegisterOpcode(0x0AB3, opcode_0AB3);
+  CLEO_RegisterOpcode(0x0AB4, opcode_0AB4);
 
-		CLEO_RegisterOpcode(0x004E, opcode_004E);
-		CLEO_RegisterOpcode(0x0051, opcode_0051);
-		CLEO_RegisterOpcode(0x0417, opcode_0417);
-		CLEO_RegisterOpcode(0x0A92, opcode_0A92);
-		CLEO_RegisterOpcode(0x0A93, opcode_0A93);
-		CLEO_RegisterOpcode(0x0A94, opcode_0A94);
-		CLEO_RegisterOpcode(0x0A95, opcode_0A95);
-		CLEO_RegisterOpcode(0x0AA0, opcode_0AA0);
-		CLEO_RegisterOpcode(0x0AA1, opcode_0AA1);
-		CLEO_RegisterOpcode(0x0AA9, opcode_0AA9);
-		CLEO_RegisterOpcode(0x0AB1, opcode_0AB1);
-		CLEO_RegisterOpcode(0x0AB2, opcode_0AB2);
-		CLEO_RegisterOpcode(0x0AB3, opcode_0AB3);
-		CLEO_RegisterOpcode(0x0AB4, opcode_0AB4);
+  CLEO_RegisterOpcode(0x0DD5, opcode_0DD5); // get_platform
 
-		CLEO_RegisterOpcode(0x0DD5, opcode_0DD5); // get_platform
+  CLEO_RegisterOpcode(0x2000, opcode_2000); // get_cleo_arg_count
+  // 2001 free
+  CLEO_RegisterOpcode(0x2002, opcode_2002); // cleo_return_with
+  CLEO_RegisterOpcode(0x2003, opcode_2003); // cleo_return_fail
 
-		CLEO_RegisterOpcode(0x2000, opcode_2000); // get_cleo_arg_count
-		// 2001 free
-		CLEO_RegisterOpcode(0x2002, opcode_2002); // cleo_return_with
-		CLEO_RegisterOpcode(0x2003, opcode_2003); // cleo_return_fail
+  initialized = true;
+}
 
-		initialized = true;
-	}
+CCustomOpcodeSystem::~CCustomOpcodeSystem() {
+  TRACE(""); // separator
+  TRACE("Custom Opcode System finalized:");
+  TRACE(" Last opcode executed: %04X", lastOpcode);
+  TRACE(" Previous opcode executed: %04X", prevOpcode);
+}
 
-	CCustomOpcodeSystem::~CCustomOpcodeSystem()
-	{
-		TRACE(""); // separator
-		TRACE("Custom Opcode System finalized:");
-		TRACE(" Last opcode executed: %04X", lastOpcode);
-		TRACE(" Previous opcode executed: %04X", prevOpcode);
-	}
+CCustomOpcodeSystem::OpcodeHandler
+    CCustomOpcodeSystem::originalOpcodeHandlers[OriginalOpcodeHandlersCount];
+CCustomOpcodeSystem::OpcodeHandler
+    CCustomOpcodeSystem::customOpcodeHandlers[CustomOpcodeHandlersCount];
+CustomOpcodeHandler CCustomOpcodeSystem::customOpcodeProc[Opcode_Max + 1];
 
-	CCustomOpcodeSystem::OpcodeHandler CCustomOpcodeSystem::originalOpcodeHandlers[OriginalOpcodeHandlersCount];
-	CCustomOpcodeSystem::OpcodeHandler CCustomOpcodeSystem::customOpcodeHandlers[CustomOpcodeHandlersCount];
-	CustomOpcodeHandler CCustomOpcodeSystem::customOpcodeProc[Opcode_Max + 1];
+bool CCustomOpcodeSystem::RegisterOpcode(WORD opcode,
+                                         CustomOpcodeHandler callback) {
+  if (opcode > Opcode_Max) {
+    SHOW_ERROR("Can not register [%04X] opcode! Out of supported range.",
+               opcode);
+    return false;
+  }
 
-	bool CCustomOpcodeSystem::RegisterOpcode(WORD opcode, CustomOpcodeHandler callback)
-	{
-		if (opcode > Opcode_Max)
-		{
-			SHOW_ERROR("Can not register [%04X] opcode! Out of supported range.", opcode);
-			return false;
-		}
+  CustomOpcodeHandler &dst = customOpcodeProc[opcode];
+  if (*dst != nullptr) {
+    LOG_WARNING(0, "Opcode [%04X] already registered! Replacing...", opcode);
+  }
 
-		CustomOpcodeHandler& dst = customOpcodeProc[opcode];
-		if (*dst != nullptr)
-		{
-			LOG_WARNING(0, "Opcode [%04X] already registered! Replacing...", opcode);
-		}
+  dst = callback;
+  TRACE("Opcode [%04X] registered", opcode);
+  return true;
+}
 
-		dst = callback;
-		TRACE("Opcode [%04X] registered", opcode);
-		return true;
-	}
-
-	OpcodeResult _CallNativeOpcode(CRunningScript* thread, void* handler, DWORD opcode)
-	{
-		// wrapped in separate function as otherwise some problems occur in debug builds
-		OpcodeResult result;
-		_asm
-		{
+OpcodeResult _CallNativeOpcode(CRunningScript *thread, void *handler,
+                               DWORD opcode) {
+  // wrapped in separate function as otherwise some problems occur in debug
+  // builds
+  OpcodeResult result;
+  _asm
+  {
 			push opcode
 			mov ecx, thread
 			call handler
 			mov result, al
-		}
-		return result;
-	}
-
-	OpcodeResult CCustomOpcodeSystem::CallNativeOpcode(CRunningScript* thread, WORD opcode)
-	{
-		if (opcode > Opcode_Max_Native)
-		{
-			return OR_ERROR;
-		}
-
-		size_t tableIdx = opcode / Opcode_Table_Size;
-		return _CallNativeOpcode(thread, originalOpcodeHandlers[tableIdx], opcode);
-	}
-
-	const char* ReadStringParam(CRunningScript *thread, char* buff, int buffSize)
-	{
-		if (buffSize > 0) buff[buffSize - 1] = '\0'; // buffer always terminated
-		return GetScriptStringParam(thread, 0, buff, buffSize - 1); // minus terminator
-	}
-
-	// write output\result string parameter
-	bool WriteStringParam(CRunningScript* thread, const char* str)
-	{
-		auto target = GetStringParamWriteBuffer(thread);
-		return WriteStringParam(target, str);
-	}
-
-	bool WriteStringParam(const StringParamBufferInfo& target, const char* str)
-	{
-		CCustomOpcodeSystem::lastErrorMsg.clear();
-
-		if (str != nullptr && (size_t)str <= MinValidAddress)
-		{
-			CCustomOpcodeSystem::lastErrorMsg = StringPrintf("Writing string from invalid '0x%X' pointer", target.data);
-			return false;
-		}
-
-		if ((size_t)target.data <= MinValidAddress)
-		{
-			CCustomOpcodeSystem::lastErrorMsg = StringPrintf("Writing string into invalid '0x%X' pointer argument", target.data);
-			return false;
-		}
-
-		if (target.size == 0)
-		{
-			return false;
-		}
-
-		bool addTerminator = target.needTerminator;
-		size_t buffLen = target.size - addTerminator;
-		size_t length = str == nullptr ? 0 : strlen(str);
-
-		if (buffLen > length) addTerminator = true; // there is space left for terminator
-
-		length = std::min(length, buffLen);
-		if (length > 0) std::memcpy(target.data, str, length);
-		if (addTerminator) target.data[length] = '\0';
-
-		return true;
-	}
-
-	StringParamBufferInfo GetStringParamWriteBuffer(CRunningScript* thread)
-	{
-		StringParamBufferInfo result;
-		CCustomOpcodeSystem::lastErrorMsg.clear();
-
-		auto paramType = thread->PeekDataType();
-		if (IsImmInteger(paramType) || IsVariable(paramType))
-		{
-			// address to output buffer
-			CScriptEngine::GetScriptParams(thread, 1);
-
-			if (opcodeParams[0].dwParam <= MinValidAddress)
-			{
-				CCustomOpcodeSystem::lastErrorMsg = StringPrintf("Writing string into invalid '0x%X' pointer argument", opcodeParams[0].dwParam);
-				return result; // error
-			}
-
-			result.data = opcodeParams[0].pcParam;
-			result.size = 0x7FFFFFFF; // user allocated memory block can be any size
-			result.needTerminator = true;
-
-			return result;
-		}
-		else
-		if (IsVarString(paramType))
-		{
-			switch(paramType)
-			{
-				// short string variable
-				case DT_VAR_TEXTLABEL:
-				case DT_LVAR_TEXTLABEL:
-				case DT_VAR_TEXTLABEL_ARRAY:
-				case DT_LVAR_TEXTLABEL_ARRAY:
-					result.data = (char*)CScriptEngine::GetScriptParamPointer(thread);
-					result.size = 8;
-					result.needTerminator = false;
-					return result;
-
-				// long string variable
-				case DT_VAR_STRING:
-				case DT_LVAR_STRING:
-				case DT_VAR_STRING_ARRAY:
-				case DT_LVAR_STRING_ARRAY:
-					result.data = (char*)CScriptEngine::GetScriptParamPointer(thread);
-					result.size = 16;
-					result.needTerminator = false;
-					return result;
-			}
-		}
-
-		CCustomOpcodeSystem::lastErrorMsg = StringPrintf("Writing string, got argument %s", ToKindStr(paramType));
-		CLEO_SkipOpcodeParams(thread, 1); // skip unhandled param
-		return result; // error
-	}
-
-	// perform 'sprintf'-operation for parameters, passed through SCM
-	int ReadFormattedString(CRunningScript *thread, char *outputStr, DWORD len, const char *format)
-	{
-		unsigned int written = 0;
-		const char *iter = format;
-		char* outIter = outputStr;
-		char bufa[MAX_STR_LEN + 1], fmtbufa[64], *fmta;
-
-		// invalid input arguments
-		if(outputStr == nullptr || len == 0)
-		{
-			LOG_WARNING(thread, "ReadFormattedString invalid input arg(s) in script %s", ScriptInfoStr(thread).c_str());
-			SkipUnusedVarArgs(thread);
-			return -1; // error
-		}
-
-		if(len > 1 && format != nullptr)
-		{
-			while (*iter)
-			{
-				while (*iter && *iter != '%')
-				{
-					if (written++ >= len) goto _ReadFormattedString_OutOfMemory;
-					*outIter++ = *iter++;
-				}
-
-				if (*iter == '%')
-				{
-					// end of format string
-					if (iter[1] == '\0')
-					{
-						LOG_WARNING(thread, "ReadFormattedString encountered incomplete format specifier in script %s", ScriptInfoStr(thread).c_str());
-						SkipUnusedVarArgs(thread);
-						return -1; // error
-					}
-
-					// escaped % character
-					if (iter[1] == '%')
-					{
-						if (written++ >= len) goto _ReadFormattedString_OutOfMemory;
-						*outIter++ = '%';
-						iter += 2;
-						continue;
-					}
-
-					//get flags and width specifier
-					fmta = fmtbufa;
-					*fmta++ = *iter++;
-					while (*iter == '0' ||
-						   *iter == '+' ||
-						   *iter == '-' ||
-						   *iter == ' ' ||
-						   *iter == '*' ||
-						   *iter == '#')
-					{
-						if (*iter == '*')
-						{
-							//get width
-							if (thread->PeekDataType() == DT_END) goto _ReadFormattedString_ArgMissing;
-							CScriptEngine::GetScriptParams(thread, 1);
-							_itoa_s(opcodeParams[0].dwParam, bufa, 10);
-
-							char* buffiter = bufa;
-							while (*buffiter)
-								*fmta++ = *buffiter++;
-						}
-						else
-							*fmta++ = *iter;
-						iter++;
-					}
-
-					//get immidiate width value
-					while (isdigit(*iter))
-						*fmta++ = *iter++;
-
-					//get precision
-					if (*iter == '.')
-					{
-						*fmta++ = *iter++;
-						if (*iter == '*')
-						{
-							if (thread->PeekDataType() == DT_END) goto _ReadFormattedString_ArgMissing;
-							CScriptEngine::GetScriptParams(thread, 1);
-							_itoa_s(opcodeParams[0].dwParam, bufa, 10);
-
-							char* buffiter = bufa;
-							while (*buffiter)
-								*fmta++ = *buffiter++;
-						}
-						else
-							while (isdigit(*iter))
-								*fmta++ = *iter++;
-					}
-					//get size
-					if (*iter == 'h' || *iter == 'l')
-						*fmta++ = *iter++;
-
-					switch (*iter)
-					{
-					case 's':
-					{
-						if (thread->PeekDataType() == DT_END) goto _ReadFormattedString_ArgMissing;
-
-						const char* str = ReadStringParam(thread, bufa, sizeof(bufa));
-						if(str == nullptr) // read error
-						{
-							static const char none[] = "(INVALID_STR)";
-							str = none;
-						}
-						
-						while (*str)
-						{
-							if (written++ >= len) goto _ReadFormattedString_OutOfMemory;
-							*outIter++ = *str++;
-						}
-						iter++;
-						break;
-					}
-
-					case 'c':
-						if (written++ >= len) goto _ReadFormattedString_OutOfMemory;
-						if (thread->PeekDataType() == DT_END) goto _ReadFormattedString_ArgMissing;
-						CScriptEngine::GetScriptParams(thread, 1);
-						*outIter++ = (char)opcodeParams[0].nParam;
-						iter++;
-						break;
-
-					default:
-					{
-						/* For non wc types, use system sprintf and append to wide char output */
-						/* FIXME: for unrecognised types, should ignore % when printing */
-						if (*iter == 'p' || *iter == 'P')
-						{
-							if (thread->PeekDataType() == DT_END) goto _ReadFormattedString_ArgMissing;
-							CScriptEngine::GetScriptParams(thread, 1);
-							sprintf_s(bufa, "%08X", opcodeParams[0].dwParam);
-						}
-						else
-						{
-							*fmta++ = *iter;
-							*fmta = '\0';
-							if (*iter == 'a' || *iter == 'A' ||
-								*iter == 'e' || *iter == 'E' ||
-								*iter == 'f' || *iter == 'F' ||
-								*iter == 'g' || *iter == 'G')
-							{
-								if (thread->PeekDataType() == DT_END) goto _ReadFormattedString_ArgMissing;
-								CScriptEngine::GetScriptParams(thread, 1);
-								sprintf_s(bufa, fmtbufa, opcodeParams[0].fParam);
-							}
-							else
-							{
-								if (thread->PeekDataType() == DT_END) goto _ReadFormattedString_ArgMissing;
-								CScriptEngine::GetScriptParams(thread, 1);
-								sprintf_s(bufa, fmtbufa, opcodeParams[0].pParam);
-							}
-						}
-						char* bufaiter = bufa;
-						while (*bufaiter)
-						{
-							if (written++ >= len) goto _ReadFormattedString_OutOfMemory;
-							*outIter++ = *bufaiter++;
-						}
-						iter++;
-						break;
-					}
-					}
-				}
-			}
-		}
-
-		if (written >= len)
-		{
-		_ReadFormattedString_OutOfMemory: // jump here on error
-
-			LOG_WARNING(thread, "Target buffer too small (%d) to read whole formatted string in script %s", len, ScriptInfoStr(thread).c_str());
-			SkipUnusedVarArgs(thread);
-			outputStr[len - 1] = '\0';
-			return -1; // error
-		}
-
-		// still more var-args available
-		if (thread->PeekDataType() != DT_END)
-		{
-			LOG_WARNING(thread, "More arguments than tokens in format string in script %s", ScriptInfoStr(thread).c_str());
-		}
-		SkipUnusedVarArgs(thread); // skip terminator too
-
-		outputStr[written] = '\0';
-		return (int)written;
-
-	_ReadFormattedString_ArgMissing: // jump here on error
-		LOG_WARNING(thread, "More tokens in format string than arguments in script %s", ScriptInfoStr(thread).c_str());
-		thread->IncPtr(); // skip vararg terminator
-		outputStr[written] = '\0';
-		return -1; // error
-	}
-
-	OpcodeResult CCustomOpcodeSystem::CleoReturnGeneric(WORD opcode, CRunningScript* thread, bool returnArgs, DWORD returnArgCount, bool strictArgCount)
-	{
-		auto cs = reinterpret_cast<CCustomScript*>(thread);
-
-		ScmFunction* scmFunc = ScmFunction::Get(cs->GetScmFunction());
-		if (scmFunc == nullptr)
-		{
-			SHOW_ERROR("Invalid Cleo Call reference. [%04X] possibly used without preceding [0AB1] in script %s\nScript suspended.", opcode, cs->GetInfoStr().c_str());
-			return thread->Suspend();
-		}
-
-		// store return arguments
-		static SCRIPT_VAR arguments[32];
-		static bool argumentIsStr[32];
-		std::forward_list<std::string> stringParams; // scope guard for strings
-		if (returnArgs)
-		{
-			if (returnArgCount > 32)
-			{
-				SHOW_ERROR("Opcode [%04X] has too many (%d) args in script %s\nScript suspended.", opcode, returnArgCount, cs->GetInfoStr().c_str());
-				return thread->Suspend();
-			}
-
-			auto nVarArg = GetVarArgCount(thread);
-			if (returnArgCount > nVarArg)
-			{
-				SHOW_ERROR("Opcode [%04X] declared %d args, but %d was provided in script %s\nScript suspended.", opcode, returnArgCount, nVarArg, ScriptInfoStr(thread).c_str());
-				return thread->Suspend();
-			}
-
-			for (DWORD i = 0; i < returnArgCount; i++)
-			{
-				SCRIPT_VAR* arg = arguments + i;
-				argumentIsStr[i] = false;
-
-				auto paramType = (eDataType)*thread->GetBytePointer();
-				if (IsImmInteger(paramType) || IsVariable(paramType))
-				{
-					arg->dwParam = CLEO_GetIntOpcodeParam(thread);
-				}
-				else if (paramType == DT_FLOAT)
-				{
-					arg->fParam = CLEO_GetFloatOpcodeParam(thread);
-				}
-				else if (IsImmString(paramType) || IsVarString(paramType))
-				{
-					argumentIsStr[i] = true;
-
-					OPCODE_READ_PARAM_STRING(str);
-					stringParams.emplace_front(str);
-					arg->pcParam = stringParams.front().data();
-				}
-				else
-				{
-					SHOW_ERROR("Invalid argument type '0x%02X' in opcode [%04X] in script %s\nScript suspended.", paramType, opcode, ScriptInfoStr(thread).c_str());
-					return thread->Suspend();
-				}
-			}
-		}
-
-		// handle program flow
-		scmFunc->Return(cs); // jump back to cleo_call, right after last input param. Return slot var args starts here
-		delete scmFunc;
-
-		if (returnArgs)
-		{
-			DWORD returnSlotCount = GetVarArgCount(cs);
-			if (returnSlotCount != returnArgCount)
-			{
-				if (strictArgCount)
-				{
-					SHOW_ERROR_COMPAT("Opcode [%04X] returned %d params, while function caller expected %d in script %s\nScript suspended.", opcode, returnArgCount, returnSlotCount, cs->GetInfoStr().c_str());
-					return cs->Suspend();
-				}
-				else
-				{
-					LOG_WARNING(thread, "Opcode [%04X] returned %d params, while function caller expected %d in script %s", opcode, returnArgCount, returnSlotCount, cs->GetInfoStr().c_str());
-				}
-			}
-
-			// set return args
-			for (DWORD i = 0; i < std::min<DWORD>(returnArgCount, returnSlotCount); i++)
-			{
-				auto arg = (SCRIPT_VAR*)thread->GetBytePointer();
-
-				auto paramType = *(eDataType*)arg;
-				if (IsVarString(paramType))
-				{
-					OPCODE_WRITE_PARAM_STRING(arguments[i].pcParam);
-				} 
-				else if (IsVariable(paramType))
-				{
-					if (argumentIsStr[i]) // source was string, write it into provided buffer ptr
-					{
-						OPCODE_WRITE_PARAM_STRING(arguments[i].pcParam);
-					}
-					else
-						CLEO_SetIntOpcodeParam(thread, arguments[i].dwParam);
-				}
-				else
-				{
-					SHOW_ERROR("Invalid output argument type '0x%02X' in opcode [%04X] in script %s\nScript suspended.", paramType, opcode, ScriptInfoStr(thread).c_str());
-					return thread->Suspend();
-				}
-			}
-		}
-
-		SkipUnusedVarArgs(thread); // skip var args terminator too
-
-		return OR_CONTINUE;
-	}
-
-	void SkipUnusedVarArgs(CRunningScript *thread)
-	{
-		while (thread->PeekDataType() != DT_END)
-			CLEO_SkipOpcodeParams(thread, 1);
-
-		thread->IncPtr(); // skip terminator
-	}
-
-	DWORD GetVarArgCount(CRunningScript* thread)
-	{
-		// store state
-		const auto ip = thread->GetBytePointer();
-		const auto handledParams = CleoInstance.OpcodeSystem.handledParamCount;
-
-		DWORD count = 0;
-		while (thread->PeekDataType() != DT_END)
-		{
-			CLEO_SkipOpcodeParams(thread, 1);
-			count++;
-		}
-
-		// restore state
-		thread->SetIp(ip);
-		CleoInstance.OpcodeSystem.handledParamCount = handledParams;
-
-		return count;
-	}
-
-	/************************************************************************/
-	/*						Opcode definitions								*/
-	/************************************************************************/
-
-	// terminate_this_script
-	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_004E(CRunningScript* thread)
-	{
-		CleoInstance.ScriptEngine.RemoveScript(thread);
-		return OR_INTERRUPT;
-	}
-
-	// GOSUB return
-	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0051(CRunningScript* thread)
-	{
-		if (thread->SP == 0 && !IsLegacyScript(thread)) // CLEO5 - allow use of GOSUB `return` to exit cleo calls too
-		{
-			OPCODE_CONDITION_RESULT(false);
-			return CleoInstance.OpcodeSystem.CleoReturnGeneric(0x0051, thread, false); // try CLEO's function return
-		}
-
-		if (thread->SP == 0)
-		{
-			SHOW_ERROR("`return` used without preceding `gosub` call in script %s\nScript suspended.", ScriptInfoStr(thread).c_str());
-			return thread->Suspend();
-		}
-
-		return CallNativeOpcode(thread, 0x0051); // call game's original
-	}
-
-	// load_and_launch_mission_internal
-	// load_and_launch_mission_internal {index} [int]
-	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0417(CRunningScript* thread)
-	{
-		CleoInstance.ScriptEngine.missionIndex = CLEO_PeekIntOpcodeParam(thread);
-
-		return CallNativeOpcode(thread, 0x0417); // call game's original
-	}
-
-	// stream_custom_script
-	// stream_custom_script {scriptFileName} [string] [arguments]
-	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0A92(CRunningScript *thread)
-	{
-		OPCODE_READ_PARAM_STRING(path);
-
-		auto filename = reinterpret_cast<CCustomScript*>(thread)->ResolvePath(path, DIR_CLEO); // legacy: default search location is game\cleo directory
-		TRACE("[0A92] Starting new custom script %s from thread named '%s'", filename.c_str(), thread->GetName().c_str());
-
-		auto cs = new CCustomScript(filename.c_str(), false, thread);
-		thread->SetConditionResult(cs && cs->IsOk());
-		if (cs && cs->IsOk())
-		{
-			CleoInstance.ScriptEngine.AddCustomScript(cs);
-			((::CRunningScript*)thread)->ReadParametersForNewlyStartedScript((::CRunningScript*)cs);
-		}
-		else
-		{
-			if (cs) delete cs;
-			SkipUnusedVarArgs(thread);
-			LOG_WARNING(0, "Failed to load script '%s' in script ", filename.c_str(), ScriptInfoStr(thread).c_str());
-		}
-
-		return OR_CONTINUE;
-	}
-
-	// terminate_this_custom_script
-	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0A93(CRunningScript *thread)
-	{
-		CCustomScript *cs = reinterpret_cast<CCustomScript *>(thread);
-		if (thread->IsMission() || !cs->IsCustom())
-		{
-			LOG_WARNING(0, "Incorrect usage of opcode [0A93] in script '%s'. Use [004E] instead.", ScriptInfoStr(thread).c_str());
-			return OR_CONTINUE; // legacy behavior
-		}
-
-		CleoInstance.ScriptEngine.RemoveScript(thread);
-		return OR_INTERRUPT;
-	}
-
-	// load_and_launch_custom_mission
-	// load_and_launch_custom_mission {scriptFileName} [string] [arguments]
-	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0A94(CRunningScript *thread)
-	{
-		OPCODE_READ_PARAM_STRING(path);
-
-		auto filename = reinterpret_cast<CCustomScript*>(thread)->ResolvePath(path, DIR_CLEO); // legacy: default search location is game\cleo directory
-		filename += ".cm"; // add custom mission extension
-		TRACE("[0A94] Starting new custom mission '%s' from thread named '%s'", filename.c_str(), thread->GetName().c_str());
-
-		auto cs = new CCustomScript(filename.c_str(), true, thread);
-		thread->SetConditionResult(cs && cs->IsOk());
-		if (cs && cs->IsOk())
-		{
-			CleoInstance.ScriptEngine.AddCustomScript(cs);
-			CTheScripts::WipeLocalVariableMemoryForMissionScript();
-			auto fakeScriptAddress = (BYTE*)missionLocals - offsetof(CRunningScript, LocalVar); // TODO: maybe copy params ourself instead?
-			((::CRunningScript*)thread)->ReadParametersForNewlyStartedScript((::CRunningScript*)fakeScriptAddress);
-		}
-		else
-		{
-			if (cs) delete cs;
-			SkipUnusedVarArgs(thread);
-			LOG_WARNING(0, "[0A94] Failed to load mission '%s' from script '%s'.", filename.c_str(), thread->GetName().c_str());
-		}
-
-		return OR_CONTINUE;
-	}
-
-	// save_this_custom_script
-	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0A95(CRunningScript *thread)
-	{
-		if (thread->IsCustom())
-		{
-			reinterpret_cast<CCustomScript*>(thread)->EnableSaving();
-		}
-		return OR_CONTINUE;
-	}
-
-	// gosub_if_false
-	// gosub_if_false [label]
-	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0AA0(CRunningScript *thread)
-	{
-		auto offset = OPCODE_READ_PARAM_INT();
-
-		if (thread->GetConditionResult()) return OR_CONTINUE;
-
-		thread->PushStack(thread->GetBytePointer());
-		thread->Jump(offset);
-		return OR_CONTINUE;
-	}
-
-	// return_if_false
-	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0AA1(CRunningScript *thread)
-	{
-		if (thread->GetConditionResult()) return OR_CONTINUE;
-
-		if (thread->SP == 0)
-		{
-			SHOW_ERROR("`return_if_false` used without preceding `gosub` call in script %s\nScript suspended.", ScriptInfoStr(thread).c_str());
-			return thread->Suspend();
-		}
-
-		thread->SetIp(thread->PopStack());
-		return OR_CONTINUE;
-	}
-
-	// is_game_version_original
-	// is_game_version_original (logical)
-	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0AA9(CRunningScript *thread)
-	{
-		auto gameVer = CleoInstance.VersionManager.GetGameVersion();
-		auto scriptVer = CLEO_GetScriptVersion(thread);
-
-		bool result = (gameVer == GV_US10) ||
-			(scriptVer <= CLEO_VER_4_MIN && gameVer == GV_EU10);
-
-		OPCODE_CONDITION_RESULT(result);
-		return OR_CONTINUE;
-	}
-
-	// cleo_call
-	// cleo_call [label] {numParams} [int] {params} [arguments]
-	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0AB1(CRunningScript *thread)
-	{
-		int label = 0;
-		std::string moduleTxt;
-
-		auto paramType = thread->PeekDataType();
-		if (IsImmInteger(paramType) || IsVariable(paramType))
-		{
-			label = CLEO_GetIntOpcodeParam(thread); // label offset
-		}
-		else if (IsImmString(paramType) || IsVarString(paramType))
-		{
-			char tmp[MAX_STR_LEN + 1];
-			auto str = ReadStringParam(thread, tmp, sizeof(tmp)); // string with module and export name
-			if (str != nullptr) moduleTxt = str;
-		}
-		else
-		{
-			SHOW_ERROR("Invalid type of first argument in opcode [0AB1], in script %s", ScriptInfoStr(thread).c_str());
-			return thread->Suspend();
-		}
-	
-		ScmFunction* scmFunc = new ScmFunction(thread);
-		
-		// parse module reference text
-		if (!moduleTxt.empty())
-		{
-			auto pos = moduleTxt.find('@');
-			if (pos == moduleTxt.npos)
-			{
-				SHOW_ERROR("Invalid module reference '%s' in opcode [0AB1] in script %s \nScript suspended.", moduleTxt.c_str(), ScriptInfoStr(thread).c_str());
-				return thread->Suspend();
-			}
-			auto strExport = std::string_view(moduleTxt.data(), pos);
-			auto strModule = std::string_view(moduleTxt.data() + pos + 1);
-
-			// get module's file absolute path
-			auto modulePath = std::string(strModule);
-			modulePath = reinterpret_cast<CCustomScript*>(thread)->ResolvePath(modulePath.c_str(), DIR_SCRIPT); // by default search relative to current script location
-
-			// get export reference
-			auto scriptRef = CleoInstance.ModuleSystem.GetExport(modulePath, strExport);
-			if (!scriptRef.Valid())
-			{
-				SHOW_ERROR("Not found module '%s' export '%s', requested by opcode [0AB1] in script %s", modulePath.c_str(), moduleTxt.c_str(), ScriptInfoStr(thread).c_str());
-				return thread->Suspend();
-			}
-
-			auto cs = reinterpret_cast<CCustomScript*>(thread);
-			cs->SetScriptFileDir(FS::path(modulePath).parent_path().string().c_str());
-			cs->SetScriptFileName(FS::path(modulePath).filename().string().c_str());
-			cs->SetBaseIp(scriptRef.base);
-			if (cs->IsCustom()) cs->SetCodeSize(scriptRef.size);
-			label = scriptRef.offset;
-		}
-
-		// "number of input parameters" opcode argument
-		DWORD nParams = 0;
-		paramType = thread->PeekDataType();
-		if (paramType != DT_END)
-		{
-			if (IsImmInteger(paramType))
-			{
-				nParams = CLEO_GetIntOpcodeParam(thread);
-			}
-			else
-			{
-				SHOW_ERROR("Invalid type (%s) of the 'input param count' argument in opcode [0AB1] in script %s \nScript suspended.", ToKindStr(paramType), ScriptInfoStr(thread).c_str());
-				return thread->Suspend();
-			}
-		}
-		if (nParams)
-		{
-			auto nVarArg = GetVarArgCount(thread);
-			if (nParams > nVarArg) // if less it means there are return params too
-			{
-				SHOW_ERROR("Opcode [0AB1] declared %d input args, but provided %d in script %s\nScript suspended.", nParams, nVarArg, ScriptInfoStr(thread).c_str());
-				return thread->Suspend();
-			}
-
-			if (nParams > 32)
-			{
-				SHOW_ERROR("Argument count %d is out of supported range (32) of opcode [0AB1] in script %s", nParams, ScriptInfoStr(thread).c_str());
-				return thread->Suspend();
-			}
-		}
-		scmFunc->callArgCount = (BYTE)nParams;
-
-		static SCRIPT_VAR arguments[32];
-		SCRIPT_VAR* locals = thread->IsMission() ? missionLocals : thread->GetVarPtr();
-		SCRIPT_VAR* localsEnd = locals + 32;
-		SCRIPT_VAR* storedLocals = scmFunc->savedTls;
-
-		// collect arguments
-		for (DWORD i = 0; i < nParams; i++)
-		{
-			SCRIPT_VAR* arg = arguments + i;
-
-			auto paramType = thread->PeekDataType();
-			if (IsImmInteger(paramType) || IsVariable(paramType))
-			{
-				arg->dwParam = CLEO_GetIntOpcodeParam(thread);
-
-			}
-			else if(paramType == DT_FLOAT)
-			{
-				arg->fParam = CLEO_GetFloatOpcodeParam(thread);
-			}
-			else if (IsImmString(paramType) || IsVarString(paramType))
-			{
-				// imm string texts exists in script code, but without terminator character.
-				// For strings stored in variables there is no guarantee these will end with terminator.
-				// In both cases copy is necessary to create proper c-string
-				char tmp[MAX_STR_LEN + 1];
-				auto str = ReadStringParam(thread, tmp, sizeof(tmp));
-				scmFunc->stringParams.emplace_back(str);
-				arg->pcParam = (char*)scmFunc->stringParams.back().c_str();
-			}
-			else
-			{
-				SHOW_ERROR("Invalid argument type '0x%02X' in opcode [0AB1] in script %s\nScript suspended.", paramType, ScriptInfoStr(thread).c_str());
-				return thread->Suspend();
-			}
-		}
-
-		// all arguments read
-		scmFunc->retnAddress = thread->GetBytePointer();
-
-		// pass arguments as new scope local variables
-		memcpy(locals, arguments, nParams * sizeof(SCRIPT_VAR));
-
-		// initialize (clear) rest of new scope local variables
-		if (CLEO_GetScriptVersion(thread) >= CLEO_VER_4_MIN) // CLEO 3 did not cleared local variables
-		{
-			for (DWORD i = nParams; i < 32; i++)
-			{
-				thread->SetIntVar(i, 0); // fill with zeros
-			}
-		}
-
-		// jump to label
-		thread->Jump(label);
-		return OR_CONTINUE;
-	}
-
-	// cleo_return
-	// cleo_return {numRet} [int] {retParams} [arguments]
-	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0AB2(CRunningScript *thread)
-	{
-		auto returnParamCount = OPCODE_PEEK_VARARG_COUNT();
-		if (returnParamCount)
-		{
-			auto paramType = thread->PeekDataType();
-			if (!IsImmInteger(paramType))
-			{
-				SHOW_ERROR("Invalid type of first argument in opcode [0AB2], in script %s", ScriptInfoStr(thread).c_str());
-				return thread->Suspend();
-			}
-			DWORD declaredParamCount = CLEO_GetIntOpcodeParam(thread);
-
-			if (returnParamCount - 1 < declaredParamCount) // minus 'num args' itself
-			{
-				SHOW_ERROR("Opcode [0AB2] declared %d return args, but provided %d in script %s\nScript suspended.", declaredParamCount, returnParamCount - 1, ScriptInfoStr(thread).c_str());
-				return thread->Suspend();
-			}
-			else if (returnParamCount - 1 > declaredParamCount) // more args than needed, not critical
-			{
-				LOG_WARNING(thread, "Opcode [0AB2] declared %d return args, but provided %d in script %s", declaredParamCount, returnParamCount - 1, ScriptInfoStr(thread).c_str());
-			}
-
-			returnParamCount = declaredParamCount;
-		}
-
-		return CleoInstance.OpcodeSystem.CleoReturnGeneric(0x0AB2, thread, true, returnParamCount, !IsLegacyScript(thread));
-	}
-
-	// set_cleo_shared_var
-	// set_cleo_shared_var {index} [int] {value} [any]
-	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0AB3(CRunningScript *thread)
-	{
-		auto varIdx = OPCODE_READ_PARAM_INT();
-
-		const auto VarCount = _countof(CScriptEngine::CleoVariables);
-		if (varIdx < 0 || varIdx >= VarCount)
-		{
-			SHOW_ERROR("Variable index '%d' out of supported range in script %s\nScript suspended.", varIdx, ScriptInfoStr(thread).c_str());
-			return thread->Suspend();
-		}
-
-		CleoInstance.ScriptEngine.CleoVariables[varIdx] = OPCODE_READ_PARAM_ANY32();
-		return OR_CONTINUE;
-	}
-
-	// get_cleo_shared_var
-	// [var result: any] = get_cleo_shared_var {index} [int]
-	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0AB4(CRunningScript *thread)
-	{
-		auto varIdx = OPCODE_READ_PARAM_INT();
-
-		const auto VarCount = _countof(CScriptEngine::CleoVariables);
-		if (varIdx < 0 || varIdx >= VarCount)
-		{
-			SHOW_ERROR("Variable index '%d' out of supported range in script %s\nScript suspended.", varIdx, ScriptInfoStr(thread).c_str());
-			return thread->Suspend();
-		}
-
-		OPCODE_WRITE_PARAM_ANY32(CleoInstance.ScriptEngine.CleoVariables[varIdx]);
-		return OR_CONTINUE;
-	}
-
-	// get_platform
-	// [var platform: Platform] = get_platform
-	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0DD5(CRunningScript* thread)
-	{
-		OPCODE_WRITE_PARAM_INT(PLATFORM_WINDOWS);
-		return OR_CONTINUE;
-	}
-
-	// get_cleo_arg_count
-	// [var count: int] = get_cleo_arg_count
-	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_2000(CRunningScript* thread)
-	{
-		auto cs = reinterpret_cast<CCustomScript*>(thread);
-
-		ScmFunction* scmFunc = ScmFunction::Get(cs->GetScmFunction());
-		if (scmFunc == nullptr)
-		{
-			SHOW_ERROR("Quering argument count without preceding CLEO function call in script %s\nScript suspended.", cs->GetInfoStr().c_str());
-			return thread->Suspend();
-		}
-
-		OPCODE_WRITE_PARAM_INT(scmFunc->callArgCount);
-		return OR_CONTINUE;
-	}
-
-	// cleo_return_with
-	// cleo_return_with {conditionResult} [bool] {retArgs} [arguments] (logical)
-	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_2002(CRunningScript* thread)
-	{
-		auto argCount = OPCODE_PEEK_VARARG_COUNT();
-		if (argCount < 1)
-		{
-			SHOW_ERROR("Opcode [2002] missing condition result argument in script %s\nScript suspended.", ScriptInfoStr(thread).c_str());
-			return thread->Suspend();
-		}
-
-		auto result = OPCODE_READ_PARAM_BOOL();
-		argCount--;
-
-		OPCODE_CONDITION_RESULT(result);
-		return CleoInstance.OpcodeSystem.CleoReturnGeneric(0x2002, thread, true, argCount);
-	}
-
-	// cleo_return_fail
-	// cleo_return_fail [arguments] (logical)
-	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_2003(CRunningScript* thread)
-	{
-		auto argCount = OPCODE_PEEK_VARARG_COUNT();
-		if (argCount != 0) // argument(s) not supported yet
-		{
-			SHOW_ERROR("Too many arguments of opcode [2003] in script %s\nScript suspended.", ScriptInfoStr(thread).c_str());
-			return thread->Suspend();
-		}
-
-		OPCODE_CONDITION_RESULT(false);
-		return CleoInstance.OpcodeSystem.CleoReturnGeneric(0x2003, thread);
-	}
+  }
+  return result;
 }
+
+OpcodeResult CCustomOpcodeSystem::CallNativeOpcode(CRunningScript *thread,
+                                                   WORD opcode) {
+  if (opcode > Opcode_Max_Native) {
+    return OR_ERROR;
+  }
+
+  size_t tableIdx = opcode / Opcode_Table_Size;
+  return _CallNativeOpcode(thread, originalOpcodeHandlers[tableIdx], opcode);
+}
+
+const char *ReadStringParam(CRunningScript *thread, char *buff, int buffSize) {
+  if (buffSize > 0)
+    buff[buffSize - 1] = '\0'; // buffer always terminated
+  return GetScriptStringParam(thread, 0, buff,
+                              buffSize - 1); // minus terminator
+}
+
+// write output\result string parameter
+bool WriteStringParam(CRunningScript *thread, const char *str) {
+  auto target = GetStringParamWriteBuffer(thread);
+  return WriteStringParam(target, str);
+}
+
+bool WriteStringParam(const StringParamBufferInfo &target, const char *str) {
+  CCustomOpcodeSystem::lastErrorMsg.clear();
+
+  if (str != nullptr && (size_t)str <= MinValidAddress) {
+    CCustomOpcodeSystem::lastErrorMsg =
+        StringPrintf("Writing string from invalid '0x%X' pointer", target.data);
+    return false;
+  }
+
+  if ((size_t)target.data <= MinValidAddress) {
+    CCustomOpcodeSystem::lastErrorMsg = StringPrintf(
+        "Writing string into invalid '0x%X' pointer argument", target.data);
+    return false;
+  }
+
+  if (target.size == 0) {
+    return false;
+  }
+
+  bool addTerminator = target.needTerminator;
+  size_t buffLen = target.size - addTerminator;
+  size_t length = str == nullptr ? 0 : strlen(str);
+
+  if (buffLen > length)
+    addTerminator = true; // there is space left for terminator
+
+  length = std::min(length, buffLen);
+  if (length > 0)
+    std::memcpy(target.data, str, length);
+  if (addTerminator)
+    target.data[length] = '\0';
+
+  return true;
+}
+
+StringParamBufferInfo GetStringParamWriteBuffer(CRunningScript *thread) {
+  StringParamBufferInfo result;
+  CCustomOpcodeSystem::lastErrorMsg.clear();
+
+  auto paramType = thread->PeekDataType();
+  if (IsImmInteger(paramType) || IsVariable(paramType)) {
+    // address to output buffer
+    CScriptEngine::GetScriptParams(thread, 1);
+
+    if (opcodeParams[0].dwParam <= MinValidAddress) {
+      CCustomOpcodeSystem::lastErrorMsg =
+          StringPrintf("Writing string into invalid '0x%X' pointer argument",
+                       opcodeParams[0].dwParam);
+      return result; // error
+    }
+
+    result.data = opcodeParams[0].pcParam;
+    result.size = 0x7FFFFFFF; // user allocated memory block can be any size
+    result.needTerminator = true;
+
+    return result;
+  } else if (IsVarString(paramType)) {
+    switch (paramType) {
+    // short string variable
+    case DT_VAR_TEXTLABEL:
+    case DT_LVAR_TEXTLABEL:
+    case DT_VAR_TEXTLABEL_ARRAY:
+    case DT_LVAR_TEXTLABEL_ARRAY:
+      result.data = (char *)CScriptEngine::GetScriptParamPointer(thread);
+      result.size = 8;
+      result.needTerminator = false;
+      return result;
+
+    // long string variable
+    case DT_VAR_STRING:
+    case DT_LVAR_STRING:
+    case DT_VAR_STRING_ARRAY:
+    case DT_LVAR_STRING_ARRAY:
+      result.data = (char *)CScriptEngine::GetScriptParamPointer(thread);
+      result.size = 16;
+      result.needTerminator = false;
+      return result;
+    }
+  }
+
+  CCustomOpcodeSystem::lastErrorMsg =
+      StringPrintf("Writing string, got argument %s", ToKindStr(paramType));
+  CLEO_SkipOpcodeParams(thread, 1); // skip unhandled param
+  return result;                    // error
+}
+
+// perform 'sprintf'-operation for parameters, passed through SCM
+int ReadFormattedString(CRunningScript *thread, char *outputStr, DWORD len,
+                        const char *format) {
+  unsigned int written = 0;
+  const char *iter = format;
+  char *outIter = outputStr;
+  char bufa[MAX_STR_LEN + 1], fmtbufa[64], *fmta;
+
+  // invalid input arguments
+  if (outputStr == nullptr || len == 0) {
+    LOG_WARNING(thread, "ReadFormattedString invalid input arg(s) in script %s",
+                ScriptInfoStr(thread).c_str());
+    SkipUnusedVarArgs(thread);
+    return -1; // error
+  }
+
+  if (len > 1 && format != nullptr) {
+    while (*iter) {
+      while (*iter && *iter != '%') {
+        if (written++ >= len)
+          goto _ReadFormattedString_OutOfMemory;
+        *outIter++ = *iter++;
+      }
+
+      if (*iter == '%') {
+        // end of format string
+        if (iter[1] == '\0') {
+          LOG_WARNING(thread,
+                      "ReadFormattedString encountered incomplete format "
+                      "specifier in script %s",
+                      ScriptInfoStr(thread).c_str());
+          SkipUnusedVarArgs(thread);
+          return -1; // error
+        }
+
+        // escaped % character
+        if (iter[1] == '%') {
+          if (written++ >= len)
+            goto _ReadFormattedString_OutOfMemory;
+          *outIter++ = '%';
+          iter += 2;
+          continue;
+        }
+
+        // get flags and width specifier
+        fmta = fmtbufa;
+        *fmta++ = *iter++;
+        while (*iter == '0' || *iter == '+' || *iter == '-' || *iter == ' ' ||
+               *iter == '*' || *iter == '#') {
+          if (*iter == '*') {
+            // get width
+            if (thread->PeekDataType() == DT_END)
+              goto _ReadFormattedString_ArgMissing;
+            CScriptEngine::GetScriptParams(thread, 1);
+            _itoa_s(opcodeParams[0].dwParam, bufa, 10);
+
+            char *buffiter = bufa;
+            while (*buffiter)
+              *fmta++ = *buffiter++;
+          } else
+            *fmta++ = *iter;
+          iter++;
+        }
+
+        // get immidiate width value
+        while (isdigit(*iter))
+          *fmta++ = *iter++;
+
+        // get precision
+        if (*iter == '.') {
+          *fmta++ = *iter++;
+          if (*iter == '*') {
+            if (thread->PeekDataType() == DT_END)
+              goto _ReadFormattedString_ArgMissing;
+            CScriptEngine::GetScriptParams(thread, 1);
+            _itoa_s(opcodeParams[0].dwParam, bufa, 10);
+
+            char *buffiter = bufa;
+            while (*buffiter)
+              *fmta++ = *buffiter++;
+          } else
+            while (isdigit(*iter))
+              *fmta++ = *iter++;
+        }
+        // get size
+        if (*iter == 'h' || *iter == 'l')
+          *fmta++ = *iter++;
+
+        switch (*iter) {
+        case 's': {
+          if (thread->PeekDataType() == DT_END)
+            goto _ReadFormattedString_ArgMissing;
+
+          const char *str = ReadStringParam(thread, bufa, sizeof(bufa));
+          if (str == nullptr) // read error
+          {
+            static const char none[] = "(INVALID_STR)";
+            str = none;
+          }
+
+          while (*str) {
+            if (written++ >= len)
+              goto _ReadFormattedString_OutOfMemory;
+            *outIter++ = *str++;
+          }
+          iter++;
+          break;
+        }
+
+        case 'c':
+          if (written++ >= len)
+            goto _ReadFormattedString_OutOfMemory;
+          if (thread->PeekDataType() == DT_END)
+            goto _ReadFormattedString_ArgMissing;
+          CScriptEngine::GetScriptParams(thread, 1);
+          *outIter++ = (char)opcodeParams[0].nParam;
+          iter++;
+          break;
+
+        default: {
+          /* For non wc types, use system sprintf and append to wide char output
+           */
+          /* FIXME: for unrecognised types, should ignore % when printing */
+          if (*iter == 'p' || *iter == 'P') {
+            if (thread->PeekDataType() == DT_END)
+              goto _ReadFormattedString_ArgMissing;
+            CScriptEngine::GetScriptParams(thread, 1);
+            sprintf_s(bufa, "%08X", opcodeParams[0].dwParam);
+          } else {
+            *fmta++ = *iter;
+            *fmta = '\0';
+            if (*iter == 'a' || *iter == 'A' || *iter == 'e' || *iter == 'E' ||
+                *iter == 'f' || *iter == 'F' || *iter == 'g' || *iter == 'G') {
+              if (thread->PeekDataType() == DT_END)
+                goto _ReadFormattedString_ArgMissing;
+              CScriptEngine::GetScriptParams(thread, 1);
+              sprintf_s(bufa, fmtbufa, opcodeParams[0].fParam);
+            } else {
+              if (thread->PeekDataType() == DT_END)
+                goto _ReadFormattedString_ArgMissing;
+              CScriptEngine::GetScriptParams(thread, 1);
+              sprintf_s(bufa, fmtbufa, opcodeParams[0].pParam);
+            }
+          }
+          char *bufaiter = bufa;
+          while (*bufaiter) {
+            if (written++ >= len)
+              goto _ReadFormattedString_OutOfMemory;
+            *outIter++ = *bufaiter++;
+          }
+          iter++;
+          break;
+        }
+        }
+      }
+    }
+  }
+
+  if (written >= len) {
+  _ReadFormattedString_OutOfMemory: // jump here on error
+
+    LOG_WARNING(thread,
+                "Target buffer too small (%d) to read whole formatted string "
+                "in script %s",
+                len, ScriptInfoStr(thread).c_str());
+    SkipUnusedVarArgs(thread);
+    outputStr[len - 1] = '\0';
+    return -1; // error
+  }
+
+  // still more var-args available
+  if (thread->PeekDataType() != DT_END) {
+    LOG_WARNING(thread,
+                "More arguments than tokens in format string in script %s",
+                ScriptInfoStr(thread).c_str());
+  }
+  SkipUnusedVarArgs(thread); // skip terminator too
+
+  outputStr[written] = '\0';
+  return (int)written;
+
+_ReadFormattedString_ArgMissing: // jump here on error
+  LOG_WARNING(thread,
+              "More tokens in format string than arguments in script %s",
+              ScriptInfoStr(thread).c_str());
+  thread->IncPtr(); // skip vararg terminator
+  outputStr[written] = '\0';
+  return -1; // error
+}
+
+OpcodeResult CCustomOpcodeSystem::CleoReturnGeneric(WORD opcode,
+                                                    CRunningScript *thread,
+                                                    bool returnArgs,
+                                                    DWORD returnArgCount,
+                                                    bool strictArgCount) {
+  auto cs = reinterpret_cast<CCustomScript *>(thread);
+
+  ScmFunction *scmFunc = ScmFunction::Get(cs->GetScmFunction());
+  if (scmFunc == nullptr) {
+    SHOW_ERROR("Invalid Cleo Call reference. [%04X] possibly used without "
+               "preceding [0AB1] in script %s\nScript suspended.",
+               opcode, cs->GetInfoStr().c_str());
+    return thread->Suspend();
+  }
+
+  // store return arguments
+  static SCRIPT_VAR arguments[32];
+  static bool argumentIsStr[32];
+  std::forward_list<std::string> stringParams; // scope guard for strings
+  if (returnArgs) {
+    if (returnArgCount > 32) {
+      SHOW_ERROR("Opcode [%04X] has too many (%d) args in script %s\nScript "
+                 "suspended.",
+                 opcode, returnArgCount, cs->GetInfoStr().c_str());
+      return thread->Suspend();
+    }
+
+    auto nVarArg = GetVarArgCount(thread);
+    if (returnArgCount > nVarArg) {
+      SHOW_ERROR("Opcode [%04X] declared %d args, but %d was provided in "
+                 "script %s\nScript suspended.",
+                 opcode, returnArgCount, nVarArg,
+                 ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
+    }
+
+    for (DWORD i = 0; i < returnArgCount; i++) {
+      SCRIPT_VAR *arg = arguments + i;
+      argumentIsStr[i] = false;
+
+      auto paramType = (eDataType)*thread->GetBytePointer();
+      if (IsImmInteger(paramType) || IsVariable(paramType)) {
+        arg->dwParam = CLEO_GetIntOpcodeParam(thread);
+      } else if (paramType == DT_FLOAT) {
+        arg->fParam = CLEO_GetFloatOpcodeParam(thread);
+      } else if (IsImmString(paramType) || IsVarString(paramType)) {
+        argumentIsStr[i] = true;
+
+        OPCODE_READ_PARAM_STRING(str);
+        stringParams.emplace_front(str);
+        arg->pcParam = stringParams.front().data();
+      } else {
+        SHOW_ERROR("Invalid argument type '0x%02X' in opcode [%04X] in script "
+                   "%s\nScript suspended.",
+                   paramType, opcode, ScriptInfoStr(thread).c_str());
+        return thread->Suspend();
+      }
+    }
+  }
+
+  // handle program flow
+  scmFunc->Return(cs); // jump back to cleo_call, right after last input param.
+                       // Return slot var args starts here
+  delete scmFunc;
+
+  if (returnArgs) {
+    DWORD returnSlotCount = GetVarArgCount(cs);
+    if (returnSlotCount != returnArgCount) {
+      if (strictArgCount) {
+        SHOW_ERROR_COMPAT("Opcode [%04X] returned %d params, while function "
+                          "caller expected %d in script %s\nScript suspended.",
+                          opcode, returnArgCount, returnSlotCount,
+                          cs->GetInfoStr().c_str());
+        return cs->Suspend();
+      } else {
+        LOG_WARNING(thread,
+                    "Opcode [%04X] returned %d params, while function caller "
+                    "expected %d in script %s",
+                    opcode, returnArgCount, returnSlotCount,
+                    cs->GetInfoStr().c_str());
+      }
+    }
+
+    // set return args
+    for (DWORD i = 0; i < std::min<DWORD>(returnArgCount, returnSlotCount);
+         i++) {
+      auto arg = (SCRIPT_VAR *)thread->GetBytePointer();
+
+      auto paramType = *(eDataType *)arg;
+      if (IsVarString(paramType)) {
+        OPCODE_WRITE_PARAM_STRING(arguments[i].pcParam);
+      } else if (IsVariable(paramType)) {
+        if (argumentIsStr[i]) // source was string, write it into provided
+                              // buffer ptr
+        {
+          OPCODE_WRITE_PARAM_STRING(arguments[i].pcParam);
+        } else
+          CLEO_SetIntOpcodeParam(thread, arguments[i].dwParam);
+      } else {
+        SHOW_ERROR("Invalid output argument type '0x%02X' in opcode [%04X] in "
+                   "script %s\nScript suspended.",
+                   paramType, opcode, ScriptInfoStr(thread).c_str());
+        return thread->Suspend();
+      }
+    }
+  }
+
+  SkipUnusedVarArgs(thread); // skip var args terminator too
+
+  return OR_CONTINUE;
+}
+
+void SkipUnusedVarArgs(CRunningScript *thread) {
+  while (thread->PeekDataType() != DT_END)
+    CLEO_SkipOpcodeParams(thread, 1);
+
+  thread->IncPtr(); // skip terminator
+}
+
+DWORD GetVarArgCount(CRunningScript *thread) {
+  // store state
+  const auto ip = thread->GetBytePointer();
+  const auto handledParams = CleoInstance.OpcodeSystem.handledParamCount;
+
+  DWORD count = 0;
+  while (thread->PeekDataType() != DT_END) {
+    CLEO_SkipOpcodeParams(thread, 1);
+    count++;
+  }
+
+  // restore state
+  thread->SetIp(ip);
+  CleoInstance.OpcodeSystem.handledParamCount = handledParams;
+
+  return count;
+}
+
+/************************************************************************/
+/*						Opcode definitions
+ */
+/************************************************************************/
+
+// terminate_this_script
+OpcodeResult __stdcall CCustomOpcodeSystem::opcode_004E(
+    CRunningScript *thread) {
+  CleoInstance.ScriptEngine.RemoveScript(thread);
+  return OR_INTERRUPT;
+}
+
+// GOSUB return
+OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0051(
+    CRunningScript *thread) {
+  if (thread->SP == 0 &&
+      !IsLegacyScript(
+          thread)) // CLEO5 - allow use of GOSUB `return` to exit cleo calls too
+  {
+    OPCODE_CONDITION_RESULT(false);
+    return CleoInstance.OpcodeSystem.CleoReturnGeneric(
+        0x0051, thread, false); // try CLEO's function return
+  }
+
+  if (thread->SP == 0) {
+    SHOW_ERROR("`return` used without preceding `gosub` call in script "
+               "%s\nScript suspended.",
+               ScriptInfoStr(thread).c_str());
+    return thread->Suspend();
+  }
+
+  return CallNativeOpcode(thread, 0x0051); // call game's original
+}
+
+// load_and_launch_mission_internal
+// load_and_launch_mission_internal {index} [int]
+OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0417(
+    CRunningScript *thread) {
+  CleoInstance.ScriptEngine.missionIndex = CLEO_PeekIntOpcodeParam(thread);
+
+  return CallNativeOpcode(thread, 0x0417); // call game's original
+}
+
+// stream_custom_script
+// stream_custom_script {scriptFileName} [string] [arguments]
+OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0A92(
+    CRunningScript *thread) {
+  OPCODE_READ_PARAM_STRING(path);
+
+  auto filename = reinterpret_cast<CCustomScript *>(thread)->ResolvePath(
+      path, DIR_CLEO); // legacy: default search location is game\cleo directory
+  TRACE("[0A92] Starting new custom script %s from thread named '%s'",
+        filename.c_str(), thread->GetName().c_str());
+
+  auto cs = new CCustomScript(filename.c_str(), false, thread);
+  thread->SetConditionResult(cs && cs->IsOk());
+  if (cs && cs->IsOk()) {
+    CleoInstance.ScriptEngine.AddCustomScript(cs);
+    ((::CRunningScript *)thread)
+        ->ReadParametersForNewlyStartedScript((::CRunningScript *)cs);
+  } else {
+    if (cs)
+      delete cs;
+    SkipUnusedVarArgs(thread);
+    LOG_WARNING(0, "Failed to load script '%s' in script ", filename.c_str(),
+                ScriptInfoStr(thread).c_str());
+  }
+
+  return OR_CONTINUE;
+}
+
+// terminate_this_custom_script
+OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0A93(
+    CRunningScript *thread) {
+  CCustomScript *cs = reinterpret_cast<CCustomScript *>(thread);
+  if (thread->IsMission() || !cs->IsCustom()) {
+    LOG_WARNING(
+        0,
+        "Incorrect usage of opcode [0A93] in script '%s'. Use [004E] instead.",
+        ScriptInfoStr(thread).c_str());
+    return OR_CONTINUE; // legacy behavior
+  }
+
+  CleoInstance.ScriptEngine.RemoveScript(thread);
+  return OR_INTERRUPT;
+}
+
+// load_and_launch_custom_mission
+// load_and_launch_custom_mission {scriptFileName} [string] [arguments]
+OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0A94(
+    CRunningScript *thread) {
+  OPCODE_READ_PARAM_STRING(path);
+
+  auto filename = reinterpret_cast<CCustomScript *>(thread)->ResolvePath(
+      path, DIR_CLEO); // legacy: default search location is game\cleo directory
+  filename += ".cm";   // add custom mission extension
+  TRACE("[0A94] Starting new custom mission '%s' from thread named '%s'",
+        filename.c_str(), thread->GetName().c_str());
+
+  auto cs = new CCustomScript(filename.c_str(), true, thread);
+  thread->SetConditionResult(cs && cs->IsOk());
+  if (cs && cs->IsOk()) {
+    CleoInstance.ScriptEngine.AddCustomScript(cs);
+    CTheScripts::WipeLocalVariableMemoryForMissionScript();
+    auto fakeScriptAddress =
+        (BYTE *)missionLocals -
+        offsetof(CRunningScript,
+                 LocalVar); // TODO: maybe copy params ourself instead?
+    ((::CRunningScript *)thread)
+        ->ReadParametersForNewlyStartedScript(
+            (::CRunningScript *)fakeScriptAddress);
+  } else {
+    if (cs)
+      delete cs;
+    SkipUnusedVarArgs(thread);
+    LOG_WARNING(0, "[0A94] Failed to load mission '%s' from script '%s'.",
+                filename.c_str(), thread->GetName().c_str());
+  }
+
+  return OR_CONTINUE;
+}
+
+// save_this_custom_script
+OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0A95(
+    CRunningScript *thread) {
+  if (thread->IsCustom()) {
+    reinterpret_cast<CCustomScript *>(thread)->EnableSaving();
+  }
+  return OR_CONTINUE;
+}
+
+// gosub_if_false
+// gosub_if_false [label]
+OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0AA0(
+    CRunningScript *thread) {
+  auto offset = OPCODE_READ_PARAM_INT();
+
+  if (thread->GetConditionResult())
+    return OR_CONTINUE;
+
+  thread->PushStack(thread->GetBytePointer());
+  thread->Jump(offset);
+  return OR_CONTINUE;
+}
+
+// return_if_false
+OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0AA1(
+    CRunningScript *thread) {
+  if (thread->GetConditionResult())
+    return OR_CONTINUE;
+
+  if (thread->SP == 0) {
+    SHOW_ERROR("`return_if_false` used without preceding `gosub` call in "
+               "script %s\nScript suspended.",
+               ScriptInfoStr(thread).c_str());
+    return thread->Suspend();
+  }
+
+  thread->SetIp(thread->PopStack());
+  return OR_CONTINUE;
+}
+
+// is_game_version_original
+// is_game_version_original (logical)
+OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0AA9(
+    CRunningScript *thread) {
+  auto gameVer = CleoInstance.VersionManager.GetGameVersion();
+  auto scriptVer = CLEO_GetScriptVersion(thread);
+
+  bool result = (gameVer == GV_US10) ||
+                (scriptVer <= CLEO_VER_4_MIN && gameVer == GV_EU10);
+
+  OPCODE_CONDITION_RESULT(result);
+  return OR_CONTINUE;
+}
+
+// cleo_call
+// cleo_call [label] {numParams} [int] {params} [arguments]
+OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0AB1(
+    CRunningScript *thread) {
+  int label = 0;
+  std::string moduleTxt;
+
+  auto paramType = thread->PeekDataType();
+  if (IsImmInteger(paramType) || IsVariable(paramType)) {
+    label = CLEO_GetIntOpcodeParam(thread); // label offset
+  } else if (IsImmString(paramType) || IsVarString(paramType)) {
+    char tmp[MAX_STR_LEN + 1];
+    auto str = ReadStringParam(
+        thread, tmp, sizeof(tmp)); // string with module and export name
+    if (str != nullptr)
+      moduleTxt = str;
+  } else {
+    SHOW_ERROR("Invalid type of first argument in opcode [0AB1], in script %s",
+               ScriptInfoStr(thread).c_str());
+    return thread->Suspend();
+  }
+
+  ScmFunction *scmFunc = new ScmFunction(thread);
+
+  // parse module reference text
+  if (!moduleTxt.empty()) {
+    auto pos = moduleTxt.find('@');
+    if (pos == moduleTxt.npos) {
+      SHOW_ERROR("Invalid module reference '%s' in opcode [0AB1] in script %s "
+                 "\nScript suspended.",
+                 moduleTxt.c_str(), ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
+    }
+    auto strExport = std::string_view(moduleTxt.data(), pos);
+    auto strModule = std::string_view(moduleTxt.data() + pos + 1);
+
+    // get module's file absolute path
+    auto modulePath = std::string(strModule);
+    modulePath = reinterpret_cast<CCustomScript *>(thread)->ResolvePath(
+        modulePath.c_str(),
+        DIR_SCRIPT); // by default search relative to current script location
+
+    // get export reference
+    auto scriptRef = CleoInstance.ModuleSystem.GetExport(modulePath, strExport);
+    if (!scriptRef.Valid()) {
+      SHOW_ERROR("Not found module '%s' export '%s', requested by opcode "
+                 "[0AB1] in script %s",
+                 modulePath.c_str(), moduleTxt.c_str(),
+                 ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
+    }
+
+    auto cs = reinterpret_cast<CCustomScript *>(thread);
+    cs->SetScriptFileDir(FS::path(modulePath).parent_path().string().c_str());
+    cs->SetScriptFileName(FS::path(modulePath).filename().string().c_str());
+    cs->SetBaseIp(scriptRef.base);
+    if (cs->IsCustom())
+      cs->SetCodeSize(scriptRef.size);
+    label = scriptRef.offset;
+  }
+
+  // "number of input parameters" opcode argument
+  DWORD nParams = 0;
+  paramType = thread->PeekDataType();
+  if (paramType != DT_END) {
+    if (IsImmInteger(paramType)) {
+      nParams = CLEO_GetIntOpcodeParam(thread);
+    } else {
+      SHOW_ERROR("Invalid type (%s) of the 'input param count' argument in "
+                 "opcode [0AB1] in script %s \nScript suspended.",
+                 ToKindStr(paramType), ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
+    }
+  }
+  if (nParams) {
+    auto nVarArg = GetVarArgCount(thread);
+    if (nParams > nVarArg) // if less it means there are return params too
+    {
+      SHOW_ERROR("Opcode [0AB1] declared %d input args, but provided %d in "
+                 "script %s\nScript suspended.",
+                 nParams, nVarArg, ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
+    }
+
+    if (nParams > 32) {
+      SHOW_ERROR("Argument count %d is out of supported range (32) of opcode "
+                 "[0AB1] in script %s",
+                 nParams, ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
+    }
+  }
+  scmFunc->callArgCount = (BYTE)nParams;
+
+  static SCRIPT_VAR arguments[32];
+  SCRIPT_VAR *locals =
+      thread->IsMission() ? missionLocals : thread->GetVarPtr();
+  SCRIPT_VAR *localsEnd = locals + 32;
+  SCRIPT_VAR *storedLocals = scmFunc->savedTls;
+
+  // collect arguments
+  for (DWORD i = 0; i < nParams; i++) {
+    SCRIPT_VAR *arg = arguments + i;
+
+    auto paramType = thread->PeekDataType();
+    if (IsImmInteger(paramType) || IsVariable(paramType)) {
+      arg->dwParam = CLEO_GetIntOpcodeParam(thread);
+
+    } else if (paramType == DT_FLOAT) {
+      arg->fParam = CLEO_GetFloatOpcodeParam(thread);
+    } else if (IsImmString(paramType) || IsVarString(paramType)) {
+      // imm string texts exists in script code, but without terminator
+      // character. For strings stored in variables there is no guarantee these
+      // will end with terminator. In both cases copy is necessary to create
+      // proper c-string
+      char tmp[MAX_STR_LEN + 1];
+      auto str = ReadStringParam(thread, tmp, sizeof(tmp));
+      scmFunc->stringParams.emplace_back(str);
+      arg->pcParam = (char *)scmFunc->stringParams.back().c_str();
+    } else {
+      SHOW_ERROR("Invalid argument type '0x%02X' in opcode [0AB1] in script "
+                 "%s\nScript suspended.",
+                 paramType, ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
+    }
+  }
+
+  // all arguments read
+  scmFunc->retnAddress = thread->GetBytePointer();
+
+  // pass arguments as new scope local variables
+  memcpy(locals, arguments, nParams * sizeof(SCRIPT_VAR));
+
+  // initialize (clear) rest of new scope local variables
+  if (CLEO_GetScriptVersion(thread) >=
+      CLEO_VER_4_MIN) // CLEO 3 did not cleared local variables
+  {
+    for (DWORD i = nParams; i < 32; i++) {
+      thread->SetIntVar(i, 0); // fill with zeros
+    }
+  }
+
+  // jump to label
+  thread->Jump(label);
+  return OR_CONTINUE;
+}
+
+// cleo_return
+// cleo_return {numRet} [int] {retParams} [arguments]
+OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0AB2(
+    CRunningScript *thread) {
+  auto returnParamCount = OPCODE_PEEK_VARARG_COUNT();
+  if (returnParamCount) {
+    auto paramType = thread->PeekDataType();
+    if (!IsImmInteger(paramType)) {
+      SHOW_ERROR(
+          "Invalid type of first argument in opcode [0AB2], in script %s",
+          ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
+    }
+    DWORD declaredParamCount = CLEO_GetIntOpcodeParam(thread);
+
+    if (returnParamCount - 1 < declaredParamCount) // minus 'num args' itself
+    {
+      SHOW_ERROR("Opcode [0AB2] declared %d return args, but provided %d in "
+                 "script %s\nScript suspended.",
+                 declaredParamCount, returnParamCount - 1,
+                 ScriptInfoStr(thread).c_str());
+      return thread->Suspend();
+    } else if (returnParamCount - 1 >
+               declaredParamCount) // more args than needed, not critical
+    {
+      LOG_WARNING(
+          thread,
+          "Opcode [0AB2] declared %d return args, but provided %d in script %s",
+          declaredParamCount, returnParamCount - 1,
+          ScriptInfoStr(thread).c_str());
+    }
+
+    returnParamCount = declaredParamCount;
+  }
+
+  return CleoInstance.OpcodeSystem.CleoReturnGeneric(
+      0x0AB2, thread, true, returnParamCount, !IsLegacyScript(thread));
+}
+
+// set_cleo_shared_var
+// set_cleo_shared_var {index} [int] {value} [any]
+OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0AB3(
+    CRunningScript *thread) {
+  auto varIdx = OPCODE_READ_PARAM_INT();
+
+  const auto VarCount = _countof(CScriptEngine::CleoVariables);
+  if (varIdx < 0 || varIdx >= VarCount) {
+    SHOW_ERROR("Variable index '%d' out of supported range in script "
+               "%s\nScript suspended.",
+               varIdx, ScriptInfoStr(thread).c_str());
+    return thread->Suspend();
+  }
+
+  CleoInstance.ScriptEngine.CleoVariables[varIdx] = OPCODE_READ_PARAM_ANY32();
+  return OR_CONTINUE;
+}
+
+// get_cleo_shared_var
+// [var result: any] = get_cleo_shared_var {index} [int]
+OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0AB4(
+    CRunningScript *thread) {
+  auto varIdx = OPCODE_READ_PARAM_INT();
+
+  const auto VarCount = _countof(CScriptEngine::CleoVariables);
+  if (varIdx < 0 || varIdx >= VarCount) {
+    SHOW_ERROR("Variable index '%d' out of supported range in script "
+               "%s\nScript suspended.",
+               varIdx, ScriptInfoStr(thread).c_str());
+    return thread->Suspend();
+  }
+
+  OPCODE_WRITE_PARAM_ANY32(CleoInstance.ScriptEngine.CleoVariables[varIdx]);
+  return OR_CONTINUE;
+}
+
+// get_platform
+// [var platform: Platform] = get_platform
+OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0DD5(
+    CRunningScript *thread) {
+  OPCODE_WRITE_PARAM_INT(PLATFORM_WINDOWS);
+  return OR_CONTINUE;
+}
+
+// get_cleo_arg_count
+// [var count: int] = get_cleo_arg_count
+OpcodeResult __stdcall CCustomOpcodeSystem::opcode_2000(
+    CRunningScript *thread) {
+  auto cs = reinterpret_cast<CCustomScript *>(thread);
+
+  ScmFunction *scmFunc = ScmFunction::Get(cs->GetScmFunction());
+  if (scmFunc == nullptr) {
+    SHOW_ERROR("Quering argument count without preceding CLEO function call in "
+               "script %s\nScript suspended.",
+               cs->GetInfoStr().c_str());
+    return thread->Suspend();
+  }
+
+  OPCODE_WRITE_PARAM_INT(scmFunc->callArgCount);
+  return OR_CONTINUE;
+}
+
+// cleo_return_with
+// cleo_return_with {conditionResult} [bool] {retArgs} [arguments] (logical)
+OpcodeResult __stdcall CCustomOpcodeSystem::opcode_2002(
+    CRunningScript *thread) {
+  auto argCount = OPCODE_PEEK_VARARG_COUNT();
+  if (argCount < 1) {
+    SHOW_ERROR("Opcode [2002] missing condition result argument in script "
+               "%s\nScript suspended.",
+               ScriptInfoStr(thread).c_str());
+    return thread->Suspend();
+  }
+
+  auto result = OPCODE_READ_PARAM_BOOL();
+  argCount--;
+
+  OPCODE_CONDITION_RESULT(result);
+  return CleoInstance.OpcodeSystem.CleoReturnGeneric(0x2002, thread, true,
+                                                     argCount);
+}
+
+// cleo_return_fail
+// cleo_return_fail [arguments] (logical)
+OpcodeResult __stdcall CCustomOpcodeSystem::opcode_2003(
+    CRunningScript *thread) {
+  auto argCount = OPCODE_PEEK_VARARG_COUNT();
+  if (argCount != 0) // argument(s) not supported yet
+  {
+    SHOW_ERROR(
+        "Too many arguments of opcode [2003] in script %s\nScript suspended.",
+        ScriptInfoStr(thread).c_str());
+    return thread->Suspend();
+  }
+
+  OPCODE_CONDITION_RESULT(false);
+  return CleoInstance.OpcodeSystem.CleoReturnGeneric(0x2003, thread);
+}
+} // namespace CLEO

--- a/source/CCustomOpcodeSystem.h
+++ b/source/CCustomOpcodeSystem.h
@@ -3,89 +3,121 @@
 #include "CDebug.h"
 #include "ScriptDelegate.h"
 
-namespace CLEO
-{
-    class CCustomOpcodeSystem
-    {
-    public:
-        static constexpr size_t Opcode_Max_Native = 0x0A4E; // GTA SA
-        static constexpr size_t Opcode_Max = 0x7FFF;
-        static constexpr size_t Opcode_Table_Size = 100; // opcodes per handler
-        
-        // most recently processed
-        static CRunningScript* lastScript;
-        static WORD lastOpcode;
-        static WORD* lastOpcodePtr;
-        static WORD lastCustomOpcode;
-        static std::string lastErrorMsg;
-        static WORD prevOpcode; // previous
-        static BYTE handledParamCount; // read/writen since current opcode handling started
+namespace CLEO {
+class CCustomOpcodeSystem {
+public:
+  static constexpr size_t Opcode_Max_Native = 0x0A4E; // GTA SA
+  static constexpr size_t Opcode_Max = 0x7FFF;
+  static constexpr size_t Opcode_Table_Size = 100; // opcodes per handler
 
-        ScriptDeleteDelegate scriptDeleteDelegate;
+  // most recently processed
+  static CRunningScript *lastScript;
+  static WORD lastOpcode;
+  static WORD *lastOpcodePtr;
+  static WORD lastCustomOpcode;
+  static std::string lastErrorMsg;
+  static WORD prevOpcode; // previous
+  static BYTE
+      handledParamCount; // read/writen since current opcode handling started
 
-        void FinalizeScriptObjects();
+  ScriptDeleteDelegate scriptDeleteDelegate;
 
-        CCustomOpcodeSystem() = default;
-        CCustomOpcodeSystem(const CCustomOpcodeSystem&) = delete; // no copying
-        void Inject(CCodeInjector& inj);
-        void Init();
-        ~CCustomOpcodeSystem();
+  void FinalizeScriptObjects();
 
-        static bool RegisterOpcode(WORD opcode, CustomOpcodeHandler callback);
-        static OpcodeResult CallNativeOpcode(CRunningScript* thread, WORD opcode);
-        static OpcodeResult CleoReturnGeneric(WORD opcode, CRunningScript* thread, bool returnArgs = false, DWORD returnArgCount = 0, bool strictArgCount = true);
+  CCustomOpcodeSystem() = default;
+  CCustomOpcodeSystem(const CCustomOpcodeSystem &) = delete; // no copying
+  void Inject(CCodeInjector &inj);
+  void Init();
+  ~CCustomOpcodeSystem();
 
-        // new/customized opcodes
-        static OpcodeResult __stdcall opcode_004E(CRunningScript* thread); // terminate_this_script
-        static OpcodeResult __stdcall opcode_0051(CRunningScript* thread); // GOSUB return
-        static OpcodeResult __stdcall opcode_0417(CRunningScript* thread); // load_and_launch_mission_internal
+  static bool RegisterOpcode(WORD opcode, CustomOpcodeHandler callback);
+  static OpcodeResult CallNativeOpcode(CRunningScript *thread, WORD opcode);
+  static OpcodeResult CleoReturnGeneric(WORD opcode, CRunningScript *thread,
+                                        bool returnArgs = false,
+                                        DWORD returnArgCount = 0,
+                                        bool strictArgCount = true);
 
-        static OpcodeResult __stdcall opcode_0A92(CRunningScript* thread); // stream_custom_script
-        static OpcodeResult __stdcall opcode_0A93(CRunningScript* thread); // terminate_this_custom_script
-        static OpcodeResult __stdcall opcode_0A94(CRunningScript* thread); // load_and_launch_custom_mission
-        static OpcodeResult __stdcall opcode_0A95(CRunningScript* thread); // save_this_custom_script
-        static OpcodeResult __stdcall opcode_0AA0(CRunningScript* thread); // gosub_if_false
-        static OpcodeResult __stdcall opcode_0AA1(CRunningScript* thread); // return_if_false
-        static OpcodeResult __stdcall opcode_0AA9(CRunningScript* thread); // is_game_version_original
-        static OpcodeResult __stdcall opcode_0AB1(CRunningScript* thread); // cleo_call
-        static OpcodeResult __stdcall opcode_0AB2(CRunningScript* thread); // cleo_return
-        static OpcodeResult __stdcall opcode_0AB3(CRunningScript* thread); // set_cleo_shared_var
-        static OpcodeResult __stdcall opcode_0AB4(CRunningScript* thread); // get_cleo_shared_var
+  // new/customized opcodes
+  static OpcodeResult __stdcall opcode_004E(
+      CRunningScript *thread); // terminate_this_script
+  static OpcodeResult __stdcall opcode_0051(
+      CRunningScript *thread); // GOSUB return
+  static OpcodeResult __stdcall opcode_0417(
+      CRunningScript *thread); // load_and_launch_mission_internal
 
-        static OpcodeResult __stdcall opcode_0DD5(CRunningScript* thread); // get_platform
+  static OpcodeResult __stdcall opcode_0A92(
+      CRunningScript *thread); // stream_custom_script
+  static OpcodeResult __stdcall opcode_0A93(
+      CRunningScript *thread); // terminate_this_custom_script
+  static OpcodeResult __stdcall opcode_0A94(
+      CRunningScript *thread); // load_and_launch_custom_mission
+  static OpcodeResult __stdcall opcode_0A95(
+      CRunningScript *thread); // save_this_custom_script
+  static OpcodeResult __stdcall opcode_0AA0(
+      CRunningScript *thread); // gosub_if_false
+  static OpcodeResult __stdcall opcode_0AA1(
+      CRunningScript *thread); // return_if_false
+  static OpcodeResult __stdcall opcode_0AA9(
+      CRunningScript *thread); // is_game_version_original
+  static OpcodeResult __stdcall opcode_0AB1(
+      CRunningScript *thread); // cleo_call
+  static OpcodeResult __stdcall opcode_0AB2(
+      CRunningScript *thread); // cleo_return
+  static OpcodeResult __stdcall opcode_0AB3(
+      CRunningScript *thread); // set_cleo_shared_var
+  static OpcodeResult __stdcall opcode_0AB4(
+      CRunningScript *thread); // get_cleo_shared_var
 
-        static OpcodeResult __stdcall opcode_2000(CRunningScript* thread); // get_cleo_arg_count
-        // 2001 free slot
-        static OpcodeResult __stdcall opcode_2002(CRunningScript* thread); // cleo_return_with
-        static OpcodeResult __stdcall opcode_2003(CRunningScript* thread); // cleo_return_fail
+  static OpcodeResult __stdcall opcode_0DD5(
+      CRunningScript *thread); // get_platform
 
-    private:
-        bool initialized = false;
+  static OpcodeResult __stdcall opcode_2000(
+      CRunningScript *thread); // get_cleo_arg_count
+  // 2001 free slot
+  static OpcodeResult __stdcall opcode_2002(
+      CRunningScript *thread); // cleo_return_with
+  static OpcodeResult __stdcall opcode_2003(
+      CRunningScript *thread); // cleo_return_fail
 
-        typedef OpcodeResult(__thiscall* OpcodeHandler)(CRunningScript* thread, WORD opcode);
+private:
+  bool initialized = false;
 
-        static const size_t OriginalOpcodeHandlersCount = (Opcode_Max_Native / Opcode_Table_Size) + 1;
-        static OpcodeHandler originalOpcodeHandlers[OriginalOpcodeHandlersCount]; // backuped when patching
+  typedef OpcodeResult(__thiscall *OpcodeHandler)(CRunningScript *thread,
+                                                  WORD opcode);
 
-        static const size_t CustomOpcodeHandlersCount = (Opcode_Max / Opcode_Table_Size) + 1;
-        static OpcodeHandler customOpcodeHandlers[CustomOpcodeHandlersCount]; // original + new opcodes
+  static const size_t OriginalOpcodeHandlersCount =
+      (Opcode_Max_Native / Opcode_Table_Size) + 1;
+  static OpcodeHandler
+      originalOpcodeHandlers[OriginalOpcodeHandlersCount]; // backuped when
+                                                           // patching
 
-        static OpcodeResult __fastcall customOpcodeHandler(CRunningScript* thread, int dummy, WORD opcode); // universal CLEO's opcode handler
+  static const size_t CustomOpcodeHandlersCount =
+      (Opcode_Max / Opcode_Table_Size) + 1;
+  static OpcodeHandler
+      customOpcodeHandlers[CustomOpcodeHandlersCount]; // original + new opcodes
 
-        static CustomOpcodeHandler customOpcodeProc[Opcode_Max + 1]; // procedure for each opcode
-    };
+  static OpcodeResult __fastcall customOpcodeHandler(
+      CRunningScript *thread, int dummy,
+      WORD opcode); // universal CLEO's opcode handler
 
-    // Read null-terminated string into the buffer
-    // returns pointer to string or nullptr on fail
-    // WARNING: returned pointer may differ from buff and contain string longer than buffSize (ptr to original data source)
-    const char* ReadStringParam(CRunningScript* thread, char* buff, int buffSize);
+  static CustomOpcodeHandler
+      customOpcodeProc[Opcode_Max + 1]; // procedure for each opcode
+};
 
-    StringParamBufferInfo GetStringParamWriteBuffer(CRunningScript* thread); // consumes the param
-    int ReadFormattedString(CRunningScript* thread, char* buf, DWORD bufSize, const char* format);
+// Read null-terminated string into the buffer
+// returns pointer to string or nullptr on fail
+// WARNING: returned pointer may differ from buff and contain string longer than
+// buffSize (ptr to original data source)
+const char *ReadStringParam(CRunningScript *thread, char *buff, int buffSize);
 
-    bool WriteStringParam(CRunningScript* thread, const char* str);
-    bool WriteStringParam(const StringParamBufferInfo& target, const char* str);
+StringParamBufferInfo
+GetStringParamWriteBuffer(CRunningScript *thread); // consumes the param
+int ReadFormattedString(CRunningScript *thread, char *buf, DWORD bufSize,
+                        const char *format);
 
-    void SkipUnusedVarArgs(CRunningScript* thread); // for var-args opcodes
-    DWORD GetVarArgCount(CRunningScript* thread); // for var-args opcodes
-}
+bool WriteStringParam(CRunningScript *thread, const char *str);
+bool WriteStringParam(const StringParamBufferInfo &target, const char *str);
+
+void SkipUnusedVarArgs(CRunningScript *thread); // for var-args opcodes
+DWORD GetVarArgCount(CRunningScript *thread);   // for var-args opcodes
+} // namespace CLEO

--- a/source/CCustomScript.cpp
+++ b/source/CCustomScript.cpp
@@ -1,393 +1,396 @@
-#include "stdafx.h"
 #include "CCustomScript.h"
-#include "CleoBase.h"
-#include "crc32.h"
 #include "CScriptEngine.h"
+#include "CleoBase.h"
 #include "ScriptUtils.h"
+#include "crc32.h"
+#include "stdafx.h"
 
 using namespace CLEO;
 
-
-// TODO: Consider split into 2 classes: CCustomExternalScript, CCustomChildScript
-CCustomScript::CCustomScript(const char* szFileName, bool bIsMiss, CRunningScript* parent, int label)
+// TODO: Consider split into 2 classes: CCustomExternalScript,
+// CCustomChildScript
+CCustomScript::CCustomScript(const char *szFileName, bool bIsMiss,
+                             CRunningScript *parent, int label)
     : CRunningScript(), m_saveEnabled(false), m_ok(false),
-    m_compatVer(CLEO_VER_CUR)
-{
-    TRACE(""); // separator
-    TRACE("Loading custom script '%s'...", szFileName);
+      m_compatVer(CLEO_VER_CUR) {
+  TRACE(""); // separator
+  TRACE("Loading custom script '%s'...", szFileName);
 
-    bIsCustom = true;
-    bIsMission = bUseMissionCleanup = bIsMiss;
+  bIsCustom = true;
+  bIsMission = bUseMissionCleanup = bIsMiss;
 
-    try
+  try {
+    std::ifstream is;
+    if (label != 0) // Create external from label.
     {
-        std::ifstream is;
-        if (label != 0) // Create external from label.
-        {
-            if (!parent)
-                throw std::logic_error("Trying to create external thread from label without parent thread");
+      if (!parent)
+        throw std::logic_error("Trying to create external thread from label "
+                               "without parent thread");
 
-            if (!parent->IsCustom())
-                throw std::logic_error("Only custom threads can spawn children threads from label");
+      if (!parent->IsCustom())
+        throw std::logic_error(
+            "Only custom threads can spawn children threads from label");
 
-            auto cs = (CCustomScript*)parent;
+      auto cs = (CCustomScript *)parent;
 
-            m_compatVer = cs->GetCompatibility();
-            m_debugMode = cs->GetDebugMode();
-            m_scriptFileDir = cs->GetScriptFileDir();
-            m_scriptFileName = cs->GetScriptFileName();
-            m_workDir = cs->GetWorkDir();
+      m_compatVer = cs->GetCompatibility();
+      m_debugMode = cs->GetDebugMode();
+      m_scriptFileDir = cs->GetScriptFileDir();
+      m_scriptFileName = cs->GetScriptFileName();
+      m_workDir = cs->GetWorkDir();
 
-            BaseIP = cs->GetBasePointer();
-            CurrentIP = cs->GetBasePointer() - label;
-            memcpy(Name, cs->Name, sizeof(Name));
-            m_codeChecksum = cs->m_codeChecksum;
-            m_parentScript = cs;
-            cs->m_childScripts.push_back(this);
+      BaseIP = cs->GetBasePointer();
+      CurrentIP = cs->GetBasePointer() - label;
+      memcpy(Name, cs->Name, sizeof(Name));
+      m_codeChecksum = cs->m_codeChecksum;
+      m_parentScript = cs;
+      cs->m_childScripts.push_back(this);
+    } else {
+      // store script file directory and name
+      std::string pathStr = szFileName;
+      FilepathNormalize(pathStr, false);
+      FS::path path = pathStr;
+
+      // file exists?
+      if (!FS::is_regular_file(path)) {
+        if (path.extension() == cs_ext) {
+          // maybe it was renamed to enable compatibility mode?
+          auto compatPath = path;
+
+          compatPath.replace_extension(cs4_ext);
+          if (FS::is_regular_file(compatPath)) {
+            path = compatPath;
+          } else {
+            compatPath.replace_extension(cs3_ext);
+            if (FS::is_regular_file(compatPath)) {
+              path = compatPath;
+            } else {
+              throw std::logic_error("File does not exists");
+            }
+          }
+        } else
+          throw std::logic_error("File does not exists");
+      }
+
+      // deduce compatibility mode from filetype extension
+      if (path.extension() == cs4_ext)
+        m_compatVer = CLEO_VER_4;
+      else if (path.extension() == cs3_ext)
+        m_compatVer = CLEO_VER_3;
+
+      if (m_compatVer == CLEO_VER_CUR && parent != nullptr) {
+        // inherit compatibility mode from parent
+        m_compatVer = CLEO_GetScriptVersion(parent);
+
+        // try loading file with same compatibility mode filetype extension
+        auto compatPath = path;
+        if (m_compatVer == CLEO_VER_4) {
+          compatPath.replace_extension(cs4_ext);
+          if (FS::is_regular_file(compatPath))
+            path = compatPath;
+        } else if (m_compatVer == CLEO_VER_3) {
+          compatPath.replace_extension(cs3_ext);
+          if (FS::is_regular_file(compatPath))
+            path = compatPath;
         }
-        else
-        {
-            // store script file directory and name
-            std::string pathStr = szFileName;
-            FilepathNormalize(pathStr, false);
-            FS::path path = pathStr;
+      }
 
-            // file exists?
-            if (!FS::is_regular_file(path))
-            {
-                if (path.extension() == cs_ext)
-                {
-                    // maybe it was renamed to enable compatibility mode?
-                    auto compatPath = path;
+      m_scriptFileDir = path.parent_path().string();
+      m_scriptFileName = path.filename().string();
 
-                    compatPath.replace_extension(cs4_ext);
-                    if (FS::is_regular_file(compatPath))
-                    {
-                        path = compatPath;
-                    }
-                    else
-                    {
-                        compatPath.replace_extension(cs3_ext);
-                        if (FS::is_regular_file(compatPath))
-                        {
-                            path = compatPath;
-                        }
-                        else
-                        {
-                            throw std::logic_error("File does not exists");
-                        }
-                    }
-                }
-                else
-                    throw std::logic_error("File does not exists");
-            }
+      if (parent != nullptr) {
+        m_debugMode = ((CCustomScript *)parent)->GetDebugMode();
+        m_workDir = ((CCustomScript *)parent)->GetWorkDir();
+      } else {
+        m_debugMode =
+            CleoInstance.ScriptEngine.NativeScriptsDebugMode; // global setting
+        m_workDir = Filepath_Game;                            // game root
+      }
 
-            // deduce compatibility mode from filetype extension
-            if (path.extension() == cs4_ext)
-                m_compatVer = CLEO_VER_4;
-            else
-                if (path.extension() == cs3_ext)
-                    m_compatVer = CLEO_VER_3;
+      using std::ios;
+      std::ifstream is(path.string().c_str(), std::ios::binary);
+      is.exceptions(std::ios::badbit | std::ios::failbit);
+      std::size_t length;
+      is.seekg(0, std::ios::end);
+      length = (size_t)is.tellg();
+      is.seekg(0, std::ios::beg);
 
-            if (m_compatVer == CLEO_VER_CUR && parent != nullptr)
-            {
-                // inherit compatibility mode from parent
-                m_compatVer = CLEO_GetScriptVersion(parent);
+      if (bIsMiss) {
+        if (CTheScripts::bAlreadyRunningAMissionScript)
+          throw std::logic_error(
+              "Starting of custom mission when other mission loaded");
 
-                // try loading file with same compatibility mode filetype extension
-                auto compatPath = path;
-                if (m_compatVer == CLEO_VER_4)
-                {
-                    compatPath.replace_extension(cs4_ext);
-                    if (FS::is_regular_file(compatPath))
-                        path = compatPath;
-                }
-                else
-                    if (m_compatVer == CLEO_VER_3)
-                    {
-                        compatPath.replace_extension(cs3_ext);
-                        if (FS::is_regular_file(compatPath))
-                            path = compatPath;
-                    }
-            }
+        CTheScripts::bAlreadyRunningAMissionScript = 1;
+        CleoInstance.ScriptEngine.missionIndex = -1;
+        BaseIP = CurrentIP = CleoInstance.ScriptEngine
+                                 .missionBlock; // TODO: there should be check
+                                                // length <= missionBlock size
+      } else {
+        BaseIP = CurrentIP = new BYTE[length];
+      }
+      is.read(reinterpret_cast<char *>(BaseIP), length);
 
-            m_scriptFileDir = path.parent_path().string();
-            m_scriptFileName = path.filename().string();
+      m_codeSize = length;
+      m_codeSize -= GetExtraInfoSize(
+          reinterpret_cast<BYTE *>(BaseIP),
+          m_codeSize); // just the code without extra SCM data at the end
 
-            if (parent != nullptr)
-            {
-                m_debugMode = ((CCustomScript*)parent)->GetDebugMode();
-                m_workDir = ((CCustomScript*)parent)->GetWorkDir();
-            }
-            else
-            {
-                m_debugMode = CleoInstance.ScriptEngine.NativeScriptsDebugMode; // global setting
-                m_workDir = Filepath_Game; // game root
-            }
+      m_codeChecksum = crc32(reinterpret_cast<BYTE *>(BaseIP), length);
 
-            using std::ios;
-            std::ifstream is(path.string().c_str(), std::ios::binary);
-            is.exceptions(std::ios::badbit | std::ios::failbit);
-            std::size_t length;
-            is.seekg(0, std::ios::end);
-            length = (size_t)is.tellg();
-            is.seekg(0, std::ios::beg);
+      // thread name from filename
+      auto threadNamePath = path;
+      if (threadNamePath.extension() == cs3_ext ||
+          threadNamePath.extension() == cs4_ext) {
+        threadNamePath.replace_extension(
+            cs_ext); // keep original extension even in compatibility modes
+      }
+      auto fName = threadNamePath.filename().string();
 
-            if (bIsMiss)
-            {
-                if (CTheScripts::bAlreadyRunningAMissionScript)
-                    throw std::logic_error("Starting of custom mission when other mission loaded");
-
-                CTheScripts::bAlreadyRunningAMissionScript = 1;
-                CleoInstance.ScriptEngine.missionIndex = -1;
-                BaseIP = CurrentIP = CleoInstance.ScriptEngine.missionBlock; // TODO: there should be check length <= missionBlock size
-            }
-            else
-            {
-                BaseIP = CurrentIP = new BYTE[length];
-            }
-            is.read(reinterpret_cast<char*>(BaseIP), length);
-
-            m_codeSize = length;
-            m_codeSize -= GetExtraInfoSize(reinterpret_cast<BYTE*>(BaseIP), m_codeSize); // just the code without extra SCM data at the end
-
-            m_codeChecksum = crc32(reinterpret_cast<BYTE*>(BaseIP), length);
-
-            // thread name from filename
-            auto threadNamePath = path;
-            if (threadNamePath.extension() == cs3_ext || threadNamePath.extension() == cs4_ext)
-            {
-                threadNamePath.replace_extension(cs_ext); // keep original extension even in compatibility modes
-            }
-            auto fName = threadNamePath.filename().string();
-
-            memset(Name, '\0', sizeof(Name));
-            if (!fName.empty())
-            {
-                auto len = std::min(fName.length(), sizeof(Name) - 1); // and text terminator
-                memcpy(Name, fName.c_str(), len);
-            }
-        }
-        CleoInstance.ScriptEngine.LastScriptCreated = this;
-        m_ok = true;
+      memset(Name, '\0', sizeof(Name));
+      if (!fName.empty()) {
+        auto len =
+            std::min(fName.length(), sizeof(Name) - 1); // and text terminator
+        memcpy(Name, fName.c_str(), len);
+      }
     }
-    catch (std::exception& e)
-    {
-        LOG_WARNING(0, "Error during loading of custom script '%s' occured.\nError message: %s", szFileName, e.what());
-    }
-    catch (...)
-    {
-        LOG_WARNING(0, "Unknown error during loading of custom script '%s' occured.", szFileName);
-    }
+    CleoInstance.ScriptEngine.LastScriptCreated = this;
+    m_ok = true;
+  } catch (std::exception &e) {
+    LOG_WARNING(0,
+                "Error during loading of custom script '%s' occured.\nError "
+                "message: %s",
+                szFileName, e.what());
+  } catch (...) {
+    LOG_WARNING(0,
+                "Unknown error during loading of custom script '%s' occured.",
+                szFileName);
+  }
 }
 
-CCustomScript::~CCustomScript()
-{
-    if (BaseIP && !bIsMission) delete[] BaseIP;
-    CleoInstance.OpcodeSystem.scriptDeleteDelegate(this);
+CCustomScript::~CCustomScript() {
+  if (BaseIP && !bIsMission)
+    delete[] BaseIP;
+  CleoInstance.OpcodeSystem.scriptDeleteDelegate(this);
 
-    if (CleoInstance.ScriptEngine.LastScriptCreated == this) CleoInstance.ScriptEngine.LastScriptCreated = nullptr;
+  if (CleoInstance.ScriptEngine.LastScriptCreated == this)
+    CleoInstance.ScriptEngine.LastScriptCreated = nullptr;
 }
 
-void CCustomScript::AddScriptToList(CRunningScript** queuelist)
-{
-    ((::CRunningScript*)this)->AddScriptToList((::CRunningScript**)queuelist); // CRunningScript from Plugin SDK
+void CCustomScript::AddScriptToList(CRunningScript **queuelist) {
+  ((::CRunningScript *)this)
+      ->AddScriptToList(
+          (::CRunningScript **)queuelist); // CRunningScript from Plugin SDK
 }
 
-void CCustomScript::RemoveScriptFromList(CRunningScript** queuelist)
-{
-    ((::CRunningScript*)this)->RemoveScriptFromList((::CRunningScript**)queuelist); // CRunningScript from Plugin SDK
+void CCustomScript::RemoveScriptFromList(CRunningScript **queuelist) {
+  ((::CRunningScript *)this)
+      ->RemoveScriptFromList(
+          (::CRunningScript **)queuelist); // CRunningScript from Plugin SDK
 }
 
-void CCustomScript::ShutdownThisScript()
-{
-    ((::CRunningScript*)this)->ShutdownThisScript(); // CRunningScript from Plugin SDK
+void CCustomScript::ShutdownThisScript() {
+  ((::CRunningScript *)this)
+      ->ShutdownThisScript(); // CRunningScript from Plugin SDK
 }
 
-bool CCustomScript::GetDebugMode() const
-{
-    return bIsCustom ? m_debugMode : CleoInstance.ScriptEngine.NativeScriptsDebugMode;
+bool CCustomScript::GetDebugMode() const {
+  return bIsCustom ? m_debugMode
+                   : CleoInstance.ScriptEngine.NativeScriptsDebugMode;
 }
 
-void CCustomScript::SetDebugMode(bool enabled)
-{
-    if (!bIsCustom)
-        CleoInstance.ScriptEngine.NativeScriptsDebugMode = enabled;
-    else
-        m_debugMode = enabled;
+void CCustomScript::SetDebugMode(bool enabled) {
+  if (!bIsCustom)
+    CleoInstance.ScriptEngine.NativeScriptsDebugMode = enabled;
+  else
+    m_debugMode = enabled;
 }
 
-const char* CCustomScript::GetScriptFileDir() const
-{
-    return bIsCustom ? m_scriptFileDir.c_str() : CleoInstance.ScriptEngine.MainScriptFileDir.c_str();
+const char *CCustomScript::GetScriptFileDir() const {
+  return bIsCustom ? m_scriptFileDir.c_str()
+                   : CleoInstance.ScriptEngine.MainScriptFileDir.c_str();
 }
 
-void CCustomScript::SetScriptFileDir(const char* directory)
-{
-    if (!bIsCustom)
-        CleoInstance.ScriptEngine.MainScriptFileDir = directory;
-    else
-        m_scriptFileDir = directory;
+void CCustomScript::SetScriptFileDir(const char *directory) {
+  if (!bIsCustom)
+    CleoInstance.ScriptEngine.MainScriptFileDir = directory;
+  else
+    m_scriptFileDir = directory;
 }
 
-const char* CCustomScript::GetScriptFileName() const
-{
-    return bIsCustom ? m_scriptFileName.c_str() : CleoInstance.ScriptEngine.MainScriptFileName.c_str();
+const char *CCustomScript::GetScriptFileName() const {
+  return bIsCustom ? m_scriptFileName.c_str()
+                   : CleoInstance.ScriptEngine.MainScriptFileName.c_str();
 }
 
-void CCustomScript::SetScriptFileName(const char* filename)
-{
-    if (!bIsCustom)
-        CleoInstance.ScriptEngine.MainScriptFileName = filename;
-    else
-        m_scriptFileName = filename;
+void CCustomScript::SetScriptFileName(const char *filename) {
+  if (!bIsCustom)
+    CleoInstance.ScriptEngine.MainScriptFileName = filename;
+  else
+    m_scriptFileName = filename;
 }
 
-std::string CCustomScript::GetScriptFileFullPath() const
-{
-    std::string path = GetScriptFileDir();
-    path += '\\';
-    path += GetScriptFileName();
-    return path;
+std::string CCustomScript::GetScriptFileFullPath() const {
+  std::string path = GetScriptFileDir();
+  path += '\\';
+  path += GetScriptFileName();
+  return path;
 }
 
-const char* CCustomScript::GetWorkDir() const
-{
-    return bIsCustom ? m_workDir.c_str() : CleoInstance.ScriptEngine.MainScriptCurWorkDir.c_str();
+const char *CCustomScript::GetWorkDir() const {
+  return bIsCustom ? m_workDir.c_str()
+                   : CleoInstance.ScriptEngine.MainScriptCurWorkDir.c_str();
 }
 
-void CCustomScript::SetWorkDir(const char* directory)
-{
-    if (directory == nullptr || strlen(directory) == 0)
-        return;  // Already done. Empty path is relative path starting at current work dir
+void CCustomScript::SetWorkDir(const char *directory) {
+  if (directory == nullptr || strlen(directory) == 0)
+    return; // Already done. Empty path is relative path starting at current
+            // work dir
 
-    auto resolved = ResolvePath(directory);
+  auto resolved = ResolvePath(directory);
 
-    if (!bIsCustom)
-        CleoInstance.ScriptEngine.MainScriptCurWorkDir = resolved;
-    else
-        m_workDir = resolved;
+  if (!bIsCustom)
+    CleoInstance.ScriptEngine.MainScriptCurWorkDir = resolved;
+  else
+    m_workDir = resolved;
 }
 
-std::string CCustomScript::ResolvePath(const char* path, const char* customWorkDir) const
-{
-    if (path == nullptr)
-    {
-        return {};
+std::string CCustomScript::ResolvePath(const char *path,
+                                       const char *customWorkDir) const {
+  if (path == nullptr) {
+    return {};
+  }
+
+  auto fsPath = FS::path(path);
+
+  // check for virtual path root
+  enum class VPref {
+    None,
+    Game,
+    User,
+    Script,
+    Cleo,
+    Modules
+  } virtualPrefix = VPref::None;
+  if (!fsPath.empty()) {
+    const auto root = fsPath.begin()->string(); // first path element
+    const auto r = root.c_str();
+
+    if (_strcmpi(r, DIR_GAME) == 0)
+      virtualPrefix = VPref::Game;
+    else if (_strcmpi(r, DIR_USER) == 0)
+      virtualPrefix = VPref::User;
+    else if (_strcmpi(r, DIR_SCRIPT) == 0 &&
+             !IsLegacyScript((CRunningScript *)this))
+      virtualPrefix = VPref::Script;
+    else if (_strcmpi(r, DIR_CLEO) == 0)
+      virtualPrefix = VPref::Cleo;
+    else if (_strcmpi(r, DIR_MODULES) == 0)
+      virtualPrefix = VPref::Modules;
+  }
+
+  // not virtual
+  if (virtualPrefix == VPref::None) {
+    if (fsPath.is_relative()) {
+      if (customWorkDir != nullptr)
+        fsPath = ResolvePath(customWorkDir) / fsPath;
+      else
+        fsPath = GetWorkDir() / fsPath;
     }
 
-    auto fsPath = FS::path(path);
-
-    // check for virtual path root
-    enum class VPref { None, Game, User, Script, Cleo, Modules } virtualPrefix = VPref::None;
-    if (!fsPath.empty())
-    {
-        const auto root = fsPath.begin()->string(); // first path element
-        const auto r = root.c_str();
-
-        if (_strcmpi(r, DIR_GAME) == 0) virtualPrefix = VPref::Game;
-        else if (_strcmpi(r, DIR_USER) == 0) virtualPrefix = VPref::User;
-        else if (_strcmpi(r, DIR_SCRIPT) == 0 && !IsLegacyScript((CRunningScript*)this)) virtualPrefix = VPref::Script;
-        else if (_strcmpi(r, DIR_CLEO) == 0) virtualPrefix = VPref::Cleo;
-        else if (_strcmpi(r, DIR_MODULES) == 0) virtualPrefix = VPref::Modules;
-    }
-
-    // not virtual
-    if (virtualPrefix == VPref::None)
-    {
-        if (fsPath.is_relative())
-        {
-            if (customWorkDir != nullptr)
-                fsPath = ResolvePath(customWorkDir) / fsPath;
-            else
-                fsPath = GetWorkDir() / fsPath;
-        }
-
-        auto result = fsPath.string();
-        FilepathNormalize(result, false);
-
-        // ModLoader support: make paths withing game directory relative to it
-        FilepathRemoveParent(result, Filepath_Game);
-
-        return std::move(result);
-    }
-
-    // expand virtual paths
-    FS::path resolved;
-    switch (virtualPrefix)
-    {
-        case VPref::User: resolved = Filepath_User; break;
-        case VPref::Script: resolved = GetScriptFileDir(); break;
-        case VPref::Game: resolved = Filepath_Game; break;
-        case VPref::Cleo: resolved = Filepath_Cleo; break;
-        case VPref::Modules: resolved = Filepath_Cleo + "\\cleo_modules"; break;
-        default: resolved = "<error>"; break; // should never happen
-    }
-
-    // append all but virtual prefix from original path
-    for (auto it = ++fsPath.begin(); it != fsPath.end(); it++)
-        resolved /= *it;
-
-    auto result = resolved.string();
+    auto result = fsPath.string();
     FilepathNormalize(result, false);
+
+    // ModLoader support: make paths withing game directory relative to it
+    FilepathRemoveParent(result, Filepath_Game);
+
     return std::move(result);
+  }
+
+  // expand virtual paths
+  FS::path resolved;
+  switch (virtualPrefix) {
+  case VPref::User:
+    resolved = Filepath_User;
+    break;
+  case VPref::Script:
+    resolved = GetScriptFileDir();
+    break;
+  case VPref::Game:
+    resolved = Filepath_Game;
+    break;
+  case VPref::Cleo:
+    resolved = Filepath_Cleo;
+    break;
+  case VPref::Modules:
+    resolved = Filepath_Cleo + "\\cleo_modules";
+    break;
+  default:
+    resolved = "<error>";
+    break; // should never happen
+  }
+
+  // append all but virtual prefix from original path
+  for (auto it = ++fsPath.begin(); it != fsPath.end(); it++)
+    resolved /= *it;
+
+  auto result = resolved.string();
+  FilepathNormalize(result, false);
+  return std::move(result);
 }
 
-std::string CCustomScript::GetInfoStr(bool currLineInfo) const
-{
-    std::ostringstream ss;
+std::string CCustomScript::GetInfoStr(bool currLineInfo) const {
+  std::ostringstream ss;
 
-    auto threadName = GetName();
-    auto fileName = GetScriptFileName();
+  auto threadName = GetName();
+  auto fileName = GetScriptFileName();
 
-    if (memcmp(threadName.c_str(), fileName, threadName.length()) != 0) // thread name no longer same as filename (was set with 03A4)
-    {
-        ss << "'" << threadName << "' from ";
-    }
+  if (memcmp(threadName.c_str(), fileName, threadName.length()) !=
+      0) // thread name no longer same as filename (was set with 03A4)
+  {
+    ss << "'" << threadName << "' from ";
+  }
 
-    ss << "'" << fileName << "'";
+  ss << "'" << fileName << "'";
 
-    if (currLineInfo)
-    {
-        ss << " at ";
+  if (currLineInfo) {
+    ss << " at ";
 
-        if (false)
-        {
-            // TODO: get Sanny's SMC extra info
-            ss << "line " << 0;
-            ss << " - ";
-            ss << "CODE";
-        }
+    if (false) {
+      // TODO: get Sanny's SMC extra info
+      ss << "line " << 0;
+      ss << " - ";
+      ss << "CODE";
+    } else {
+      auto offset = CLEO_GetScriptBaseRelativeOffset(
+          (CLEO::CRunningScript *)this,
+          (BYTE *)CCustomOpcodeSystem::lastOpcodePtr);
+      ss << "offset {" << offset << "}"; // Sanny offsets style
+      ss << " - ";
+      ss << std::hex << std::uppercase << std::setw(4) << std::setfill('0')
+         << CCustomOpcodeSystem::lastOpcode;
+
+      auto commandName = CleoInstance.OpcodeInfoDb.GetCommandName(
+          CCustomOpcodeSystem::lastOpcode);
+      if (commandName != nullptr) {
+        ss << ": " << commandName;
+      } else {
+        ss << ": ...";
+      }
+
+      // add previously executed command info if available
+      if (CCustomOpcodeSystem::prevOpcode != 0xFFFF) {
+        ss << " \nPreviously called command: ";
+
+        auto commandName = CleoInstance.OpcodeInfoDb.GetCommandName(
+            CCustomOpcodeSystem::prevOpcode);
+        if (commandName)
+          ss << commandName;
         else
-        {
-            auto offset = CLEO_GetScriptBaseRelativeOffset((CLEO::CRunningScript*)this, (BYTE*)CCustomOpcodeSystem::lastOpcodePtr);
-            ss << "offset {" << offset << "}"; // Sanny offsets style
-            ss << " - ";
-            ss << std::hex << std::uppercase << std::setw(4) << std::setfill('0') << CCustomOpcodeSystem::lastOpcode;
-
-            auto commandName = CleoInstance.OpcodeInfoDb.GetCommandName(CCustomOpcodeSystem::lastOpcode);
-            if (commandName != nullptr)
-            {
-                ss << ": " << commandName;
-            }
-            else
-            {
-                ss << ": ...";
-            }
-
-            // add previously executed command info if available
-            if (CCustomOpcodeSystem::prevOpcode != 0xFFFF)
-            {
-                ss << " \nPreviously called command: ";
-
-                auto commandName = CleoInstance.OpcodeInfoDb.GetCommandName(CCustomOpcodeSystem::prevOpcode);
-                if (commandName)
-                    ss << commandName;
-                else
-                    ss << "[" << std::hex << std::uppercase << std::setw(4) << std::setfill('0') << CCustomOpcodeSystem::prevOpcode << "]";
-            }
-        }
+          ss << "[" << std::hex << std::uppercase << std::setw(4)
+             << std::setfill('0') << CCustomOpcodeSystem::prevOpcode << "]";
+      }
     }
+  }
 
-    return ss.str();
+  return ss.str();
 }

--- a/source/CCustomScript.h
+++ b/source/CCustomScript.h
@@ -1,71 +1,70 @@
 #pragma once
 
-namespace CLEO
-{
-    class CCustomScript : public CRunningScript
-    {
-        friend class CScriptEngine;
-        friend class CCustomOpcodeSystem;
-        friend struct ThreadSavingInfo;
+namespace CLEO {
+class CCustomScript : public CRunningScript {
+  friend class CScriptEngine;
+  friend class CCustomOpcodeSystem;
+  friend struct ThreadSavingInfo;
 
-        DWORD m_codeSize;
-        DWORD m_codeChecksum;
+  DWORD m_codeSize;
+  DWORD m_codeChecksum;
 
-        bool m_saveEnabled;
-        bool m_ok;
-        eCLEO_Version m_compatVer;
-        CCustomScript* m_parentScript;
-        std::list<CCustomScript*> m_childScripts;
+  bool m_saveEnabled;
+  bool m_ok;
+  eCLEO_Version m_compatVer;
+  CCustomScript *m_parentScript;
+  std::list<CCustomScript *> m_childScripts;
 
-        bool m_debugMode; // debug opcodes enabled
+  bool m_debugMode; // debug opcodes enabled
 
-        std::string m_scriptFileDir;
-        std::string m_scriptFileName;
-        std::string m_workDir;
+  std::string m_scriptFileDir;
+  std::string m_scriptFileName;
+  std::string m_workDir;
 
-    public:
-        inline SCRIPT_VAR* GetVarsPtr() { return LocalVar; }
-        inline bool IsOk() const { return m_ok; }
-        inline DWORD GetCodeSize() const { return m_codeSize; }
-        inline void SetCodeSize(DWORD size) { m_codeSize = size; }
-        inline DWORD GetCodeChecksum() const { return m_codeChecksum; }
-        inline void EnableSaving(bool en = true) { m_saveEnabled = en; }
-        inline void SetCompatibility(eCLEO_Version ver) { m_compatVer = ver; }
-        inline eCLEO_Version GetCompatibility() const { return m_compatVer; }
+public:
+  inline SCRIPT_VAR *GetVarsPtr() { return LocalVar; }
+  inline bool IsOk() const { return m_ok; }
+  inline DWORD GetCodeSize() const { return m_codeSize; }
+  inline void SetCodeSize(DWORD size) { m_codeSize = size; }
+  inline DWORD GetCodeChecksum() const { return m_codeChecksum; }
+  inline void EnableSaving(bool en = true) { m_saveEnabled = en; }
+  inline void SetCompatibility(eCLEO_Version ver) { m_compatVer = ver; }
+  inline eCLEO_Version GetCompatibility() const { return m_compatVer; }
 
-        CCustomScript(const char* szFileName, bool bIsMiss = false, CRunningScript* parent = nullptr, int label = 0);
-        CCustomScript(const CCustomScript&) = delete; // no copying
-        ~CCustomScript();
+  CCustomScript(const char *szFileName, bool bIsMiss = false,
+                CRunningScript *parent = nullptr, int label = 0);
+  CCustomScript(const CCustomScript &) = delete; // no copying
+  ~CCustomScript();
 
-        void AddScriptToList(CRunningScript** queuelist);
-        void RemoveScriptFromList(CRunningScript** queuelist);
+  void AddScriptToList(CRunningScript **queuelist);
+  void RemoveScriptFromList(CRunningScript **queuelist);
 
-        void ShutdownThisScript();
+  void ShutdownThisScript();
 
-        // debug related utils enabled?
-        bool GetDebugMode() const;
-        void SetDebugMode(bool enabled);
+  // debug related utils enabled?
+  bool GetDebugMode() const;
+  void SetDebugMode(bool enabled);
 
-        // absolute path to directory where script's source file is located
-        const char* GetScriptFileDir() const;
-        void SetScriptFileDir(const char* directory);
+  // absolute path to directory where script's source file is located
+  const char *GetScriptFileDir() const;
+  void SetScriptFileDir(const char *directory);
 
-        // filename with type extension of script's source file
-        const char* GetScriptFileName() const;
-        void SetScriptFileName(const char* filename);
+  // filename with type extension of script's source file
+  const char *GetScriptFileName() const;
+  void SetScriptFileName(const char *filename);
 
-        // absolute path to the script file
-        std::string GetScriptFileFullPath() const;
+  // absolute path to the script file
+  std::string GetScriptFileFullPath() const;
 
-        // current working directory of this script. Can be changed ith 0A99
-        const char* GetWorkDir() const;
-        void SetWorkDir(const char* directory);
+  // current working directory of this script. Can be changed ith 0A99
+  const char *GetWorkDir() const;
+  void SetWorkDir(const char *directory);
 
-        // create absolute file path
-        std::string ResolvePath(const char* path, const char* customWorkDir = nullptr) const;
+  // create absolute file path
+  std::string ResolvePath(const char *path,
+                          const char *customWorkDir = nullptr) const;
 
-        // get short info text about script
-        std::string GetInfoStr(bool currLineInfo = true) const;
-    };
-}
-
+  // get short info text about script
+  std::string GetInfoStr(bool currLineInfo = true) const;
+};
+} // namespace CLEO

--- a/source/CDebug.cpp
+++ b/source/CDebug.cpp
@@ -1,76 +1,75 @@
-#include "stdafx.h"
 #include "CDebug.h"
 #include "CleoBase.h"
-
+#include "stdafx.h"
 
 CDebug Debug;
 using namespace CLEO;
 
-void CDebug::Trace(CLEO::eLogLevel level, const char* msg)
-{
-    std::lock_guard<std::mutex> guard(mutex);
+void CDebug::Trace(CLEO::eLogLevel level, const char *msg) {
+  std::lock_guard<std::mutex> guard(mutex);
 
-    // output to console
+  // output to console
 #ifdef _DEBUG
-    OutputDebugString(msg);
-    OutputDebugString("\n");
+  OutputDebugString(msg);
+  OutputDebugString("\n");
 #endif
 
-    // censor user name in paths like "C:\Users\xxx\Documents..."
-    const char* UsersDir = "\\users\\";
-    std::string msgStr = msg;
-    StringToLower(msgStr);
-    auto usersDirPos = strstr(msgStr.c_str(), UsersDir);
-    if (usersDirPos != nullptr)
-    {
-        size_t userBegin = (size_t)(usersDirPos - msgStr.c_str()) + strlen(UsersDir);
-        
-        size_t userEnd = msgStr.find_first_of("\\/*\"<>:|?", userBegin); // till next path separator or any invalid filepath character
-        if (userEnd == std::string::npos)
-        {
-            userEnd = msgStr.length();
-        }
+  // censor user name in paths like "C:\Users\xxx\Documents..."
+  const char *UsersDir = "\\users\\";
+  std::string msgStr = msg;
+  StringToLower(msgStr);
+  auto usersDirPos = strstr(msgStr.c_str(), UsersDir);
+  if (usersDirPos != nullptr) {
+    size_t userBegin =
+        (size_t)(usersDirPos - msgStr.c_str()) + strlen(UsersDir);
 
-        msgStr = msg; // restore original case
-        msgStr.replace(userBegin, userEnd - userBegin, "[redacted]");
-        msg = msgStr.c_str();
+    size_t userEnd = msgStr.find_first_of(
+        "\\/*\"<>:|?", userBegin); // till next path separator or any invalid
+                                   // filepath character
+    if (userEnd == std::string::npos) {
+      userEnd = msgStr.length();
     }
 
-    // output to callbacks
-    if (CleoInstance.IsStarted())
-    {
-        for (void* func : CleoInstance.GetCallbacks(eCallbackId::Log))
-        {
-            typedef void WINAPI callback(eLogLevel, const char*);
-            ((callback*)func)(level, msg);
-        }
+    msgStr = msg; // restore original case
+    msgStr.replace(userBegin, userEnd - userBegin, "[redacted]");
+    msg = msgStr.c_str();
+  }
+
+  // output to callbacks
+  if (CleoInstance.IsStarted()) {
+    for (void *func : CleoInstance.GetCallbacks(eCallbackId::Log)) {
+      typedef void WINAPI callback(eLogLevel, const char *);
+      ((callback *)func)(level, msg);
+    }
+  }
+
+  // output to log file
+  if (m_hFile.good()) {
+    // time stamp
+    SYSTEMTIME t;
+    GetLocalTime(&t);
+    // void(__stdcall * GTA_GetLocalTime)(LPSYSTEMTIME lpSystemTime) =
+    // memory_pointer(0x0081E514); // use ingame function instead as
+    // GetLocalTime seems to be considered suspicious by some AV software
+    // GTA_GetLocalTime(&t);
+
+    char timestampStr[32];
+    sprintf_s(timestampStr, "%02d/%02d/%04d %02d:%02d:%02d.%03d ", t.wDay,
+              t.wMonth, t.wYear, t.wHour, t.wMinute, t.wSecond,
+              t.wMilliseconds);
+    m_hFile << timestampStr;
+
+    // add separator line if frame rendered since last log entry
+    if (lastFrame != CTimer::m_FrameCounter) {
+      m_hFile << std::endl << timestampStr;
+      lastFrame = CTimer::m_FrameCounter;
     }
 
-    // output to log file
-    if (m_hFile.good())
-    {
-        // time stamp
-        SYSTEMTIME t;
-        GetLocalTime(&t);
-        //void(__stdcall * GTA_GetLocalTime)(LPSYSTEMTIME lpSystemTime) = memory_pointer(0x0081E514); // use ingame function instead as GetLocalTime seems to be considered suspicious by some AV software
-        //GTA_GetLocalTime(&t);
+    // message
+    auto message = std::string(msg);
+    StringRemoveFormatting(message);
+    m_hFile << message.c_str();
 
-        char timestampStr[32];
-        sprintf_s(timestampStr, "%02d/%02d/%04d %02d:%02d:%02d.%03d ", t.wDay, t.wMonth, t.wYear, t.wHour, t.wMinute, t.wSecond, t.wMilliseconds);
-        m_hFile << timestampStr;
-
-        // add separator line if frame rendered since last log entry
-        if (lastFrame != CTimer::m_FrameCounter)
-        {
-            m_hFile << std::endl << timestampStr;
-            lastFrame = CTimer::m_FrameCounter;
-        }
-
-        // message
-        auto message = std::string(msg);
-        StringRemoveFormatting(message);
-        m_hFile << message.c_str();
-
-        m_hFile << std::endl;
-    }
+    m_hFile << std::endl;
+  }
 }

--- a/source/CDebug.h
+++ b/source/CDebug.h
@@ -1,32 +1,29 @@
 #pragma once
 #include <mutex>
 
-class CDebug
-{
+class CDebug {
 public:
-    CDebug() : m_hFile(Filepath_Log)
-    {
-        Trace(CLEO::eLogLevel::Default, "Log started.");
+  CDebug() : m_hFile(Filepath_Log) {
+    Trace(CLEO::eLogLevel::Default, "Log started.");
 
 #ifdef _DEBUG
-        CLEO::Trace(CLEO::eLogLevel::Default, "CLEO v%s DEBUG", CLEO_VERSION_STR);
+    CLEO::Trace(CLEO::eLogLevel::Default, "CLEO v%s DEBUG", CLEO_VERSION_STR);
 #else
-        CLEO::Trace(CLEO::eLogLevel::Default, "CLEO v%s", CLEO_VERSION_STR);
+    CLEO::Trace(CLEO::eLogLevel::Default, "CLEO v%s", CLEO_VERSION_STR);
 #endif
-    }
+  }
 
-    ~CDebug()
-    {
-        CLEO::Trace(CLEO::eLogLevel::Default, ""); // separator
-        CLEO::Trace(CLEO::eLogLevel::Default, "Log finished.");
-    }
-    
-    void Trace(CLEO::eLogLevel level, const char* msg);
-    
+  ~CDebug() {
+    CLEO::Trace(CLEO::eLogLevel::Default, ""); // separator
+    CLEO::Trace(CLEO::eLogLevel::Default, "Log finished.");
+  }
+
+  void Trace(CLEO::eLogLevel level, const char *msg);
+
 private:
-    unsigned int lastFrame = -1;
-    std::mutex mutex;
-    std::ofstream m_hFile;
- };
+  unsigned int lastFrame = -1;
+  std::mutex mutex;
+  std::ofstream m_hFile;
+};
 
 extern CDebug Debug;

--- a/source/CDmaFix.cpp
+++ b/source/CDmaFix.cpp
@@ -1,50 +1,47 @@
 #pragma once
-#include "stdafx.h"
 #include "CDmaFix.h"
 #include "CGameVersionManager.h"
 #include "CleoBase.h"
+#include "stdafx.h"
 
-namespace CLEO
-{
-    void CDmaFix::Inject(CCodeInjector& inj)
-    {
-        TRACE("Injecting DmaFix...");
-        CGameVersionManager& gvm = CleoInstance.VersionManager;
-        switch (gvm.GetGameVersion())
-        {
-        case GV_EU10:
-        case GV_US10:
-            inj.MemoryWrite<DWORD>(0x463CC5, 0x0824448B);
-            inj.MemoryWrite<BYTE>(0x463CC9, 0x90);
+namespace CLEO {
+void CDmaFix::Inject(CCodeInjector &inj) {
+  TRACE("Injecting DmaFix...");
+  CGameVersionManager &gvm = CleoInstance.VersionManager;
+  switch (gvm.GetGameVersion()) {
+  case GV_EU10:
+  case GV_US10:
+    inj.MemoryWrite<DWORD>(0x463CC5, 0x0824448B);
+    inj.MemoryWrite<BYTE>(0x463CC9, 0x90);
 
-            inj.Nop(0x4641C6, 3);
-            inj.Nop(0x4641E8, 3);
-            inj.Nop(0x4641FE, 3);
+    inj.Nop(0x4641C6, 3);
+    inj.Nop(0x4641E8, 3);
+    inj.Nop(0x4641FE, 3);
 
-            inj.Nop(0x46447F, 3);
-            inj.Nop(0x4644A1, 3);
-            inj.Nop(0x4644B7, 3);
-            break;
-        case GV_EU11:
-            inj.MemoryWrite<DWORD>(0x463D45, 0x0824448B);
-            inj.MemoryWrite<BYTE>(0x463D49, 0x90);
+    inj.Nop(0x46447F, 3);
+    inj.Nop(0x4644A1, 3);
+    inj.Nop(0x4644B7, 3);
+    break;
+  case GV_EU11:
+    inj.MemoryWrite<DWORD>(0x463D45, 0x0824448B);
+    inj.MemoryWrite<BYTE>(0x463D49, 0x90);
 
-            inj.Nop(0x464246, 3);
-            inj.Nop(0x464268, 3);
-            inj.Nop(0x46427E, 3);
+    inj.Nop(0x464246, 3);
+    inj.Nop(0x464268, 3);
+    inj.Nop(0x46427E, 3);
 
-            inj.Nop(0x4644FF, 3);
-            inj.Nop(0x464521, 3);
-            inj.Nop(0x464537, 3);
-            break;
-        case GV_STEAM:
-            inj.MemoryWrite<DWORD>(0x469390, 0x0824448B);
-            inj.MemoryWrite<BYTE>(0x469394, 0x90);
+    inj.Nop(0x4644FF, 3);
+    inj.Nop(0x464521, 3);
+    inj.Nop(0x464537, 3);
+    break;
+  case GV_STEAM:
+    inj.MemoryWrite<DWORD>(0x469390, 0x0824448B);
+    inj.MemoryWrite<BYTE>(0x469394, 0x90);
 
-            inj.Nop(0x4698F6, 3);
-            break;
-        default:
-            SHOW_ERROR("CDmaFix::Inject(): Unimplemented game version.");
-        }
-    }
+    inj.Nop(0x4698F6, 3);
+    break;
+  default:
+    SHOW_ERROR("CDmaFix::Inject(): Unimplemented game version.");
+  }
 }
+} // namespace CLEO

--- a/source/CDmaFix.h
+++ b/source/CDmaFix.h
@@ -1,11 +1,9 @@
 #pragma once
 #include "CCodeInjector.h"
 
-namespace CLEO
-{
-    class CDmaFix
-    {
-    public:
-        void Inject(CCodeInjector& inj);
-    };
-}
+namespace CLEO {
+class CDmaFix {
+public:
+  void Inject(CCodeInjector &inj);
+};
+} // namespace CLEO

--- a/source/CGameMenu.cpp
+++ b/source/CGameMenu.cpp
@@ -1,70 +1,73 @@
-#include "stdafx.h"
 #include "CGameMenu.h"
-#include "CleoBase.h"
 #include "CDebug.h"
+#include "CleoBase.h"
+#include "stdafx.h"
 
-namespace CLEO
-{
-    void CGameMenu::Inject(CCodeInjector& inj)
-    {
-        TRACE("Injecting MenuStatusNotifier...");
-        inj.ReplaceFunction(HOOK_DrawMenuBackground, CleoInstance.VersionManager.TranslateMemoryAddress(MA_CALL_CTEXTURE_DRAW_BG_RECT), &DrawMenuBackground_Orig);
-    }
-
-    void __fastcall CGameMenu::HOOK_DrawMenuBackground(CSprite2d* texture, int dummy, CRect* rect, RwRGBA *color)
-    {
-        CleoInstance.Start(CCleoInstance::InitStage::OnDraw); // late initialization
-
-        CleoInstance.GameMenu.DrawMenuBackground_Orig(texture, dummy, rect, color);
-
-        CFont::SetBackground(false, false);
-        CFont::SetWrapx(640.0f);
-        CFont::SetFontStyle(FONT_MENU);
-        CFont::SetProportional(true);
-        CFont::SetOrientation(ALIGN_LEFT);
-
-        CFont::SetColor({ 0xAD, 0xCE, 0xC4, 0xFF });
-        CFont::SetEdge(1);
-        CFont::SetDropColor({ 0x00, 0x00, 0x00, 0xFF });
-
-        const float fontSize = 0.5f / 448.0f;
-        const float aspect = (float)RsGlobal.maximumWidth / RsGlobal.maximumHeight;
-        const float subtextHeight = 0.75f; // factor of first line height
-        float sizeX = fontSize * 0.5f / aspect * RsGlobal.maximumWidth;
-        float sizeY = fontSize * RsGlobal.maximumHeight;
-
-        float posX = 25.0f * sizeX; // left margin
-        float posY = RsGlobal.maximumHeight - 15.0f * sizeY; // bottom margin
-
-        auto cs_count = CleoInstance.ScriptEngine.WorkingScriptsCount();
-        auto plugin_count = CleoInstance.PluginSystem.GetNumPlugins();
-        if (cs_count || plugin_count)
-        {
-            posY -= 15.0f * sizeY; // add space for bottom text
-        }
-
-        // draw CLEO version text
-        std::ostringstream text;
-        text << "CLEO v" << CLEO_VERSION_STR;
-#ifdef _DEBUG
-        text << " ~r~~h~DEBUG";
-#endif
-        CFont::SetScale(sizeX, sizeY);
-        CFont::PrintString(posX, posY - 15.0f * sizeY, text.str().c_str());
-
-        // draw plugins / scripts text
-        if (cs_count || plugin_count)
-        {
-            text.str(""); // clear
-            if (plugin_count) text << plugin_count << (plugin_count > 1 ? " plugins" : " plugin");
-            if (cs_count && plugin_count) text << " / ";
-            if (cs_count) text << cs_count << (cs_count > 1 ? " scripts" : " script");
-
-            posY += 15.0f * sizeY; // line feed
-            sizeX *= subtextHeight;
-            sizeY *= subtextHeight;
-            CFont::SetScale(sizeX, sizeY);
-            CFont::PrintString(posX, posY - 15.0f * sizeY, text.str().c_str());
-        }
-    }
+namespace CLEO {
+void CGameMenu::Inject(CCodeInjector &inj) {
+  TRACE("Injecting MenuStatusNotifier...");
+  inj.ReplaceFunction(HOOK_DrawMenuBackground,
+                      CleoInstance.VersionManager.TranslateMemoryAddress(
+                          MA_CALL_CTEXTURE_DRAW_BG_RECT),
+                      &DrawMenuBackground_Orig);
 }
+
+void __fastcall CGameMenu::HOOK_DrawMenuBackground(CSprite2d *texture,
+                                                   int dummy, CRect *rect,
+                                                   RwRGBA *color) {
+  CleoInstance.Start(CCleoInstance::InitStage::OnDraw); // late initialization
+
+  CleoInstance.GameMenu.DrawMenuBackground_Orig(texture, dummy, rect, color);
+
+  CFont::SetBackground(false, false);
+  CFont::SetWrapx(640.0f);
+  CFont::SetFontStyle(FONT_MENU);
+  CFont::SetProportional(true);
+  CFont::SetOrientation(ALIGN_LEFT);
+
+  CFont::SetColor({0xAD, 0xCE, 0xC4, 0xFF});
+  CFont::SetEdge(1);
+  CFont::SetDropColor({0x00, 0x00, 0x00, 0xFF});
+
+  const float fontSize = 0.5f / 448.0f;
+  const float aspect = (float)RsGlobal.maximumWidth / RsGlobal.maximumHeight;
+  const float subtextHeight = 0.75f; // factor of first line height
+  float sizeX = fontSize * 0.5f / aspect * RsGlobal.maximumWidth;
+  float sizeY = fontSize * RsGlobal.maximumHeight;
+
+  float posX = 25.0f * sizeX;                          // left margin
+  float posY = RsGlobal.maximumHeight - 15.0f * sizeY; // bottom margin
+
+  auto cs_count = CleoInstance.ScriptEngine.WorkingScriptsCount();
+  auto plugin_count = CleoInstance.PluginSystem.GetNumPlugins();
+  if (cs_count || plugin_count) {
+    posY -= 15.0f * sizeY; // add space for bottom text
+  }
+
+  // draw CLEO version text
+  std::ostringstream text;
+  text << "CLEO v" << CLEO_VERSION_STR;
+#ifdef _DEBUG
+  text << " ~r~~h~DEBUG";
+#endif
+  CFont::SetScale(sizeX, sizeY);
+  CFont::PrintString(posX, posY - 15.0f * sizeY, text.str().c_str());
+
+  // draw plugins / scripts text
+  if (cs_count || plugin_count) {
+    text.str(""); // clear
+    if (plugin_count)
+      text << plugin_count << (plugin_count > 1 ? " plugins" : " plugin");
+    if (cs_count && plugin_count)
+      text << " / ";
+    if (cs_count)
+      text << cs_count << (cs_count > 1 ? " scripts" : " script");
+
+    posY += 15.0f * sizeY; // line feed
+    sizeX *= subtextHeight;
+    sizeY *= subtextHeight;
+    CFont::SetScale(sizeX, sizeY);
+    CFont::PrintString(posX, posY - 15.0f * sizeY, text.str().c_str());
+  }
+}
+} // namespace CLEO

--- a/source/CGameMenu.h
+++ b/source/CGameMenu.h
@@ -1,15 +1,16 @@
 #pragma once
 #include "CCodeInjector.h"
 
-namespace CLEO
-{
-    class CGameMenu
-    {
-    public:
-        void Inject(CCodeInjector& inj);
+namespace CLEO {
+class CGameMenu {
+public:
+  void Inject(CCodeInjector &inj);
 
-    private:
-        static void __fastcall HOOK_DrawMenuBackground(CSprite2d* texture, int dummy, CRect* rect, RwRGBA* color);
-        void(__fastcall* DrawMenuBackground_Orig)(CSprite2d* texture, int dummy, CRect* rect, RwRGBA* color) = nullptr;
-    };
-}
+private:
+  static void __fastcall HOOK_DrawMenuBackground(CSprite2d *texture, int dummy,
+                                                 CRect *rect, RwRGBA *color);
+  void(__fastcall *DrawMenuBackground_Orig)(CSprite2d *texture, int dummy,
+                                            CRect *rect,
+                                            RwRGBA *color) = nullptr;
+};
+} // namespace CLEO

--- a/source/CGameVersionManager.cpp
+++ b/source/CGameVersionManager.cpp
@@ -1,61 +1,85 @@
-#include "stdafx.h"
 #include "CGameVersionManager.h"
 #include "CScriptEngine.h"
+#include "stdafx.h"
 
-namespace CLEO
-{
-    memory_pointer MemoryAddresses[MA_TOTAL][GV_TOTAL] =
-    {
-        // GV_US10,	    GV_US11,	GV_EU10,	GV_EU11,	GV_STEAM
-        { 0x0053E981,	memory_und, 0x0053E981, 0x0053EE21, 0x00551174 },		// MA_CALL_UPDATE_GAME_LOGICS,
+namespace CLEO {
+memory_pointer MemoryAddresses[MA_TOTAL][GV_TOTAL] = {
+    // GV_US10,	    GV_US11,	GV_EU10,	GV_EU11,	GV_STEAM
+    {0x0053E981, memory_und, 0x0053E981, 0x0053EE21,
+     0x00551174}, // MA_CALL_UPDATE_GAME_LOGICS,
 
-        // GV_US10,	    GV_US11,	GV_EU10,	GV_EU11,	GV_STEAM
-        { 0x0057B9FD,	memory_und, 0x0057B9FD, 0x0057BF71, 0x00591379 },		// MA_CALL_CTEXTURE_DRAW_BG_RECT,
+    // GV_US10,	    GV_US11,	GV_EU10,	GV_EU11,	GV_STEAM
+    {0x0057B9FD, memory_und, 0x0057B9FD, 0x0057BF71,
+     0x00591379}, // MA_CALL_CTEXTURE_DRAW_BG_RECT,
 
-        // GV_US10,		GV_US11,	GV_EU10,	GV_EU11,	GV_STEAM
-        { 0x0044CA44,	memory_und, memory_und, memory_und, memory_und },		// MA_SCM_BLOCK_REF,
-        { 0x004899D7,	memory_und, memory_und, memory_und, memory_und },		// MA_MISSION_BLOCK_REF,
-        { 0x0053BDD7,	memory_und, 0x0053BDD7, memory_und, 0x0054DD49 },		// MA_CALL_INIT_SCM1,
-        { 0x005BA340,	memory_und, 0x005BA340, memory_und, 0x005D8EE9 },		// MA_CALL_INIT_SCM2,
-        { 0x005D4FD7,	memory_und, 0x005D4FD7, 0x005D57B7, 0x005F1777 },		// MA_CALL_INIT_SCM3,
-        { 0x005D14D5,	memory_und, 0x005D14D5, 0x005D157C, 0x005EDBD4 },		// MA_CALL_SAVE_SCM_DATA,
-        { 0x005D18F0,	memory_und, 0x005D18F0, 0x005D20D0, 0x005EE017 },		// MA_CALL_LOAD_SCM_DATA,
-        { 0x0046A21B,	memory_und,	0x0046A21B, 0x0046AE9B, 0x0046F9A8 },		// MA_CALL_PROCESS_SCRIPT
-        { 0x0058FCE4,	memory_und, 0x0058FCE4, 0x005904B4, 0x0059E73C },		// MA_CALL_DRAW_SCRIPT_TEXTS_BEFORE_FADE
-        { 0x0058D552,	memory_und, 0x0058D552, 0x0058DD22, 0x0059BAD4 },		// MA_CALL_DRAW_SCRIPT_TEXTS_AFTER_FADE
-        { 0x00748E6B,	memory_und, memory_und, memory_und, memory_und },		// MA_CALL_GAME_SHUTDOWN TODO: find for other versions
-        { 0x0053C758,	memory_und, memory_und, memory_und, memory_und },		// MA_CALL_GAME_RESTART_1 TODO: find for other versions
-        { 0x00748E04,	memory_und, memory_und, memory_und, memory_und },		// MA_CALL_GAME_RESTART_2 TODO: find for other versions
-        { 0x00748E3E,	memory_und, memory_und, memory_und, memory_und },		// MA_CALL_GAME_RESTART_3 TODO: find for other versions
-        { 0x0053EBE4,	memory_und, memory_und, memory_und, memory_und },		// MA_CALL_DEBUG_DISPLAY_TEXT_BUFFER_IDLE TODO: find for other versions
-        { 0x0053E86C,	memory_und, memory_und, memory_und, memory_und },		// MA_CALL_DEBUG_DISPLAY_TEXT_BUFFER_FRONTEND TODO: find for other versions
+    // GV_US10,		GV_US11,	GV_EU10,	GV_EU11,	GV_STEAM
+    {0x0044CA44, memory_und, memory_und, memory_und,
+     memory_und}, // MA_SCM_BLOCK_REF,
+    {0x004899D7, memory_und, memory_und, memory_und,
+     memory_und}, // MA_MISSION_BLOCK_REF,
+    {0x0053BDD7, memory_und, 0x0053BDD7, memory_und,
+     0x0054DD49}, // MA_CALL_INIT_SCM1,
+    {0x005BA340, memory_und, 0x005BA340, memory_und,
+     0x005D8EE9}, // MA_CALL_INIT_SCM2,
+    {0x005D4FD7, memory_und, 0x005D4FD7, 0x005D57B7,
+     0x005F1777}, // MA_CALL_INIT_SCM3,
+    {0x005D14D5, memory_und, 0x005D14D5, 0x005D157C,
+     0x005EDBD4}, // MA_CALL_SAVE_SCM_DATA,
+    {0x005D18F0, memory_und, 0x005D18F0, 0x005D20D0,
+     0x005EE017}, // MA_CALL_LOAD_SCM_DATA,
+    {0x0046A21B, memory_und, 0x0046A21B, 0x0046AE9B,
+     0x0046F9A8}, // MA_CALL_PROCESS_SCRIPT
+    {0x0058FCE4, memory_und, 0x0058FCE4, 0x005904B4,
+     0x0059E73C}, // MA_CALL_DRAW_SCRIPT_TEXTS_BEFORE_FADE
+    {0x0058D552, memory_und, 0x0058D552, 0x0058DD22,
+     0x0059BAD4}, // MA_CALL_DRAW_SCRIPT_TEXTS_AFTER_FADE
+    {0x00748E6B, memory_und, memory_und, memory_und,
+     memory_und}, // MA_CALL_GAME_SHUTDOWN TODO: find for other versions
+    {0x0053C758, memory_und, memory_und, memory_und,
+     memory_und}, // MA_CALL_GAME_RESTART_1 TODO: find for other versions
+    {0x00748E04, memory_und, memory_und, memory_und,
+     memory_und}, // MA_CALL_GAME_RESTART_2 TODO: find for other versions
+    {0x00748E3E, memory_und, memory_und, memory_und,
+     memory_und}, // MA_CALL_GAME_RESTART_3 TODO: find for other versions
+    {0x0053EBE4, memory_und, memory_und, memory_und,
+     memory_und}, // MA_CALL_DEBUG_DISPLAY_TEXT_BUFFER_IDLE TODO: find for other
+                  // versions
+    {0x0053E86C, memory_und, memory_und, memory_und,
+     memory_und}, // MA_CALL_DEBUG_DISPLAY_TEXT_BUFFER_FRONTEND TODO: find for
+                  // other versions
 
-        // GV_US10,	    GV_US11,	GV_EU10,	GV_EU11,	GV_STEAM
-        { 0x00469FEE,	memory_und, 0x00469FEE, 0x0046A06E, 0x0046F75C },		// MA_OPCODE_HANDLER_REF_1,
-        { 0x00469EF0,	memory_und, memory_und, memory_und, memory_und },		// MA_OPCODE_HANDLER_REF_2,
+    // GV_US10,	    GV_US11,	GV_EU10,	GV_EU11,	GV_STEAM
+    {0x00469FEE, memory_und, 0x00469FEE, 0x0046A06E,
+     0x0046F75C}, // MA_OPCODE_HANDLER_REF_1,
+    {0x00469EF0, memory_und, memory_und, memory_und,
+     memory_und}, // MA_OPCODE_HANDLER_REF_2,
 
-        // GV_US10,	    GV_US11,	GV_EU10,	GV_EU11,	GV_STEAM
-        { 0x007487A8,	memory_und, 0x007487F8, 0x0074907C, 0x0078276D },		// MA_CALL_CREATE_MAIN_WINDOW,
-    };
+    // GV_US10,	    GV_US11,	GV_EU10,	GV_EU11,	GV_STEAM
+    {0x007487A8, memory_und, 0x007487F8, 0x0074907C,
+     0x0078276D}, // MA_CALL_CREATE_MAIN_WINDOW,
+};
 
-    eGameVersion DetermineGameVersion()
-    {
-        MemGrantAccess(0x8A6168, sizeof(DWORD));
-        if (MemRead<DWORD>(0x8A6168) == 0x8523A0) return GV_EU11;
+eGameVersion DetermineGameVersion() {
+  MemGrantAccess(0x8A6168, sizeof(DWORD));
+  if (MemRead<DWORD>(0x8A6168) == 0x8523A0)
+    return GV_EU11;
 
-        MemGrantAccess(0x8A4004, sizeof(DWORD));
-        if (MemRead<DWORD>(0x8A4004) == 0x8339CA) return GV_US10;
-        if (MemRead<DWORD>(0x8A4004) == 0x833A0A) return GV_EU10;
+  MemGrantAccess(0x8A4004, sizeof(DWORD));
+  if (MemRead<DWORD>(0x8A4004) == 0x8339CA)
+    return GV_US10;
+  if (MemRead<DWORD>(0x8A4004) == 0x833A0A)
+    return GV_EU10;
 
-        MemGrantAccess(0x913000, sizeof(DWORD));
-        if (MemRead<DWORD>(0x913000) == 0x8A5B0C) return GV_STEAM;
+  MemGrantAccess(0x913000, sizeof(DWORD));
+  if (MemRead<DWORD>(0x913000) == 0x8A5B0C)
+    return GV_STEAM;
 
-        return GV_UNK;
-    }
-
-    // converts memory address' identifier to actual memory pointer
-    memory_pointer CGameVersionManager::TranslateMemoryAddress(eMemoryAddress addrId) const
-    {
-        return MemoryAddresses[addrId][GetGameVersion()];
-    }
+  return GV_UNK;
 }
+
+// converts memory address' identifier to actual memory pointer
+memory_pointer
+CGameVersionManager::TranslateMemoryAddress(eMemoryAddress addrId) const {
+  return MemoryAddresses[addrId][GetGameVersion()];
+}
+} // namespace CLEO

--- a/source/CGameVersionManager.h
+++ b/source/CGameVersionManager.h
@@ -1,81 +1,69 @@
 #pragma once
 #include "CCodeInjector.h"
 
-namespace CLEO
-{
-    // returned by 0DD5: get_platform opcode
-    enum ePlatform
-    {
-        PLATFORM_NONE,
-        PLATFORM_ANDROID,
-        PLATFORM_PSP,
-        PLATFORM_IOS,
-        PLATFORM_FOS,
-        PLATFORM_XBOX,
-        PLATFORM_PS2,
-        PLATFORM_PS3,
-        PLATFORM_MAC,
-        PLATFORM_WINDOWS
-    };
+namespace CLEO {
+// returned by 0DD5: get_platform opcode
+enum ePlatform {
+  PLATFORM_NONE,
+  PLATFORM_ANDROID,
+  PLATFORM_PSP,
+  PLATFORM_IOS,
+  PLATFORM_FOS,
+  PLATFORM_XBOX,
+  PLATFORM_PS2,
+  PLATFORM_PS3,
+  PLATFORM_MAC,
+  PLATFORM_WINDOWS
+};
 
-    // determines the list of memory adresses, that can be translated 
-    // considering to game version
-    enum eMemoryAddress
-    {
-        // UpdateGameLogics
-        MA_CALL_UPDATE_GAME_LOGICS,
+// determines the list of memory adresses, that can be translated
+// considering to game version
+enum eMemoryAddress {
+  // UpdateGameLogics
+  MA_CALL_UPDATE_GAME_LOGICS,
 
-        // MenuStatusNotifier
-        MA_CALL_CTEXTURE_DRAW_BG_RECT,
+  // MenuStatusNotifier
+  MA_CALL_CTEXTURE_DRAW_BG_RECT,
 
-        // ScriptEngine
-        MA_SCM_BLOCK_REF,
-        MA_MISSION_BLOCK_REF,
-        MA_CALL_INIT_SCM1,
-        MA_CALL_INIT_SCM2,
-        MA_CALL_INIT_SCM3,
-        MA_CALL_SAVE_SCM_DATA,
-        MA_CALL_LOAD_SCM_DATA,
-        MA_CALL_PROCESS_SCRIPT,
-        MA_CALL_DRAW_SCRIPT_TEXTS_BEFORE_FADE,
-        MA_CALL_DRAW_SCRIPT_TEXTS_AFTER_FADE,
-        MA_CALL_GAME_SHUTDOWN,
-        MA_CALL_GAME_RESTART_1,
-        MA_CALL_GAME_RESTART_2,
-        MA_CALL_GAME_RESTART_3,
-        MA_CALL_DEBUG_DISPLAY_TEXT_BUFFER_IDLE,
-        MA_CALL_DEBUG_DISPLAY_TEXT_BUFFER_FRONTEND,
+  // ScriptEngine
+  MA_SCM_BLOCK_REF,
+  MA_MISSION_BLOCK_REF,
+  MA_CALL_INIT_SCM1,
+  MA_CALL_INIT_SCM2,
+  MA_CALL_INIT_SCM3,
+  MA_CALL_SAVE_SCM_DATA,
+  MA_CALL_LOAD_SCM_DATA,
+  MA_CALL_PROCESS_SCRIPT,
+  MA_CALL_DRAW_SCRIPT_TEXTS_BEFORE_FADE,
+  MA_CALL_DRAW_SCRIPT_TEXTS_AFTER_FADE,
+  MA_CALL_GAME_SHUTDOWN,
+  MA_CALL_GAME_RESTART_1,
+  MA_CALL_GAME_RESTART_2,
+  MA_CALL_GAME_RESTART_3,
+  MA_CALL_DEBUG_DISPLAY_TEXT_BUFFER_IDLE,
+  MA_CALL_DEBUG_DISPLAY_TEXT_BUFFER_FRONTEND,
 
-        // CustomOpcodeSystem
-        MA_OPCODE_HANDLER_REF_1,
-        MA_OPCODE_HANDLER_REF_2,
+  // CustomOpcodeSystem
+  MA_OPCODE_HANDLER_REF_1,
+  MA_OPCODE_HANDLER_REF_2,
 
-        MA_CALL_CREATE_MAIN_WINDOW,
+  MA_CALL_CREATE_MAIN_WINDOW,
 
-        MA_TOTAL,
-    };
+  MA_TOTAL,
+};
 
-    eGameVersion DetermineGameVersion();
+eGameVersion DetermineGameVersion();
 
-    class CGameVersionManager
-    {
-        eGameVersion m_eVersion;
+class CGameVersionManager {
+  eGameVersion m_eVersion;
 
-    public:
-        CGameVersionManager()
-        {
-            m_eVersion = DetermineGameVersion();
-        }
+public:
+  CGameVersionManager() { m_eVersion = DetermineGameVersion(); }
 
-        ~CGameVersionManager()
-        {
-        }
+  ~CGameVersionManager() {}
 
-        eGameVersion GetGameVersion() const
-        {
-            return m_eVersion;
-        }
+  eGameVersion GetGameVersion() const { return m_eVersion; }
 
-        memory_pointer TranslateMemoryAddress(eMemoryAddress addrId) const;
-    };
-}
+  memory_pointer TranslateMemoryAddress(eMemoryAddress addrId) const;
+};
+} // namespace CLEO

--- a/source/CModuleSystem.cpp
+++ b/source/CModuleSystem.cpp
@@ -1,332 +1,295 @@
-#include "stdafx.h"
-#include "CleoBase.h"
 #include "CModuleSystem.h"
+#include "CleoBase.h"
 #include "FileEnumerator.h"
 #include "ScriptUtils.h"
-
+#include "stdafx.h"
 
 using namespace CLEO;
 
-void CModuleSystem::Clear()
-{
-	modules.clear();
+void CModuleSystem::Clear() { modules.clear(); }
+
+const ScriptDataRef CModuleSystem::GetExport(std::string modulePath,
+                                             std::string_view exportName) {
+  NormalizePath(modulePath);
+
+  auto &it = modules.find(modulePath);
+  if (it == modules.end()) // module not loaded yet?
+  {
+    if (!LoadFile(modulePath.c_str())) {
+      return {};
+    }
+
+    // check if available now
+    it = modules.find(modulePath);
+    if (it == modules.end()) {
+      return {};
+    }
+  }
+  auto &module = it->second;
+
+  auto e = module.GetExport(std::string(exportName));
+  return e;
 }
 
-const ScriptDataRef CModuleSystem::GetExport(std::string modulePath, std::string_view exportName)
-{
-	NormalizePath(modulePath);
+bool CModuleSystem::LoadFile(const char *path) {
+  std::string normalizedPath(path);
+  NormalizePath(normalizedPath);
 
-	auto& it = modules.find(modulePath);
-	if (it == modules.end()) // module not loaded yet?
-	{
-		if (!LoadFile(modulePath.c_str()))
-		{
-			return {};
-		}
+  if (!modules[normalizedPath].LoadFromFile(normalizedPath.c_str())) {
+    return false;
+  }
 
-		// check if available now
-		it = modules.find(modulePath);
-		if (it == modules.end())
-		{
-			return {};
-		}
-	}
-	auto& module = it->second;
-
-	auto e = module.GetExport(std::string(exportName));
-	return e;
+  return true;
 }
 
-bool CModuleSystem::LoadFile(const char* path)
-{
-	std::string normalizedPath(path);
-	NormalizePath(normalizedPath);
+bool CModuleSystem::LoadDirectory(const char *path) {
+  bool result = true;
+  FilesWalk(path, ".s", [&](const char *fullPath, const char *filename) {
+    result &= LoadFile(fullPath);
+  });
 
-	if (!modules[normalizedPath].LoadFromFile(normalizedPath.c_str()))
-	{
-		return false;
-	}
-
-	return true;
+  return result;
 }
 
-bool CModuleSystem::LoadDirectory(const char* path)
-{
-	bool result = true;
-	FilesWalk(path, ".s", [&](const char* fullPath, const char* filename)
-	{
-		result &= LoadFile(fullPath);
-	});
-
-	return result;
+bool CModuleSystem::LoadCleoModules() {
+  const auto path = FS::path(Filepath_Cleo).append("cleo_modules").string();
+  return LoadDirectory(path.c_str());
 }
 
-bool CModuleSystem::LoadCleoModules()
-{
-	const auto path = FS::path(Filepath_Cleo).append("cleo_modules").string();
-	return LoadDirectory(path.c_str());
+void CModuleSystem::NormalizePath(std::string &path) {
+  for (char &c : path) {
+    // standarize path separators
+    if (c == '/')
+      c = '\\';
+
+    // lower case
+    c = std::tolower(c);
+  };
 }
 
-void CModuleSystem::NormalizePath(std::string& path)
-{
-	for (char& c : path)
-	{
-		// standarize path separators
-		if (c == '/')
-			c = '\\';
-
-		// lower case
-		c = std::tolower(c);
-	};
+void CModuleSystem::CModule::Clear() {
+  filepath.clear();
+  data.clear();
+  exports.clear();
 }
 
-void CModuleSystem::CModule::Clear()
-{
-	filepath.clear();
-	data.clear();
-	exports.clear();
+const char *CModuleSystem::CModule::GetFilepath() const {
+  return filepath.c_str();
 }
 
-const char* CModuleSystem::CModule::GetFilepath() const
-{
-	return filepath.c_str();
-}
+bool CModuleSystem::CModule::LoadFromFile(const char *path) {
+  Clear();
+  filepath = path;
 
-bool CModuleSystem::CModule::LoadFromFile(const char* path)
-{
-	Clear();
-	filepath = path;
+  std::ifstream file(path, std::ios::binary);
+  if (!file.good()) {
+    LOG_WARNING(0, "Failed to open module file '%s'", path);
+    return false;
+  }
 
-	std::ifstream file(path, std::ios::binary);
-	if (!file.good())
-	{
-		LOG_WARNING(0, "Failed to open module file '%s'", path);
-		return false;
-	}
+  const BYTE Segment_First_Instruction[] = {0x02, 0x00,
+                                            0x01}; // jump, param type
+  const BYTE Segment_Magic[] = {0xFF, 0x7F, 0xFE, 0x00,
+                                0x00}; // Rockstar custom header magic
+  const char Header_Signature_Module_Exports[] = {
+      'E', 'X', 'P', 'T'}; // CLEO's module header signature
 
-	const BYTE Segment_First_Instruction[] = { 0x02, 0x00, 0x01 }; // jump, param type
-	const BYTE Segment_Magic[] = { 0xFF, 0x7F, 0xFE, 0x00, 0x00 }; // Rockstar custom header magic
-	const char Header_Signature_Module_Exports[] = { 'E', 'X', 'P', 'T' }; // CLEO's module header signature
-
-	// read first instruction
+  // read first instruction
 #pragma pack(push, 1)
-	struct
-	{
-		char firstInstruction[3];
-		int jumpAddress;
-		char magic[5];
-	} segment;
+  struct {
+    char firstInstruction[3];
+    int jumpAddress;
+    char magic[5];
+  } segment;
 #pragma pack(pop)
 
-	file.read((char*)&segment, sizeof(segment));
-	if (file.fail())
-	{
-		LOG_WARNING(0, "Module '%s' file header read error", path);
-		return false;
-	}
+  file.read((char *)&segment, sizeof(segment));
+  if (file.fail()) {
+    LOG_WARNING(0, "Module '%s' file header read error", path);
+    return false;
+  }
 
-	// verify segment data
-	if (std::memcmp(segment.firstInstruction, Segment_First_Instruction, sizeof(Segment_First_Instruction)) != 0 ||
-		segment.jumpAddress >= 0 || // jump labels should be negative values
-		std::memcmp(segment.magic, Segment_Magic, sizeof(Segment_Magic)) != 0) // not a custom header
-	{
-		LOG_WARNING(0, "Module '%s' load error. Custom segment not present", path);
-		return false;
-	}
-	segment.jumpAddress = abs(segment.jumpAddress); // turn label into actual file offset
+  // verify segment data
+  if (std::memcmp(segment.firstInstruction, Segment_First_Instruction,
+                  sizeof(Segment_First_Instruction)) != 0 ||
+      segment.jumpAddress >= 0 || // jump labels should be negative values
+      std::memcmp(segment.magic, Segment_Magic, sizeof(Segment_Magic)) !=
+          0) // not a custom header
+  {
+    LOG_WARNING(0, "Module '%s' load error. Custom segment not present", path);
+    return false;
+  }
+  segment.jumpAddress =
+      abs(segment.jumpAddress); // turn label into actual file offset
 
-	// process custom headers
+  // process custom headers
 #pragma pack(push, 1)
-	struct
-	{
-		char signature[4];
-		int size;
-	} header;
+  struct {
+    char signature[4];
+    int size;
+  } header;
 #pragma pack(pop)
 
-	bool result = false; // no custom header found yet
-	while (file.tellg() < segment.jumpAddress)
-	{
-		file.read((char*)&header, sizeof(header));
-		if (file.fail() ||
-			file.tellg() > segment.jumpAddress) // read past the segment end
-		{ 
-			LOG_WARNING(0, "Module '%s' load error. Invalid custom header", path);
-			return false;
-		}
+  bool result = false; // no custom header found yet
+  while (file.tellg() < segment.jumpAddress) {
+    file.read((char *)&header, sizeof(header));
+    if (file.fail() ||
+        file.tellg() > segment.jumpAddress) // read past the segment end
+    {
+      LOG_WARNING(0, "Module '%s' load error. Invalid custom header", path);
+      return false;
+    }
 
-		auto headerEndPos = file.tellg();
-		headerEndPos += header.size;
+    auto headerEndPos = file.tellg();
+    headerEndPos += header.size;
 
-		// CLEO Module Exports
-		if (std::memcmp(header.signature, Header_Signature_Module_Exports, sizeof(Header_Signature_Module_Exports)) == 0)
-		{
-			if (headerEndPos > segment.jumpAddress)
-			{
-				LOG_WARNING(0, "Module '%s' load error. Invalid size of exports header", path);
-				return false;
-			}
+    // CLEO Module Exports
+    if (std::memcmp(header.signature, Header_Signature_Module_Exports,
+                    sizeof(Header_Signature_Module_Exports)) == 0) {
+      if (headerEndPos > segment.jumpAddress) {
+        LOG_WARNING(0, "Module '%s' load error. Invalid size of exports header",
+                    path);
+        return false;
+      }
 
-			while (true)
-			{
-				ModuleExport e;
+      while (true) {
+        ModuleExport e;
 
-				if (!e.LoadFromFile(file) ||
-					!file.good() ||
-					file.tellg() > headerEndPos)
-				{
-					if (e.name.empty())
-					{
-						LOG_WARNING(0, "Module '%s' export load error.", path);
-					}
-					else
-					{
-						LOG_WARNING(0, "Module's '%s' export '%s' load error.", path, e.name.c_str());
-					}
-					return false;
-				}
+        if (!e.LoadFromFile(file) || !file.good() ||
+            file.tellg() > headerEndPos) {
+          if (e.name.empty()) {
+            LOG_WARNING(0, "Module '%s' export load error.", path);
+          } else {
+            LOG_WARNING(0, "Module's '%s' export '%s' load error.", path,
+                        e.name.c_str());
+          }
+          return false;
+        }
 
-				exports[e.name] = std::move(e); // move to container
-				result = true; // something useful loaded
+        exports[e.name] = std::move(e); // move to container
+        result = true;                  // something useful loaded
 
-				if (file.tellg() == headerEndPos)
-				{
-					break; // all exports done
-				}
-			}
-		}
-		else // other unknown header type
-		{
-			file.seekg(headerEndPos, file.beg);
-			if (file.fail())
-			{
-				LOG_WARNING(0, "Module '%s' load error. Error while skipping unknown header type", path);
-				return false;
-			}
-		}
-	}
+        if (file.tellg() == headerEndPos) {
+          break; // all exports done
+        }
+      }
+    } else // other unknown header type
+    {
+      file.seekg(headerEndPos, file.beg);
+      if (file.fail()) {
+        LOG_WARNING(
+            0,
+            "Module '%s' load error. Error while skipping unknown header type",
+            path);
+        return false;
+      }
+    }
+  }
 
-	if (!file.good())
-	{
-		LOG_WARNING(0, "Module '%s' read error", path);
-		return false;
-	}
+  if (!file.good()) {
+    LOG_WARNING(0, "Module '%s' read error", path);
+    return false;
+  }
 
-	if (!result) // no usable elements found. No point to keeping this module
-	{
-		LOG_WARNING(0, "Module '%s' skipped. Nothing found", path);
-		return false;
-	}
+  if (!result) // no usable elements found. No point to keeping this module
+  {
+    LOG_WARNING(0, "Module '%s' skipped. Nothing found", path);
+    return false;
+  }
 
-	// get file size
-	file.seekg(0, file.end);
-	auto size = (size_t)file.tellg();
-	file.seekg(0, file.beg);
+  // get file size
+  file.seekg(0, file.end);
+  auto size = (size_t)file.tellg();
+  file.seekg(0, file.beg);
 
-	// store file data
-	data.resize(size);
-	file.read(data.data(), size);
-	if (file.fail())
-	{
-		return false;
-	}
+  // store file data
+  data.resize(size);
+  file.read(data.data(), size);
+  if (file.fail()) {
+    return false;
+  }
 
-	// cut Sanny extra info if present
-	auto infoSize = GetExtraInfoSize((BYTE*)data.data(), data.size());
-	if (infoSize)
-	{
-		data.resize(data.size() - infoSize);
-	}
+  // cut Sanny extra info if present
+  auto infoSize = GetExtraInfoSize((BYTE *)data.data(), data.size());
+  if (infoSize) {
+    data.resize(data.size() - infoSize);
+  }
 
-	return true;
+  return true;
 }
 
-const ScriptDataRef CModuleSystem::CModule::GetExport(std::string name)
-{
-	ModuleExport::NormalizeName(name);
+const ScriptDataRef CModuleSystem::CModule::GetExport(std::string name) {
+  ModuleExport::NormalizeName(name);
 
-	auto& it = exports.find(name);
-	if (it == exports.end())
-	{
-		return {};
-	}
-	auto& exp = it->second;
+  auto &it = exports.find(name);
+  if (it == exports.end()) {
+    return {};
+  }
+  auto &exp = it->second;
 
-	return { data.data(), data.size(), exp.offset };
+  return {data.data(), data.size(), exp.offset};
 }
 
-void CModuleSystem::CModule::ModuleExport::Clear()
-{
-	name.clear();
-	offset = 0;
+void CModuleSystem::CModule::ModuleExport::Clear() {
+  name.clear();
+  offset = 0;
 }
 
-bool CModuleSystem::CModule::ModuleExport::LoadFromFile(std::ifstream& file)
-{
-	if (!file.good())
-	{
-		return false;
-	}
+bool CModuleSystem::CModule::ModuleExport::LoadFromFile(std::ifstream &file) {
+  if (!file.good()) {
+    return false;
+  }
 
-	// name
-	std::getline(file, name, '\0');
-	if (file.fail() || name.length() >= 0xFF)
-	{
-		return false;
-	}
-	NormalizeName(name);
+  // name
+  std::getline(file, name, '\0');
+  if (file.fail() || name.length() >= 0xFF) {
+    return false;
+  }
+  NormalizeName(name);
 
-	// address
-	file.read((char*)&offset, 4);
-	if (file.fail())
-	{
-		return false;
-	}
+  // address
+  file.read((char *)&offset, 4);
+  if (file.fail()) {
+    return false;
+  }
 
-	// input arg count
-	unsigned char inParamCount;
-	file.read((char*)&inParamCount, 1);
-	if (file.fail())
-	{
-		return false;
-	}
+  // input arg count
+  unsigned char inParamCount;
+  file.read((char *)&inParamCount, 1);
+  if (file.fail()) {
+    return false;
+  }
 
-	// skip input argument types info
-	file.seekg(inParamCount, file.cur);
-	if (file.fail())
-	{
-		return false;
-	}
+  // skip input argument types info
+  file.seekg(inParamCount, file.cur);
+  if (file.fail()) {
+    return false;
+  }
 
-	// return value count
-	unsigned char outParamCount;
-	file.read((char*)&outParamCount, 1);
-	if (file.fail())
-	{
-		return false;
-	}
+  // return value count
+  unsigned char outParamCount;
+  file.read((char *)&outParamCount, 1);
+  if (file.fail()) {
+    return false;
+  }
 
-	// skip return value types info
-	file.seekg(outParamCount, file.cur);
-	if (file.fail())
-	{
-		return false;
-	}
+  // skip return value types info
+  file.seekg(outParamCount, file.cur);
+  if (file.fail()) {
+    return false;
+  }
 
-	// skip flags (1 byte) and address (4 bytes)
-	file.seekg(5, file.cur);
-	if (file.fail())
-	{
-		return false;
-	}
+  // skip flags (1 byte) and address (4 bytes)
+  file.seekg(5, file.cur);
+  if (file.fail()) {
+    return false;
+  }
 
-	return true; // done
+  return true; // done
 }
 
-void CModuleSystem::CModule::ModuleExport::NormalizeName(std::string& name)
-{
-	for (auto& ch : name)
-	{
-		ch = std::tolower(ch);
-	}
+void CModuleSystem::CModule::ModuleExport::NormalizeName(std::string &name) {
+  for (auto &ch : name) {
+    ch = std::tolower(ch);
+  }
 }

--- a/source/CModuleSystem.h
+++ b/source/CModuleSystem.h
@@ -1,68 +1,62 @@
 #pragma once
 
-namespace CLEO
-{
-	struct ScriptDataRef
-	{
-		char* base = nullptr; // script's base data
-		DWORD size = 0; // available code block size
-		int offset = 0; // address within the script
+namespace CLEO {
+struct ScriptDataRef {
+  char *base = nullptr; // script's base data
+  DWORD size = 0;       // available code block size
+  int offset = 0;       // address within the script
 
-		bool Valid() const
-		{
-			return base != nullptr && size >= sizeof(WORD); // at least one opcode
-		}
-	};
+  bool Valid() const {
+    return base != nullptr && size >= sizeof(WORD); // at least one opcode
+  }
+};
 
-	class CModuleSystem
-	{
-	public:
-		CModuleSystem() = default;
-		CModuleSystem(const CModuleSystem&) = delete; // no copying
+class CModuleSystem {
+public:
+  CModuleSystem() = default;
+  CModuleSystem(const CModuleSystem &) = delete; // no copying
 
-		void Clear();
+  void Clear();
 
-		// registers module reference. Needs to be released with ReleaseModuleRef
-		const ScriptDataRef GetExport(std::string modulePath, std::string_view exportName);
+  // registers module reference. Needs to be released with ReleaseModuleRef
+  const ScriptDataRef GetExport(std::string modulePath,
+                                std::string_view exportName);
 
-		bool LoadFile(const char* const path); // single file
-		bool LoadDirectory(const char* const path); // all modules in directory
-		bool LoadCleoModules(); // all in cleo\cleo_modules
+  bool LoadFile(const char *const path);      // single file
+  bool LoadDirectory(const char *const path); // all modules in directory
+  bool LoadCleoModules();                     // all in cleo\cleo_modules
 
-	private:
-		static void NormalizePath(std::string& path);
+private:
+  static void NormalizePath(std::string &path);
 
-		class CModule
-		{
-			friend class CModuleSystem;
+  class CModule {
+    friend class CModuleSystem;
 
-			struct ModuleExport
-			{
-				std::string name;
-				int offset = 0; // address within module's data
+    struct ModuleExport {
+      std::string name;
+      int offset = 0; // address within module's data
 
-				void Clear();
-				bool LoadFromFile(std::ifstream& file);
+      void Clear();
+      bool LoadFromFile(std::ifstream &file);
 
-				static void NormalizeName(std::string& name);
-			};
+      static void NormalizeName(std::string &name);
+    };
 
-			std::string filepath; // source file
-			std::vector<char> data;
-			std::map<std::string, ModuleExport> exports;
+    std::string filepath; // source file
+    std::vector<char> data;
+    std::map<std::string, ModuleExport> exports;
 
-		public:
-			CModule() = default;
-			CModule(const CModule&) = delete; // no copying
-			~CModule() = default;
+  public:
+    CModule() = default;
+    CModule(const CModule &) = delete; // no copying
+    ~CModule() = default;
 
-			void Clear();
-			const char* GetFilepath() const;
-			bool LoadFromFile(const char* path);
-			const ScriptDataRef GetExport(std::string name);
-		};
+    void Clear();
+    const char *GetFilepath() const;
+    bool LoadFromFile(const char *path);
+    const ScriptDataRef GetExport(std::string name);
+  };
 
-		std::map<std::string, CModule> modules;
-	};
-}
-
+  std::map<std::string, CModule> modules;
+};
+} // namespace CLEO

--- a/source/CPluginSystem.cpp
+++ b/source/CPluginSystem.cpp
@@ -1,178 +1,167 @@
-#include "stdafx.h"
 #include "CPluginSystem.h"
 #include "CleoBase.h"
-
+#include "stdafx.h"
 
 using namespace CLEO;
 
-CPluginSystem::~CPluginSystem()
-{
-    UnloadPlugins();
-}
+CPluginSystem::~CPluginSystem() { UnloadPlugins(); }
 
-void CPluginSystem::LoadPlugins()
-{
-    if (pluginsLoaded) return; // already done
+void CPluginSystem::LoadPlugins() {
+  if (pluginsLoaded)
+    return; // already done
 
-    std::set<std::string> names;
-    std::vector<std::string> paths;
-    std::set<std::string> skippedPaths;
+  std::set<std::string> names;
+  std::vector<std::string> paths;
+  std::set<std::string> skippedPaths;
 
-    // get blacklist from config
-    auto blacklistStr = std::string(512, '\0');
-    GetPrivateProfileString("General", "PluginBlacklist", "", blacklistStr.data(), blacklistStr.size(), Filepath_Config.c_str());
-    blacklistStr.resize(strlen(blacklistStr.data()));
-    StringToLower(blacklistStr);
-    std::vector<std::string> blacklist;
-    StringSplit(blacklistStr, "\t ,", blacklist);
+  // get blacklist from config
+  auto blacklistStr = std::string(512, '\0');
+  GetPrivateProfileString("General", "PluginBlacklist", "", blacklistStr.data(),
+                          blacklistStr.size(), Filepath_Config.c_str());
+  blacklistStr.resize(strlen(blacklistStr.data()));
+  StringToLower(blacklistStr);
+  std::vector<std::string> blacklist;
+  StringSplit(blacklistStr, "\t ,", blacklist);
 
-    // load plugins from main CLEO directory
-    auto ScanPluginsDir = [&](std::string path, const std::string prefix, const std::string extension)
-    {
-        auto pattern = path + '\\' + prefix + '*' + extension;
-        auto files = CLEO_ListDirectory(nullptr, pattern.c_str(), false, true);
+  // load plugins from main CLEO directory
+  auto ScanPluginsDir = [&](std::string path, const std::string prefix,
+                            const std::string extension) {
+    auto pattern = path + '\\' + prefix + '*' + extension;
+    auto files = CLEO_ListDirectory(nullptr, pattern.c_str(), false, true);
 
-        for (DWORD i = 0; i < files.count; i++)
-        {
-            if (std::find(paths.begin(), paths.end(), files.strings[i]) != paths.end())
-                continue; // file already listed
+    for (DWORD i = 0; i < files.count; i++) {
+      if (std::find(paths.begin(), paths.end(), files.strings[i]) !=
+          paths.end())
+        continue; // file already listed
 
-            if (skippedPaths.find(files.strings[i]) != skippedPaths.end())
-                continue; // file already skipped
+      if (skippedPaths.find(files.strings[i]) != skippedPaths.end())
+        continue; // file already skipped
 
-            auto name = FS::path(files.strings[i]).filename().string();
-            name = name.substr(prefix.length()); // cut off prefix
-            name.resize(name.length() - extension.length()); // cut off extension
+      auto name = FS::path(files.strings[i]).filename().string();
+      name = name.substr(prefix.length());             // cut off prefix
+      name.resize(name.length() - extension.length()); // cut off extension
 
-            // on blacklist?
-            auto blName = FS::path(files.strings[i]).filename().string();
-            StringToLower(blName);
-            if (std::find(blacklist.begin(), blacklist.end(), blName) != blacklist.end())
-            {
-                skippedPaths.emplace(files.strings[i]);
-                LOG_WARNING(0, " %s - skipped, blacklisted in config.ini", files.strings[i]);
-                continue;
-            }
+      // on blacklist?
+      auto blName = FS::path(files.strings[i]).filename().string();
+      StringToLower(blName);
+      if (std::find(blacklist.begin(), blacklist.end(), blName) !=
+          blacklist.end()) {
+        skippedPaths.emplace(files.strings[i]);
+        LOG_WARNING(0, " %s - skipped, blacklisted in config.ini",
+                    files.strings[i]);
+        continue;
+      }
 
-            // case insensitive search in already listed plugin names
-            auto found = std::find_if(names.begin(), names.end(), [&](const std::string& s) {
-                return _stricmp(s.c_str(), name.c_str()) == 0;
-            });
+      // case insensitive search in already listed plugin names
+      auto found =
+          std::find_if(names.begin(), names.end(), [&](const std::string &s) {
+            return _stricmp(s.c_str(), name.c_str()) == 0;
+          });
 
-            // duplicated?
-            if (found != names.end())
-            {
-                skippedPaths.emplace(files.strings[i]);
-                LOG_WARNING(0, " %s - skipped, duplicate of '%s' plugin", files.strings[i], name.c_str());
-                continue;
-            }
+      // duplicated?
+      if (found != names.end()) {
+        skippedPaths.emplace(files.strings[i]);
+        LOG_WARNING(0, " %s - skipped, duplicate of '%s' plugin",
+                    files.strings[i], name.c_str());
+        continue;
+      }
 
-            names.insert(name);
-            paths.emplace_back(files.strings[i]);
-            TRACE(" %s", files.strings[i]);
-        }
+      names.insert(name);
+      paths.emplace_back(files.strings[i]);
+      TRACE(" %s", files.strings[i]);
+    }
 
-        CLEO_StringListFree(files);
-    };
+    CLEO_StringListFree(files);
+  };
 
+  TRACE(""); // separator
+  TRACE("Listing CLEO plugins:");
+  ScanPluginsDir(FS::path(Filepath_Cleo).append("cleo_plugins").string(), "SA.",
+                 ".cleo");
+  ScanPluginsDir(FS::path(Filepath_Cleo).append("cleo_plugins").string(), "",
+                 ".cleo");                    // legacy plugins in new location
+  ScanPluginsDir(Filepath_Cleo, "", ".cleo"); // legacy plugins in old location
+
+  // reverse order, so opcodes from CLEO5 plugins can overwrite opcodes from
+  // legacy plugins
+  if (!paths.empty()) {
+    for (auto it = paths.crbegin(); it != paths.crend(); it++) {
+      std::string filename = *it;
+
+      // ModLoader support: keep game dir relative paths relative
+      FilepathRemoveParent(filename, Filepath_Game);
+
+      TRACE(""); // separator
+      TRACE("Loading plugin '%s'", filename.c_str());
+
+      HMODULE hlib = LoadLibrary(filename.c_str());
+      if (!hlib) {
+        LOG_WARNING(0, "Error loading plugin '%s'", filename.c_str());
+        continue;
+      }
+
+      plugins.emplace_back(filename, hlib);
+    }
     TRACE(""); // separator
-    TRACE("Listing CLEO plugins:");
-    ScanPluginsDir(FS::path(Filepath_Cleo).append("cleo_plugins").string(), "SA.", ".cleo");
-    ScanPluginsDir(FS::path(Filepath_Cleo).append("cleo_plugins").string(), "", ".cleo"); // legacy plugins in new location
-    ScanPluginsDir(Filepath_Cleo, "", ".cleo"); // legacy plugins in old location
+  } else {
+    TRACE(" nothing found");
+  }
 
-    // reverse order, so opcodes from CLEO5 plugins can overwrite opcodes from legacy plugins
-    if (!paths.empty())
-    {
-        for (auto it = paths.crbegin(); it != paths.crend(); it++)
-        {
-            std::string filename = *it;
-
-            // ModLoader support: keep game dir relative paths relative
-            FilepathRemoveParent(filename, Filepath_Game);
-
-            TRACE(""); // separator
-            TRACE("Loading plugin '%s'", filename.c_str());
-
-            HMODULE hlib = LoadLibrary(filename.c_str());
-            if (!hlib)
-            {
-                LOG_WARNING(0, "Error loading plugin '%s'", filename.c_str());
-                continue;
-            }
-
-            plugins.emplace_back(filename, hlib);
-        }
-        TRACE(""); // separator
-    }
-    else
-    {
-        TRACE(" nothing found");
-    }
-
-    pluginsLoaded = true;
+  pluginsLoaded = true;
 }
 
-void CPluginSystem::UnloadPlugins()
-{
-    if (!pluginsLoaded) return;
+void CPluginSystem::UnloadPlugins() {
+  if (!pluginsLoaded)
+    return;
 
-    TRACE(""); // separator
-    TRACE("Unloading CLEO plugins:");
-    for (const auto& plugin : plugins)
-    {
-        TRACE(" - Unloading '%s' at 0x%08X", plugin.name.c_str(), plugin.handle);
-        FreeLibrary(plugin.handle);
-    }
-    TRACE("CLEO plugins unloaded");
+  TRACE(""); // separator
+  TRACE("Unloading CLEO plugins:");
+  for (const auto &plugin : plugins) {
+    TRACE(" - Unloading '%s' at 0x%08X", plugin.name.c_str(), plugin.handle);
+    FreeLibrary(plugin.handle);
+  }
+  TRACE("CLEO plugins unloaded");
 
-    plugins.clear();
-    pluginsLoaded = false;
+  plugins.clear();
+  pluginsLoaded = false;
 }
 
-size_t CPluginSystem::GetNumPlugins() const
-{
-    return plugins.size();
+size_t CPluginSystem::GetNumPlugins() const { return plugins.size(); }
+
+void CLEO::CPluginSystem::LogLoadedPlugins() const {
+  auto process = GetCurrentProcess();
+
+  DWORD buffSize = 0;
+  if (!EnumProcessModules(process, nullptr, 0, &buffSize) ||
+      buffSize < sizeof(HMODULE)) {
+    return;
+  }
+
+  std::vector<HMODULE> modules(buffSize / sizeof(HMODULE));
+  if (!EnumProcessModules(process, modules.data(), buffSize, &buffSize)) {
+    return;
+  }
+
+  TRACE(""); // separator
+  TRACE("Loaded plugins summary:");
+
+  for (const auto &m : modules) {
+    std::string filename(512, '\0');
+    if (GetModuleFileName(m, filename.data(), filename.size())) {
+      filename.resize(strlen(filename.data()));
+
+      if (StringStartsWith(filename, Filepath_Game, false) ||
+          StringEndsWith(filename, ".asi", false) ||
+          StringEndsWith(filename, ".cleo", false)) {
+        std::error_code err;
+        auto fileSize = (size_t)FS::file_size(filename, err);
+
+        FilepathRemoveParent(filename, Filepath_Game);
+
+        TRACE(" %s (%zu bytes)", filename.c_str(), fileSize);
+      }
+    }
+  }
+
+  TRACE(""); // separator
 }
-
-void CLEO::CPluginSystem::LogLoadedPlugins() const
-{
-    auto process = GetCurrentProcess();
-
-    DWORD buffSize = 0;
-    if (!EnumProcessModules(process, nullptr, 0, &buffSize) || buffSize < sizeof(HMODULE))
-    {
-        return;
-    }
-
-    std::vector<HMODULE> modules(buffSize / sizeof(HMODULE));
-    if (!EnumProcessModules(process, modules.data(), buffSize, &buffSize))
-    {
-        return;
-    }
-
-    TRACE(""); // separator
-    TRACE("Loaded plugins summary:");
-
-    for (const auto& m : modules)
-    {
-        std::string filename(512, '\0');
-        if (GetModuleFileName(m, filename.data(), filename.size()))
-        {
-            filename.resize(strlen(filename.data()));
-
-            if (StringStartsWith(filename, Filepath_Game, false) || StringEndsWith(filename, ".asi", false) || StringEndsWith(filename, ".cleo", false))
-            {
-                std::error_code err;
-                auto fileSize = (size_t)FS::file_size(filename, err);
-
-                FilepathRemoveParent(filename, Filepath_Game);
-
-                TRACE(" %s (%zu bytes)", filename.c_str(), fileSize);
-            }
-        }
-    }
-
-    TRACE(""); // separator
-}
-

--- a/source/CPluginSystem.h
+++ b/source/CPluginSystem.h
@@ -1,32 +1,30 @@
 #pragma once
-#include <windows.h>
 #include <list>
 #include <string>
+#include <windows.h>
 
-namespace CLEO
-{
-    class CPluginSystem
-    {
-        struct PluginEntry
-        {
-            std::string name;
-            HMODULE handle = nullptr;
+namespace CLEO {
+class CPluginSystem {
+  struct PluginEntry {
+    std::string name;
+    HMODULE handle = nullptr;
 
-            PluginEntry() = default;
-            PluginEntry(std::string name, HMODULE handle) : name(name), handle(handle) {}
-        };
-        std::list<PluginEntry> plugins;
-        bool pluginsLoaded = false;
+    PluginEntry() = default;
+    PluginEntry(std::string name, HMODULE handle)
+        : name(name), handle(handle) {}
+  };
+  std::list<PluginEntry> plugins;
+  bool pluginsLoaded = false;
 
-    public:
-        CPluginSystem() = default;
-        CPluginSystem(const CPluginSystem&) = delete; // no copying
-        ~CPluginSystem();
+public:
+  CPluginSystem() = default;
+  CPluginSystem(const CPluginSystem &) = delete; // no copying
+  ~CPluginSystem();
 
-        void LoadPlugins();
-        void UnloadPlugins();
-        size_t GetNumPlugins() const;
+  void LoadPlugins();
+  void UnloadPlugins();
+  size_t GetNumPlugins() const;
 
-        void LogLoadedPlugins() const;
-    };
-}
+  void LogLoadedPlugins() const;
+};
+} // namespace CLEO

--- a/source/CScriptEngine.cpp
+++ b/source/CScriptEngine.cpp
@@ -1,871 +1,835 @@
-#include "stdafx.h"
 #include "CleoBase.h"
+#include "stdafx.h"
 
+namespace CLEO {
+const char *__fastcall GetScriptStringParam(CRunningScript *thread, int dummy,
+                                            char *buff, int buffLen) {
+  if (buff == nullptr || buffLen < 0) {
+    LOG_WARNING(0,
+                "Invalid ReadStringParam input argument! Ptr: 0x%08X, Size: %d",
+                buff, buffLen);
+    CLEO_SkipOpcodeParams(thread, 1);
+    return nullptr;
+  }
 
-namespace CLEO
-{
-    const char* __fastcall GetScriptStringParam(CRunningScript* thread, int dummy, char* buff, int buffLen)
-    {
-        if (buff == nullptr || buffLen < 0)
-        {
-            LOG_WARNING(0, "Invalid ReadStringParam input argument! Ptr: 0x%08X, Size: %d", buff, buffLen);
-            CLEO_SkipOpcodeParams(thread, 1);
-            return nullptr;
-        }
+  auto paramType = thread->PeekDataType();
+  auto arrayType = thread->PeekArrayType();
+  auto isVariableInt =
+      IsVariable(paramType) && (arrayType == eArrayDataType::ADT_NONE ||
+                                arrayType == eArrayDataType::ADT_INT);
 
-        auto paramType = thread->PeekDataType();
-        auto arrayType = thread->PeekArrayType();
-        auto isVariableInt = IsVariable(paramType) && (arrayType == eArrayDataType::ADT_NONE || arrayType == eArrayDataType::ADT_INT);
+  // integer address to text buffer
+  if (IsImmInteger(paramType) || isVariableInt) {
+    auto str = (char *)CLEO_PeekIntOpcodeParam(thread);
+    CLEO_SkipOpcodeParams(thread, 1);
 
-        // integer address to text buffer
-        if (IsImmInteger(paramType) || isVariableInt)
-        {
-            auto str = (char*)CLEO_PeekIntOpcodeParam(thread);
-            CLEO_SkipOpcodeParams(thread, 1);
-
-            if ((size_t)str <= MinValidAddress)
-            {
-                LOG_WARNING(thread, "Invalid '0x%X' pointer of input string argument %s in script %s", str, GetParamInfo().c_str(), ScriptInfoStr(thread).c_str());
-                return nullptr; // error
-            }
-
-            auto len = std::min((int)strlen(str), buffLen);
-            memcpy(buff, str, len);
-            if (len < buffLen) buff[len] = '\0'; // add terminator if possible
-            return str; // pointer to original data
-        }
-        else if (paramType == DT_VARLEN_STRING)
-        {
-            CleoInstance.OpcodeSystem.handledParamCount++;
-            thread->IncPtr(1); // already processed paramType
-
-            DWORD length = *thread->GetBytePointer(); // as unsigned byte!
-            thread->IncPtr(1); // length info
-
-            char* str = (char*)thread->GetBytePointer();
-            thread->IncPtr(length); // text data
-
-            memcpy(buff, str, std::min(buffLen, (int)length));
-            if ((int)length < buffLen) buff[length] = '\0'; // add terminator if possible
-            return buff;
-        }
-        else if (IsImmString(paramType))
-        {
-            thread->IncPtr(1); // already processed paramType
-            auto str = (char*)thread->GetBytePointer();
-
-            switch (paramType)
-            {
-                case DT_TEXTLABEL:
-                {
-                    CleoInstance.OpcodeSystem.handledParamCount++;
-                    memcpy(buff, str, std::min(buffLen, 8));
-                    thread->IncPtr(8); // text data
-                    return buff;
-                }
-
-                case DT_STRING:
-                {
-                    CleoInstance.OpcodeSystem.handledParamCount++;
-                    memcpy(buff, str, std::min(buffLen, 16));
-                    thread->IncPtr(16); // ext data
-                    return buff;
-                }
-            }
-        }
-        else if (IsVarString(paramType))
-        {
-            switch (paramType)
-            {
-                // short string variable
-                case DT_VAR_TEXTLABEL:
-                case DT_LVAR_TEXTLABEL:
-                case DT_VAR_TEXTLABEL_ARRAY:
-                case DT_LVAR_TEXTLABEL_ARRAY:
-                {
-                    auto str = (char*)CScriptEngine::GetScriptParamPointer(thread);
-                    memcpy(buff, str, std::min(buffLen, 8));
-                    if (buffLen > 8) buff[8] = '\0'; // add terminator if possible
-                    return buff;
-                }
-
-                // long string variable
-                case DT_VAR_STRING:
-                case DT_LVAR_STRING:
-                case DT_VAR_STRING_ARRAY:
-                case DT_LVAR_STRING_ARRAY:
-                {
-                    auto str = (char*)CScriptEngine::GetScriptParamPointer(thread);
-                    memcpy(buff, str, std::min(buffLen, 16));
-                    if (buffLen > 16) buff[16] = '\0'; // add terminator if possible
-                    return buff;
-                }
-            }
-        }
-
-        // unsupported param type
-        LOG_WARNING(thread, "Argument %s expected to be string, got %s in script %s", GetParamInfo().c_str(), ToKindStr(paramType, arrayType), ScriptInfoStr(thread).c_str());
-        CLEO_SkipOpcodeParams(thread, 1); // try skip unhandled param
-        return nullptr; // error
+    if ((size_t)str <= MinValidAddress) {
+      LOG_WARNING(
+          thread,
+          "Invalid '0x%X' pointer of input string argument %s in script %s",
+          str, GetParamInfo().c_str(), ScriptInfoStr(thread).c_str());
+      return nullptr; // error
     }
 
-    void OnLoadScmData(void)
-    {
-        TRACE("Loading scripts save data...");
-        CTheScripts::Load();
+    auto len = std::min((int)strlen(str), buffLen);
+    memcpy(buff, str, len);
+    if (len < buffLen)
+      buff[len] = '\0'; // add terminator if possible
+    return str;         // pointer to original data
+  } else if (paramType == DT_VARLEN_STRING) {
+    CleoInstance.OpcodeSystem.handledParamCount++;
+    thread->IncPtr(1); // already processed paramType
+
+    DWORD length = *thread->GetBytePointer(); // as unsigned byte!
+    thread->IncPtr(1);                        // length info
+
+    char *str = (char *)thread->GetBytePointer();
+    thread->IncPtr(length); // text data
+
+    memcpy(buff, str, std::min(buffLen, (int)length));
+    if ((int)length < buffLen)
+      buff[length] = '\0'; // add terminator if possible
+    return buff;
+  } else if (IsImmString(paramType)) {
+    thread->IncPtr(1); // already processed paramType
+    auto str = (char *)thread->GetBytePointer();
+
+    switch (paramType) {
+    case DT_TEXTLABEL: {
+      CleoInstance.OpcodeSystem.handledParamCount++;
+      memcpy(buff, str, std::min(buffLen, 8));
+      thread->IncPtr(8); // text data
+      return buff;
     }
 
-    void OnSaveScmData(void)
-    {
-        TRACE("Saving scripts save data...");
-        CleoInstance.ScriptEngine.SaveState();
-        CleoInstance.ScriptEngine.UnregisterAllCustomScripts();
-        CTheScripts::Save();
-        CleoInstance.ScriptEngine.ReregisterAllCustomScripts();
+    case DT_STRING: {
+      CleoInstance.OpcodeSystem.handledParamCount++;
+      memcpy(buff, str, std::min(buffLen, 16));
+      thread->IncPtr(16); // ext data
+      return buff;
+    }
+    }
+  } else if (IsVarString(paramType)) {
+    switch (paramType) {
+    // short string variable
+    case DT_VAR_TEXTLABEL:
+    case DT_LVAR_TEXTLABEL:
+    case DT_VAR_TEXTLABEL_ARRAY:
+    case DT_LVAR_TEXTLABEL_ARRAY: {
+      auto str = (char *)CScriptEngine::GetScriptParamPointer(thread);
+      memcpy(buff, str, std::min(buffLen, 8));
+      if (buffLen > 8)
+        buff[8] = '\0'; // add terminator if possible
+      return buff;
     }
 
-    struct CleoSafeHeader
-    {
-        const static unsigned sign;
-        unsigned signature;
-        unsigned n_saved_threads;
-        unsigned n_stopped_threads;
-    };
-
-    const unsigned CleoSafeHeader::sign = 0x31345653;
-
-    struct ThreadSavingInfo
-    {
-        unsigned long hash;
-        SCRIPT_VAR tls[32];
-        unsigned timers[2];
-        bool condResult;
-        unsigned sleepTime;
-        eLogicalOperation logicalOp;
-        bool notFlag;
-        ptrdiff_t ip_diff;
-        char threadName[8];
-
-        ThreadSavingInfo(CCustomScript *cs) :
-            hash(cs->m_codeChecksum), condResult(cs->bCondResult),
-            logicalOp(cs->LogicalOp), notFlag(cs->NotFlag != false), ip_diff(cs->CurrentIP - reinterpret_cast<BYTE*>(cs->BaseIP))
-        {
-            sleepTime = cs->WakeTime >= CTimer::m_snTimeInMilliseconds ? 0 : cs->WakeTime - CTimer::m_snTimeInMilliseconds;
-            std::copy(cs->LocalVar, cs->LocalVar + 32, tls);
-            std::copy(cs->Timers, cs->Timers + 2, timers);
-            std::copy(cs->Name, cs->Name + 8, threadName);
-        }
-
-        void Apply(CCustomScript *cs)
-        {
-            cs->m_codeChecksum = hash;
-            std::copy(tls, tls + 32, cs->LocalVar);
-            std::copy(timers, timers + 2, cs->Timers);
-            cs->bCondResult = condResult;
-            cs->WakeTime = CTimer::m_snTimeInMilliseconds + sleepTime;
-            cs->LogicalOp = logicalOp;
-            cs->NotFlag = notFlag;
-            cs->CurrentIP = reinterpret_cast<BYTE*>(cs->BaseIP) + ip_diff;
-            std::copy(threadName, threadName + 8, cs->Name);
-            cs->EnableSaving(true);
-        }
-
-        ThreadSavingInfo() { }
-    };
-
-    SCRIPT_VAR CScriptEngine::CleoVariables[0x400];
-
-    template<typename T>
-    void inline ReadBinary(std::istream& s, T& buf)
-    {
-        s.read(reinterpret_cast<char *>(&buf), sizeof(T));
+    // long string variable
+    case DT_VAR_STRING:
+    case DT_LVAR_STRING:
+    case DT_VAR_STRING_ARRAY:
+    case DT_LVAR_STRING_ARRAY: {
+      auto str = (char *)CScriptEngine::GetScriptParamPointer(thread);
+      memcpy(buff, str, std::min(buffLen, 16));
+      if (buffLen > 16)
+        buff[16] = '\0'; // add terminator if possible
+      return buff;
     }
-
-    template<typename T>
-    void inline ReadBinary(std::istream& s, T *buf, size_t size)
-    {
-        s.read(reinterpret_cast<char *>(buf), sizeof(T) * size);
     }
-
-    template<typename T>
-    void inline WriteBinary(std::ostream& s, const T& data)
-    {
-        s.write(reinterpret_cast<const char *>(&data), sizeof(T));
-    }
-
-    template<typename T>
-    void inline WriteBinary(std::ostream& s, const T*data, size_t size)
-    {
-        s.write(reinterpret_cast<const char *>(data), sizeof(T) * size);
-    }
-
-    void __cdecl CScriptEngine::HOOK_DrawScriptText(char beforeFade)
-    {
-        DrawScriptText_Orig(beforeFade);
-
-        // run registered callbacks
-        for (void* func : CleoInstance.GetCallbacks(eCallbackId::ScriptDraw))
-        {
-            typedef void WINAPI callback(bool);
-            ((callback*)func)(beforeFade != 0);
-        }
-    }
-
-    SCRIPT_VAR* CScriptEngine::GetScriptParamPointer(CRunningScript* thread)
-    {
-        auto type = DT_DWORD; //thread->PeekDataType(); // ignored in GetPointerToScriptVariable anyway
-        auto ptr = ((::CRunningScript*)thread)->GetPointerToScriptVariable(type);
-        CleoInstance.OpcodeSystem.handledParamCount++; // TODO: hook game's GetPointerToScriptVariable so this is always incremented?
-        return (SCRIPT_VAR*)ptr;
-    }
-
-    void CScriptEngine::GetScriptParams(CRunningScript* script, BYTE count)
-    {
-        ((::CRunningScript*)script)->CollectParameters(count);
-        CleoInstance.OpcodeSystem.handledParamCount += count;
-    }
-
-    void CScriptEngine::SetScriptParams(CRunningScript* script, BYTE count)
-    {
-        ((::CRunningScript*)script)->StoreParameters(count);
-        CleoInstance.OpcodeSystem.handledParamCount += count;
-    }
-
-    void CScriptEngine::DrawScriptText_Orig(char beforeFade)
-    {
-        if (beforeFade)
-            CleoInstance.ScriptEngine.DrawScriptTextBeforeFade_Orig(beforeFade);
-        else
-            CleoInstance.ScriptEngine.DrawScriptTextAfterFade_Orig(beforeFade);
-    }
-
-    void __fastcall CScriptEngine::HOOK_ProcessScript(CLEO::CRunningScript* pScript)
-    {
-        CleoInstance.ScriptEngine.GameBegin(); // all initialized and ready to process scripts
-
-        // run registered callbacks
-        bool process = true;
-        for (void* func : CleoInstance.GetCallbacks(eCallbackId::ScriptProcessBefore))
-        {
-            typedef bool WINAPI callback(CRunningScript*);
-            process = process && ((callback*)func)(pScript);
-        }
-
-        if (process)
-        {
-            CleoInstance.ScriptEngine.ProcessScript_Orig(pScript);
-        }
-
-        // run registered callbacks
-        for (void* func : CleoInstance.GetCallbacks(eCallbackId::ScriptProcessAfter))
-        {
-            typedef void WINAPI callback(CRunningScript*);
-            ((callback*)func)(pScript);
-        }
-    }
-
-    void CScriptEngine::Inject(CCodeInjector& inj)
-    {
-        TRACE("Injecting ScriptEngine: Phase 1");
-        CGameVersionManager& gvm = CleoInstance.VersionManager;
-            
-        // Global Events crashfix
-        //inj.MemoryWrite(0xA9AF6C, 0, 4);
-
-        opcodeParams = (SCRIPT_VAR*)ScriptParams; // from Plugin SDK's TheScripts.h
-        missionLocals = (SCRIPT_VAR*)CTheScripts::LocalVariablesForCurrentMission;
-        staticThreads = (CRunningScript*)CTheScripts::ScriptsArray;
-
-        // Protect script dependencies
-        inj.ReplaceFunction(HOOK_ProcessScript, gvm.TranslateMemoryAddress(MA_CALL_PROCESS_SCRIPT), &ProcessScript_Orig);
-
-        inj.ReplaceFunction(HOOK_DrawScriptText, gvm.TranslateMemoryAddress(MA_CALL_DRAW_SCRIPT_TEXTS_AFTER_FADE), &DrawScriptTextAfterFade_Orig);
-        inj.ReplaceFunction(HOOK_DrawScriptText, gvm.TranslateMemoryAddress(MA_CALL_DRAW_SCRIPT_TEXTS_BEFORE_FADE), &DrawScriptTextBeforeFade_Orig);
-
-        inj.ReplaceFunction(OnLoadScmData, gvm.TranslateMemoryAddress(MA_CALL_LOAD_SCM_DATA));
-        inj.ReplaceFunction(OnSaveScmData, gvm.TranslateMemoryAddress(MA_CALL_SAVE_SCM_DATA));
-    }
-
-    void CScriptEngine::InjectLate(CCodeInjector& inj)
-    {
-        TRACE("Injecting ScriptEngine: Phase 2");
-        CGameVersionManager& gvm = CleoInstance.VersionManager;
-
-        // limit adjusters support: get adresses from (possibly) patched references
-        inj.MemoryRead(gvm.TranslateMemoryAddress(MA_SCM_BLOCK_REF), scmBlock);
-        inj.MemoryRead(gvm.TranslateMemoryAddress(MA_MISSION_BLOCK_REF), missionBlock);
-    }
-
-    CScriptEngine::~CScriptEngine()
-    {
-        GameEnd();
-    }
-
-    CleoSafeHeader safe_header;
-    ThreadSavingInfo *safe_info;
-    unsigned long *stopped_info;
-    std::unique_ptr<ThreadSavingInfo[]> safe_info_utilizer;
-    std::unique_ptr<unsigned long[]> stopped_info_utilizer;
-
-    void CScriptEngine::GameBegin()
-    {
-        auto& activeScriptsListHead = (CRunningScript*&)CTheScripts::pActiveScripts; // reference, but with type casted to CLEO's CRunningScript
-
-        if(gameInProgress) return; // already started
-        if(activeScriptsListHead == nullptr) return; // main gamescript not loaded yet 
-        gameInProgress = true;
-
-        if (CGame::bMissionPackGame == 0) // regular main game
-        {
-            MainScriptFileDir = Filepath_Game + "\\data\\script";
-            MainScriptFileName = "main.scm";
-        }
-        else // mission pack
-        {
-            MainScriptFileDir = Filepath_User + StringPrintf("\\MPACK\\MPACK%d", CGame::bMissionPackGame);
-            MainScriptFileName = "scr.scm";
-        }
-
-        NativeScriptsDebugMode = GetPrivateProfileInt("General", "DebugMode", 0, Filepath_Config.c_str()) != 0;
-
-        // global native scripts legacy mode
-        int ver = GetPrivateProfileInt("General", "MainScmLegacyMode", 0, Filepath_Config.c_str());
-        switch(ver)
-        {
-            case 3: NativeScriptsVersion = eCLEO_Version::CLEO_VER_3; break;
-            case 4: NativeScriptsVersion = eCLEO_Version::CLEO_VER_4; break;
-            default: 
-                NativeScriptsVersion = eCLEO_Version::CLEO_VER_CUR;
-                ver = 0;
-            break;
-        }
-        if (ver != 0) TRACE("Legacy mode for native scripts active: CLEO%d", ver);
-
-        MainScriptCurWorkDir = Filepath_Game;
-
-        CleoInstance.ModuleSystem.LoadCleoModules();
-        LoadState(CleoInstance.saveSlot);
-
-        // keep already loaded scripts at front of processing queue
-        auto head = activeScriptsListHead;
-        auto tail = head;
-        while (tail->Next) tail = tail->Next;
-
-        // load custom scripts as new list
-        activeScriptsListHead = nullptr;
-        LoadCustomScripts();
-
-        // append custom scripts list to the back
-        if (activeScriptsListHead != nullptr)
-        {
-            tail->Next = activeScriptsListHead;
-            activeScriptsListHead->Previous = tail;
-        }
-
-        activeScriptsListHead = head; // restore original
-    }
-
-    void CScriptEngine::GameEnd()
-    {
-        if (!gameInProgress) return;
-        gameInProgress = false;
-
-        RemoveAllCustomScripts();
-        CleoInstance.ModuleSystem.Clear();
-        memset(CleoVariables, 0, sizeof(CleoVariables));
-    }
-
-    void CScriptEngine::LoadCustomScripts()
-    {
-        TRACE(""); // separator
-        TRACE("Listing CLEO scripts:");
-
-        std::set<std::string> found;
-
-        auto processFileList = [&](StringList fileList)
-        {
-            for (DWORD i = 0; i < fileList.count; i++)
-            {
-                const auto ext = FS::path(fileList.strings[i]).extension();
-                if (ext == cs_ext || ext == cs3_ext || ext == cs4_ext)
-                {
-                    TRACE(" %s", fileList.strings[i]);
-                    found.emplace(fileList.strings[i]);
-                }
-            }
-        };
-
-        auto searchPattern = Filepath_Cleo + "\\*" + cs_ext;
-        auto list = CLEO_ListDirectory(nullptr, searchPattern.c_str(), false, true);
-        processFileList(list);
-        CLEO_StringListFree(list);
-
-        searchPattern = Filepath_Cleo + "\\*" + cs3_ext;
-        list = CLEO_ListDirectory(nullptr, searchPattern.c_str(), false, true);
-        processFileList(list);
-        CLEO_StringListFree(list);
-
-        searchPattern = Filepath_Cleo + "\\*" + cs4_ext;
-        list = CLEO_ListDirectory(nullptr, searchPattern.c_str(), false, true);
-        processFileList(list);
-        CLEO_StringListFree(list);
-
-        if (!found.empty())
-        {
-            TRACE("Starting CLEO scripts...");
-
-            for (const auto& path : found)
-            {
-                LoadScript(path.c_str());
-            }
-        }
-        else
-        {
-            TRACE(" - nothing found");
-        }
-    }
-
-    CCustomScript * CScriptEngine::LoadScript(const char * szFilePath)
-    {
-        auto cs = new CCustomScript(szFilePath);
-
-        if (!cs || !cs->IsOk())
-        {
-            TRACE("Loading of custom script '%s' failed", szFilePath);
-            if (cs) delete cs;
-            return nullptr;
-        }
-
-        // check whether the script is in stop-list
-        if (stopped_info)
-        {
-            for (size_t i = 0; i < safe_header.n_stopped_threads; ++i)
-            {
-                if (stopped_info[i] == cs->m_codeChecksum)
-                {
-                    TRACE("Custom script '%s' found in the stop-list", szFilePath);
-                    InactiveScriptHashes.insert(stopped_info[i]);
-                    delete cs;
-                    return nullptr;
-                }
-            }
-        }
-
-        // check whether the script is in safe-list
-        if (safe_info)
-        {
-            for (size_t i = 0; i < safe_header.n_saved_threads; ++i)
-            {
-                if (safe_info[i].hash == cs->GetCodeChecksum())
-                {
-                    TRACE("Custom script '%s' found in the safe-list", szFilePath);
-                    safe_info[i].Apply(cs);
-                    break;
-                }
-            }
-        }
-
-        AddCustomScript(cs);
-        return cs;
-    }
-
-    CCustomScript* CScriptEngine::CreateCustomScript(CRunningScript* fromThread, const char* script_name, int label)
-    {
-        auto filename = reinterpret_cast<CCustomScript*>(fromThread)->ResolvePath(script_name, DIR_CLEO); // legacy: default search location is game\cleo directory
-
-        if (label != 0) // create from label
-        {
-            TRACE("Starting new custom script from thread named '%s' label 0x%08X", filename.c_str(), label);
-        }
-        else
-        {
-            TRACE("Starting new custom script '%s'", filename.c_str());
-        }
-
-        // if "label == 0" then "script_name" need to be the file name
-        auto cs = new CCustomScript(filename.c_str(), false, fromThread, label);
-        if (fromThread) fromThread->SetConditionResult(cs && cs->IsOk());
-        if (cs && cs->IsOk())
-        {
-            AddCustomScript(cs);
-            if (fromThread) ((::CRunningScript*)fromThread)->ReadParametersForNewlyStartedScript((::CRunningScript*)cs);
-        }
-        else
-        {
-            if (cs) delete cs;
-            if (fromThread) SkipUnusedVarArgs(fromThread);
-            LOG_WARNING(0, "Failed to load script '%s'", filename.c_str());
-            return nullptr;
-        }
-
-        return cs;
-    }
-
-    void CScriptEngine::LoadState(int saveSlot)
-    {
-        memset(CleoVariables, 0, sizeof(CleoVariables));
-        safe_info = nullptr;
-        stopped_info = nullptr;
-        safe_header.n_saved_threads = safe_header.n_stopped_threads = 0;
-
-        if(saveSlot == -1) return; // new game started
-
-        auto saveFile = FS::path(Filepath_Cleo).append(StringPrintf("cleo_saves\\cs%d.sav", saveSlot)).string();
-
-        // load cleo saving file
-        try
-        {
-            TRACE(""); // separator
-            TRACE("Loading cleo safe '%s'", saveFile.c_str());
-            std::ifstream ss(saveFile.c_str(), std::ios::binary);
-            if (ss.is_open())
-            {
-                ss.exceptions(std::ios::eofbit | std::ios::badbit | std::ios::failbit);
-                ReadBinary(ss, safe_header);
-                if (safe_header.signature != CleoSafeHeader::sign)
-                    throw std::runtime_error("Invalid file format");
-                safe_info = new ThreadSavingInfo[safe_header.n_saved_threads];
-                safe_info_utilizer.reset(safe_info);
-                stopped_info = new unsigned long[safe_header.n_stopped_threads];
-                stopped_info_utilizer.reset(stopped_info);
-                ReadBinary(ss, CleoVariables, 0x400);
-                ReadBinary(ss, safe_info, safe_header.n_saved_threads);
-                ReadBinary(ss, stopped_info, safe_header.n_stopped_threads);
-                for (size_t i = 0; i < safe_header.n_stopped_threads; ++i)
-                    InactiveScriptHashes.insert(stopped_info[i]);
-                TRACE("Finished. Loaded %u cleo variables, %u saved threads info, %u stopped threads info",
-                    0x400, safe_header.n_saved_threads, safe_header.n_stopped_threads);
-            }
-            else
-            {
-                memset(CleoVariables, 0, sizeof(CleoVariables));
-            }
-        }
-        catch (std::exception& ex)
-        {
-            TRACE("Loading of cleo safe '%s' failed: %s", saveFile.c_str(), ex.what());
-            safe_header.n_saved_threads = safe_header.n_stopped_threads = 0;
-            memset(CleoVariables, 0, sizeof(CleoVariables));
-        }
-    }
-
-    void CScriptEngine::SaveState()
-    {
-        try
-        {
-            std::list<CCustomScript *> savedThreads;
-            std::for_each(CustomScripts.begin(), CustomScripts.end(), [this, &savedThreads](CCustomScript *cs) {
-                if (cs->m_saveEnabled)
-                    savedThreads.push_back(cs);
-            });
-
-            CleoSafeHeader header = { CleoSafeHeader::sign, savedThreads.size(), InactiveScriptHashes.size() };
-
-            char safe_name[MAX_PATH];
-            sprintf_s(safe_name, "./cleo/cleo_saves/cs%d.sav", FrontEndMenuManager.m_nSelectedSaveGame);
-            TRACE("Saving script engine state to the file '%s'", safe_name);
-
-            CreateDirectory("cleo", NULL);
-            CreateDirectory("cleo/cleo_saves", NULL);
-            std::ofstream ss(safe_name, std::ios::binary);
-            if (ss.is_open())
-            {
-                ss.exceptions(std::ios::failbit | std::ios::badbit);
-
-                WriteBinary(ss, header);
-                WriteBinary(ss, CleoVariables, 0x400);
-
-                std::for_each(savedThreads.begin(), savedThreads.end(), [&savedThreads, &ss](CCustomScript *cs)
-                {
-                    ThreadSavingInfo savingInfo(cs);
-                    WriteBinary(ss, savingInfo);
-                });
-
-                std::for_each(InactiveScriptHashes.begin(), InactiveScriptHashes.end(), [&ss](unsigned long hash) {
-                    WriteBinary(ss, hash);
-                });
-
-                TRACE("Done. Saved %u cleo variables, %u saved threads, %u stopped threads",
-                    0x400, header.n_saved_threads, header.n_stopped_threads);
-            }
-            else
-            {
-                TRACE("Failed to write save file '%s'!", safe_name);
-            }
-        }
-        catch (std::exception& ex)
-        {
-            TRACE("Saving failed. %s", ex.what());
-        }
-    }
-
-    CRunningScript* CScriptEngine::FindScriptNamed(const char* threadName, bool standardScripts, bool customScripts, size_t resultIndex)
-    {
-        if (standardScripts)
-        {
-            for (auto script = (CRunningScript*)CTheScripts::pActiveScripts; script; script = script->GetNext())
-            {
-                if (script->IsCustom()) 
-                {
-                    // skip custom scripts in the queue, they are handled separately
-                    continue;
-                }
-                if (_strnicmp(threadName, script->Name, sizeof(script->Name)) == 0)
-                {
-                    if (resultIndex == 0) return script;
-                    else resultIndex--;
-                }
-            }
-        }
-
-        if (customScripts)
-        {
-            if (CustomMission)
-            {
-                if (_strnicmp(threadName, CustomMission->Name, sizeof(CustomMission->Name)) == 0)
-                {
-                    if (resultIndex == 0) return CustomMission;
-                    else resultIndex--;
-                }
-            }
-
-            for (auto it = CustomScripts.begin(); it != CustomScripts.end(); ++it)
-            {
-                auto cs = *it;
-                if (_strnicmp(threadName, cs->Name, sizeof(cs->Name)) == 0)
-                {
-                    if (resultIndex == 0) return cs;
-                    else resultIndex--;
-                }
-            }
-        }
-
-        return nullptr;
-    }
-
-    CRunningScript* CScriptEngine::FindScriptByFilename(const char* path, size_t resultIndex)
-    {
-        if (path == nullptr) return nullptr;
-
-        auto pathLen = strlen(path);
-        auto CheckScript = [&](CRunningScript* script)
-        {
-            if (script == nullptr) return false;
-
-            auto cs = (CCustomScript*)script;
-            std::string scriptPath = cs->GetScriptFileFullPath();
-
-            if (scriptPath.length() < pathLen) return false;
-
-            auto startPos = scriptPath.length() - pathLen;
-            if (_strnicmp(path, scriptPath.c_str() + startPos, pathLen) == 0)
-            {
-                if (startPos > 0 && path[startPos - 1] != '\\') return false; // whole file/dir name must match
-
-                return true;
-            }
-
-            return false;
-        };
-
-        // standard scripts
-        for (auto script = (CRunningScript*)CTheScripts::pActiveScripts; script; script = script->GetNext())
-        {
-            if (CheckScript(script))
-            {
-                if (resultIndex == 0) return script;
-                else resultIndex--;
-            }
-        }
-
-        // custom scripts
-        if (CheckScript(CustomMission))
-        {
-            if (resultIndex == 0) return CustomMission;
-            else resultIndex--;
-        }
-
-        for (auto it = CustomScripts.begin(); it != CustomScripts.end(); ++it)
-        {
-            auto cs = *it;
-            if (CheckScript(cs))
-            {
-                if (resultIndex == 0) return cs;
-                else resultIndex--;
-            }
-        }
-
-        return nullptr;
-    }
-
-    bool CScriptEngine::IsActiveScriptPtr(const CRunningScript* ptr) const
-    {
-        for (auto script = (CRunningScript*)CTheScripts::pActiveScripts; script != nullptr; script = script->GetNext())
-        {
-            if (script == ptr)
-                return ptr->IsActive();
-        }
-
-        for (const auto script : CustomScripts)
-        {
-            if (script == ptr)
-                return ptr->IsActive();
-        }
-
-        return false;
-    }
-
-    bool CScriptEngine::IsValidScriptPtr(const CRunningScript* ptr) const
-    {
-        for (auto script = (CRunningScript*)CTheScripts::pActiveScripts; script != nullptr; script = script->GetNext())
-        {
-            if (script == ptr)
-                return true;
-        }
-
-        for (auto script = (CLEO::CRunningScript*)CTheScripts::pIdleScripts; script != nullptr; script = script->GetNext())
-        {
-            if (script == ptr)
-                return true;
-        }
-
-        for (const auto script : CustomScripts)
-        {
-            if (script == ptr)
-                return true;
-        }
-
-        for (const auto script : ScriptsWaitingForDelete)
-        {
-            if (script == ptr)
-                return true;
-        }
-
-        return false;
-    }
-
-    void CScriptEngine::AddCustomScript(CCustomScript *cs)
-    {
-        if (cs->IsMission())
-        {
-            TRACE("Registering custom mission named '%s'", cs->GetName().c_str());
-            CustomMission = cs;
-        }
-        else
-        {
-            TRACE("Registering custom script named '%s'", cs->GetName().c_str());
-            CustomScripts.push_back(cs);
-        }
-
-        cs->AddScriptToList((CRunningScript**)&CTheScripts::pActiveScripts);
-        cs->SetActive(true);
-
-        // run registered callbacks
-        for (void* func : CleoInstance.GetCallbacks(eCallbackId::ScriptRegister))
-        {
-            typedef void WINAPI callback(CCustomScript*);
-            ((callback*)func)(cs);
-        }
-    }
-
-    void CScriptEngine::RemoveScript(CRunningScript* script)
-    {
-        if (script->IsMission()) CTheScripts::bAlreadyRunningAMissionScript = false;
-
-        if (script->IsCustom())
-        {
-            RemoveCustomScript((CCustomScript*)script);
-        }
-        else // native script
-        {
-            auto cs = (CCustomScript*)script;
-            cs->RemoveScriptFromList((CRunningScript**)&CTheScripts::pActiveScripts);
-            cs->AddScriptToList((CRunningScript**)&CTheScripts::pIdleScripts);
-            cs->ShutdownThisScript();
-        }
-    }
-
-    void CScriptEngine::RemoveCustomScript(CCustomScript *cs)
-    {
-        // run registered callbacks
-        for (void* func : CleoInstance.GetCallbacks(eCallbackId::ScriptUnregister))
-        {
-            typedef void WINAPI callback(CCustomScript*);
-            ((callback*)func)(cs);
-        }
-
-        if (cs == CustomMission)
-        {
-            CustomMission = nullptr;
-            CTheScripts::bAlreadyRunningAMissionScript = false; // on_mission
-        }
-
-        if (cs->m_parentScript)
-        {
-            cs->BaseIP = 0; // don't delete BaseIP if child thread
-        }
-
-        for (auto childThread : cs->m_childScripts)
-        {
-            RemoveScript(childThread);
-        }
-
-        cs->SetActive(false);
-        cs->RemoveScriptFromList((CRunningScript**)&CTheScripts::pActiveScripts);
-        CustomScripts.remove(cs);
-
-        if (cs->m_saveEnabled && !cs->IsMission())
-        {
-            TRACE("Stopping custom script named '%s'", cs->GetName().c_str());
-            InactiveScriptHashes.insert(cs->GetCodeChecksum());
-        }
-        else
-        {
-            TRACE("Unregistering custom %s named '%s'", cs->IsMission() ? "mission" : "script", cs->GetName().c_str());
-            ScriptsWaitingForDelete.push_back(cs);
-        }
-    }
-
-    void CScriptEngine::RemoveAllCustomScripts(void)
-    {
-        TRACE("");
-        TRACE("Unloading scripts...");
-
-        if (CustomMission)
-        {
-            RemoveCustomScript(CustomMission);
-        }
-
-        while (!CustomScripts.empty())
-        {
-            RemoveCustomScript(CustomScripts.back());
-        }
-
-        for (auto& script : ScriptsWaitingForDelete)
-        {
-            TRACE(" Deleting inactive script named '%s'", script->GetName().c_str());
-            delete script;
-        }
-        ScriptsWaitingForDelete.clear();
-    }
-
-    void CScriptEngine::UnregisterAllCustomScripts()
-    {
-        TRACE("Unregistering all custom scripts");
-        std::for_each(CustomScripts.begin(), CustomScripts.end(), [this](CCustomScript *cs)
-        {
-            cs->RemoveScriptFromList((CRunningScript**)&CTheScripts::pActiveScripts);
-            cs->SetActive(false);
-        });
-    }
-
-    void CScriptEngine::ReregisterAllCustomScripts()
-    {
-        TRACE("Reregistering all custom scripts");
-        std::for_each(CustomScripts.begin(), CustomScripts.end(), [this](CCustomScript *cs)
-        {
-            cs->AddScriptToList((CRunningScript**)&CTheScripts::pActiveScripts);
-            cs->SetActive(true);
-        });
-    }
+  }
+
+  // unsupported param type
+  LOG_WARNING(thread, "Argument %s expected to be string, got %s in script %s",
+              GetParamInfo().c_str(), ToKindStr(paramType, arrayType),
+              ScriptInfoStr(thread).c_str());
+  CLEO_SkipOpcodeParams(thread, 1); // try skip unhandled param
+  return nullptr;                   // error
 }
+
+void OnLoadScmData(void) {
+  TRACE("Loading scripts save data...");
+  CTheScripts::Load();
+}
+
+void OnSaveScmData(void) {
+  TRACE("Saving scripts save data...");
+  CleoInstance.ScriptEngine.SaveState();
+  CleoInstance.ScriptEngine.UnregisterAllCustomScripts();
+  CTheScripts::Save();
+  CleoInstance.ScriptEngine.ReregisterAllCustomScripts();
+}
+
+struct CleoSafeHeader {
+  const static unsigned sign;
+  unsigned signature;
+  unsigned n_saved_threads;
+  unsigned n_stopped_threads;
+};
+
+const unsigned CleoSafeHeader::sign = 0x31345653;
+
+struct ThreadSavingInfo {
+  unsigned long hash;
+  SCRIPT_VAR tls[32];
+  unsigned timers[2];
+  bool condResult;
+  unsigned sleepTime;
+  eLogicalOperation logicalOp;
+  bool notFlag;
+  ptrdiff_t ip_diff;
+  char threadName[8];
+
+  ThreadSavingInfo(CCustomScript *cs)
+      : hash(cs->m_codeChecksum), condResult(cs->bCondResult),
+        logicalOp(cs->LogicalOp), notFlag(cs->NotFlag != false),
+        ip_diff(cs->CurrentIP - reinterpret_cast<BYTE *>(cs->BaseIP)) {
+    sleepTime = cs->WakeTime >= CTimer::m_snTimeInMilliseconds
+                    ? 0
+                    : cs->WakeTime - CTimer::m_snTimeInMilliseconds;
+    std::copy(cs->LocalVar, cs->LocalVar + 32, tls);
+    std::copy(cs->Timers, cs->Timers + 2, timers);
+    std::copy(cs->Name, cs->Name + 8, threadName);
+  }
+
+  void Apply(CCustomScript *cs) {
+    cs->m_codeChecksum = hash;
+    std::copy(tls, tls + 32, cs->LocalVar);
+    std::copy(timers, timers + 2, cs->Timers);
+    cs->bCondResult = condResult;
+    cs->WakeTime = CTimer::m_snTimeInMilliseconds + sleepTime;
+    cs->LogicalOp = logicalOp;
+    cs->NotFlag = notFlag;
+    cs->CurrentIP = reinterpret_cast<BYTE *>(cs->BaseIP) + ip_diff;
+    std::copy(threadName, threadName + 8, cs->Name);
+    cs->EnableSaving(true);
+  }
+
+  ThreadSavingInfo() {}
+};
+
+SCRIPT_VAR CScriptEngine::CleoVariables[0x400];
+
+template <typename T> void inline ReadBinary(std::istream &s, T &buf) {
+  s.read(reinterpret_cast<char *>(&buf), sizeof(T));
+}
+
+template <typename T>
+void inline ReadBinary(std::istream &s, T *buf, size_t size) {
+  s.read(reinterpret_cast<char *>(buf), sizeof(T) * size);
+}
+
+template <typename T> void inline WriteBinary(std::ostream &s, const T &data) {
+  s.write(reinterpret_cast<const char *>(&data), sizeof(T));
+}
+
+template <typename T>
+void inline WriteBinary(std::ostream &s, const T *data, size_t size) {
+  s.write(reinterpret_cast<const char *>(data), sizeof(T) * size);
+}
+
+void __cdecl CScriptEngine::HOOK_DrawScriptText(char beforeFade) {
+  DrawScriptText_Orig(beforeFade);
+
+  // run registered callbacks
+  for (void *func : CleoInstance.GetCallbacks(eCallbackId::ScriptDraw)) {
+    typedef void WINAPI callback(bool);
+    ((callback *)func)(beforeFade != 0);
+  }
+}
+
+SCRIPT_VAR *CScriptEngine::GetScriptParamPointer(CRunningScript *thread) {
+  auto type = DT_DWORD; // thread->PeekDataType(); // ignored in
+                        // GetPointerToScriptVariable anyway
+  auto ptr = ((::CRunningScript *)thread)->GetPointerToScriptVariable(type);
+  CleoInstance.OpcodeSystem
+      .handledParamCount++; // TODO: hook game's GetPointerToScriptVariable so
+                            // this is always incremented?
+  return (SCRIPT_VAR *)ptr;
+}
+
+void CScriptEngine::GetScriptParams(CRunningScript *script, BYTE count) {
+  ((::CRunningScript *)script)->CollectParameters(count);
+  CleoInstance.OpcodeSystem.handledParamCount += count;
+}
+
+void CScriptEngine::SetScriptParams(CRunningScript *script, BYTE count) {
+  ((::CRunningScript *)script)->StoreParameters(count);
+  CleoInstance.OpcodeSystem.handledParamCount += count;
+}
+
+void CScriptEngine::DrawScriptText_Orig(char beforeFade) {
+  if (beforeFade)
+    CleoInstance.ScriptEngine.DrawScriptTextBeforeFade_Orig(beforeFade);
+  else
+    CleoInstance.ScriptEngine.DrawScriptTextAfterFade_Orig(beforeFade);
+}
+
+void __fastcall CScriptEngine::HOOK_ProcessScript(
+    CLEO::CRunningScript *pScript) {
+  CleoInstance.ScriptEngine
+      .GameBegin(); // all initialized and ready to process scripts
+
+  // run registered callbacks
+  bool process = true;
+  for (void *func :
+       CleoInstance.GetCallbacks(eCallbackId::ScriptProcessBefore)) {
+    typedef bool WINAPI callback(CRunningScript *);
+    process = process && ((callback *)func)(pScript);
+  }
+
+  if (process) {
+    CleoInstance.ScriptEngine.ProcessScript_Orig(pScript);
+  }
+
+  // run registered callbacks
+  for (void *func :
+       CleoInstance.GetCallbacks(eCallbackId::ScriptProcessAfter)) {
+    typedef void WINAPI callback(CRunningScript *);
+    ((callback *)func)(pScript);
+  }
+}
+
+void CScriptEngine::Inject(CCodeInjector &inj) {
+  TRACE("Injecting ScriptEngine: Phase 1");
+  CGameVersionManager &gvm = CleoInstance.VersionManager;
+
+  // Global Events crashfix
+  // inj.MemoryWrite(0xA9AF6C, 0, 4);
+
+  opcodeParams = (SCRIPT_VAR *)ScriptParams; // from Plugin SDK's TheScripts.h
+  missionLocals = (SCRIPT_VAR *)CTheScripts::LocalVariablesForCurrentMission;
+  staticThreads = (CRunningScript *)CTheScripts::ScriptsArray;
+
+  // Protect script dependencies
+  inj.ReplaceFunction(HOOK_ProcessScript,
+                      gvm.TranslateMemoryAddress(MA_CALL_PROCESS_SCRIPT),
+                      &ProcessScript_Orig);
+
+  inj.ReplaceFunction(
+      HOOK_DrawScriptText,
+      gvm.TranslateMemoryAddress(MA_CALL_DRAW_SCRIPT_TEXTS_AFTER_FADE),
+      &DrawScriptTextAfterFade_Orig);
+  inj.ReplaceFunction(
+      HOOK_DrawScriptText,
+      gvm.TranslateMemoryAddress(MA_CALL_DRAW_SCRIPT_TEXTS_BEFORE_FADE),
+      &DrawScriptTextBeforeFade_Orig);
+
+  inj.ReplaceFunction(OnLoadScmData,
+                      gvm.TranslateMemoryAddress(MA_CALL_LOAD_SCM_DATA));
+  inj.ReplaceFunction(OnSaveScmData,
+                      gvm.TranslateMemoryAddress(MA_CALL_SAVE_SCM_DATA));
+}
+
+void CScriptEngine::InjectLate(CCodeInjector &inj) {
+  TRACE("Injecting ScriptEngine: Phase 2");
+  CGameVersionManager &gvm = CleoInstance.VersionManager;
+
+  // limit adjusters support: get adresses from (possibly) patched references
+  inj.MemoryRead(gvm.TranslateMemoryAddress(MA_SCM_BLOCK_REF), scmBlock);
+  inj.MemoryRead(gvm.TranslateMemoryAddress(MA_MISSION_BLOCK_REF),
+                 missionBlock);
+}
+
+CScriptEngine::~CScriptEngine() { GameEnd(); }
+
+CleoSafeHeader safe_header;
+ThreadSavingInfo *safe_info;
+unsigned long *stopped_info;
+std::unique_ptr<ThreadSavingInfo[]> safe_info_utilizer;
+std::unique_ptr<unsigned long[]> stopped_info_utilizer;
+
+void CScriptEngine::GameBegin() {
+  auto &activeScriptsListHead = (CRunningScript *&)
+      CTheScripts::pActiveScripts; // reference, but with type casted to CLEO's
+                                   // CRunningScript
+
+  if (gameInProgress)
+    return; // already started
+  if (activeScriptsListHead == nullptr)
+    return; // main gamescript not loaded yet
+  gameInProgress = true;
+
+  if (CGame::bMissionPackGame == 0) // regular main game
+  {
+    MainScriptFileDir = Filepath_Game + "\\data\\script";
+    MainScriptFileName = "main.scm";
+  } else // mission pack
+  {
+    MainScriptFileDir = Filepath_User + StringPrintf("\\MPACK\\MPACK%d",
+                                                     CGame::bMissionPackGame);
+    MainScriptFileName = "scr.scm";
+  }
+
+  NativeScriptsDebugMode = GetPrivateProfileInt("General", "DebugMode", 0,
+                                                Filepath_Config.c_str()) != 0;
+
+  // global native scripts legacy mode
+  int ver = GetPrivateProfileInt("General", "MainScmLegacyMode", 0,
+                                 Filepath_Config.c_str());
+  switch (ver) {
+  case 3:
+    NativeScriptsVersion = eCLEO_Version::CLEO_VER_3;
+    break;
+  case 4:
+    NativeScriptsVersion = eCLEO_Version::CLEO_VER_4;
+    break;
+  default:
+    NativeScriptsVersion = eCLEO_Version::CLEO_VER_CUR;
+    ver = 0;
+    break;
+  }
+  if (ver != 0)
+    TRACE("Legacy mode for native scripts active: CLEO%d", ver);
+
+  MainScriptCurWorkDir = Filepath_Game;
+
+  CleoInstance.ModuleSystem.LoadCleoModules();
+  LoadState(CleoInstance.saveSlot);
+
+  // keep already loaded scripts at front of processing queue
+  auto head = activeScriptsListHead;
+  auto tail = head;
+  while (tail->Next)
+    tail = tail->Next;
+
+  // load custom scripts as new list
+  activeScriptsListHead = nullptr;
+  LoadCustomScripts();
+
+  // append custom scripts list to the back
+  if (activeScriptsListHead != nullptr) {
+    tail->Next = activeScriptsListHead;
+    activeScriptsListHead->Previous = tail;
+  }
+
+  activeScriptsListHead = head; // restore original
+}
+
+void CScriptEngine::GameEnd() {
+  if (!gameInProgress)
+    return;
+  gameInProgress = false;
+
+  RemoveAllCustomScripts();
+  CleoInstance.ModuleSystem.Clear();
+  memset(CleoVariables, 0, sizeof(CleoVariables));
+}
+
+void CScriptEngine::LoadCustomScripts() {
+  TRACE(""); // separator
+  TRACE("Listing CLEO scripts:");
+
+  std::set<std::string> found;
+
+  auto processFileList = [&](StringList fileList) {
+    for (DWORD i = 0; i < fileList.count; i++) {
+      const auto ext = FS::path(fileList.strings[i]).extension();
+      if (ext == cs_ext || ext == cs3_ext || ext == cs4_ext) {
+        TRACE(" %s", fileList.strings[i]);
+        found.emplace(fileList.strings[i]);
+      }
+    }
+  };
+
+  auto searchPattern = Filepath_Cleo + "\\*" + cs_ext;
+  auto list = CLEO_ListDirectory(nullptr, searchPattern.c_str(), false, true);
+  processFileList(list);
+  CLEO_StringListFree(list);
+
+  searchPattern = Filepath_Cleo + "\\*" + cs3_ext;
+  list = CLEO_ListDirectory(nullptr, searchPattern.c_str(), false, true);
+  processFileList(list);
+  CLEO_StringListFree(list);
+
+  searchPattern = Filepath_Cleo + "\\*" + cs4_ext;
+  list = CLEO_ListDirectory(nullptr, searchPattern.c_str(), false, true);
+  processFileList(list);
+  CLEO_StringListFree(list);
+
+  if (!found.empty()) {
+    TRACE("Starting CLEO scripts...");
+
+    for (const auto &path : found) {
+      LoadScript(path.c_str());
+    }
+  } else {
+    TRACE(" - nothing found");
+  }
+}
+
+CCustomScript *CScriptEngine::LoadScript(const char *szFilePath) {
+  auto cs = new CCustomScript(szFilePath);
+
+  if (!cs || !cs->IsOk()) {
+    TRACE("Loading of custom script '%s' failed", szFilePath);
+    if (cs)
+      delete cs;
+    return nullptr;
+  }
+
+  // check whether the script is in stop-list
+  if (stopped_info) {
+    for (size_t i = 0; i < safe_header.n_stopped_threads; ++i) {
+      if (stopped_info[i] == cs->m_codeChecksum) {
+        TRACE("Custom script '%s' found in the stop-list", szFilePath);
+        InactiveScriptHashes.insert(stopped_info[i]);
+        delete cs;
+        return nullptr;
+      }
+    }
+  }
+
+  // check whether the script is in safe-list
+  if (safe_info) {
+    for (size_t i = 0; i < safe_header.n_saved_threads; ++i) {
+      if (safe_info[i].hash == cs->GetCodeChecksum()) {
+        TRACE("Custom script '%s' found in the safe-list", szFilePath);
+        safe_info[i].Apply(cs);
+        break;
+      }
+    }
+  }
+
+  AddCustomScript(cs);
+  return cs;
+}
+
+CCustomScript *CScriptEngine::CreateCustomScript(CRunningScript *fromThread,
+                                                 const char *script_name,
+                                                 int label) {
+  auto filename =
+      reinterpret_cast<CCustomScript *>(fromThread)
+          ->ResolvePath(script_name,
+                        DIR_CLEO); // legacy: default search location is
+                                   // game\cleo directory
+
+  if (label != 0) // create from label
+  {
+    TRACE("Starting new custom script from thread named '%s' label 0x%08X",
+          filename.c_str(), label);
+  } else {
+    TRACE("Starting new custom script '%s'", filename.c_str());
+  }
+
+  // if "label == 0" then "script_name" need to be the file name
+  auto cs = new CCustomScript(filename.c_str(), false, fromThread, label);
+  if (fromThread)
+    fromThread->SetConditionResult(cs && cs->IsOk());
+  if (cs && cs->IsOk()) {
+    AddCustomScript(cs);
+    if (fromThread)
+      ((::CRunningScript *)fromThread)
+          ->ReadParametersForNewlyStartedScript((::CRunningScript *)cs);
+  } else {
+    if (cs)
+      delete cs;
+    if (fromThread)
+      SkipUnusedVarArgs(fromThread);
+    LOG_WARNING(0, "Failed to load script '%s'", filename.c_str());
+    return nullptr;
+  }
+
+  return cs;
+}
+
+void CScriptEngine::LoadState(int saveSlot) {
+  memset(CleoVariables, 0, sizeof(CleoVariables));
+  safe_info = nullptr;
+  stopped_info = nullptr;
+  safe_header.n_saved_threads = safe_header.n_stopped_threads = 0;
+
+  if (saveSlot == -1)
+    return; // new game started
+
+  auto saveFile = FS::path(Filepath_Cleo)
+                      .append(StringPrintf("cleo_saves\\cs%d.sav", saveSlot))
+                      .string();
+
+  // load cleo saving file
+  try {
+    TRACE(""); // separator
+    TRACE("Loading cleo safe '%s'", saveFile.c_str());
+    std::ifstream ss(saveFile.c_str(), std::ios::binary);
+    if (ss.is_open()) {
+      ss.exceptions(std::ios::eofbit | std::ios::badbit | std::ios::failbit);
+      ReadBinary(ss, safe_header);
+      if (safe_header.signature != CleoSafeHeader::sign)
+        throw std::runtime_error("Invalid file format");
+      safe_info = new ThreadSavingInfo[safe_header.n_saved_threads];
+      safe_info_utilizer.reset(safe_info);
+      stopped_info = new unsigned long[safe_header.n_stopped_threads];
+      stopped_info_utilizer.reset(stopped_info);
+      ReadBinary(ss, CleoVariables, 0x400);
+      ReadBinary(ss, safe_info, safe_header.n_saved_threads);
+      ReadBinary(ss, stopped_info, safe_header.n_stopped_threads);
+      for (size_t i = 0; i < safe_header.n_stopped_threads; ++i)
+        InactiveScriptHashes.insert(stopped_info[i]);
+      TRACE("Finished. Loaded %u cleo variables, %u saved threads info, %u "
+            "stopped threads info",
+            0x400, safe_header.n_saved_threads, safe_header.n_stopped_threads);
+    } else {
+      memset(CleoVariables, 0, sizeof(CleoVariables));
+    }
+  } catch (std::exception &ex) {
+    TRACE("Loading of cleo safe '%s' failed: %s", saveFile.c_str(), ex.what());
+    safe_header.n_saved_threads = safe_header.n_stopped_threads = 0;
+    memset(CleoVariables, 0, sizeof(CleoVariables));
+  }
+}
+
+void CScriptEngine::SaveState() {
+  try {
+    std::list<CCustomScript *> savedThreads;
+    std::for_each(CustomScripts.begin(), CustomScripts.end(),
+                  [this, &savedThreads](CCustomScript *cs) {
+                    if (cs->m_saveEnabled)
+                      savedThreads.push_back(cs);
+                  });
+
+    CleoSafeHeader header = {CleoSafeHeader::sign, savedThreads.size(),
+                             InactiveScriptHashes.size()};
+
+    char safe_name[MAX_PATH];
+    sprintf_s(safe_name, "./cleo/cleo_saves/cs%d.sav",
+              FrontEndMenuManager.m_nSelectedSaveGame);
+    TRACE("Saving script engine state to the file '%s'", safe_name);
+
+    CreateDirectory("cleo", NULL);
+    CreateDirectory("cleo/cleo_saves", NULL);
+    std::ofstream ss(safe_name, std::ios::binary);
+    if (ss.is_open()) {
+      ss.exceptions(std::ios::failbit | std::ios::badbit);
+
+      WriteBinary(ss, header);
+      WriteBinary(ss, CleoVariables, 0x400);
+
+      std::for_each(savedThreads.begin(), savedThreads.end(),
+                    [&savedThreads, &ss](CCustomScript *cs) {
+                      ThreadSavingInfo savingInfo(cs);
+                      WriteBinary(ss, savingInfo);
+                    });
+
+      std::for_each(InactiveScriptHashes.begin(), InactiveScriptHashes.end(),
+                    [&ss](unsigned long hash) { WriteBinary(ss, hash); });
+
+      TRACE(
+          "Done. Saved %u cleo variables, %u saved threads, %u stopped threads",
+          0x400, header.n_saved_threads, header.n_stopped_threads);
+    } else {
+      TRACE("Failed to write save file '%s'!", safe_name);
+    }
+  } catch (std::exception &ex) {
+    TRACE("Saving failed. %s", ex.what());
+  }
+}
+
+CRunningScript *CScriptEngine::FindScriptNamed(const char *threadName,
+                                               bool standardScripts,
+                                               bool customScripts,
+                                               size_t resultIndex) {
+  if (standardScripts) {
+    for (auto script = (CRunningScript *)CTheScripts::pActiveScripts; script;
+         script = script->GetNext()) {
+      if (script->IsCustom()) {
+        // skip custom scripts in the queue, they are handled separately
+        continue;
+      }
+      if (_strnicmp(threadName, script->Name, sizeof(script->Name)) == 0) {
+        if (resultIndex == 0)
+          return script;
+        else
+          resultIndex--;
+      }
+    }
+  }
+
+  if (customScripts) {
+    if (CustomMission) {
+      if (_strnicmp(threadName, CustomMission->Name,
+                    sizeof(CustomMission->Name)) == 0) {
+        if (resultIndex == 0)
+          return CustomMission;
+        else
+          resultIndex--;
+      }
+    }
+
+    for (auto it = CustomScripts.begin(); it != CustomScripts.end(); ++it) {
+      auto cs = *it;
+      if (_strnicmp(threadName, cs->Name, sizeof(cs->Name)) == 0) {
+        if (resultIndex == 0)
+          return cs;
+        else
+          resultIndex--;
+      }
+    }
+  }
+
+  return nullptr;
+}
+
+CRunningScript *CScriptEngine::FindScriptByFilename(const char *path,
+                                                    size_t resultIndex) {
+  if (path == nullptr)
+    return nullptr;
+
+  auto pathLen = strlen(path);
+  auto CheckScript = [&](CRunningScript *script) {
+    if (script == nullptr)
+      return false;
+
+    auto cs = (CCustomScript *)script;
+    std::string scriptPath = cs->GetScriptFileFullPath();
+
+    if (scriptPath.length() < pathLen)
+      return false;
+
+    auto startPos = scriptPath.length() - pathLen;
+    if (_strnicmp(path, scriptPath.c_str() + startPos, pathLen) == 0) {
+      if (startPos > 0 && path[startPos - 1] != '\\')
+        return false; // whole file/dir name must match
+
+      return true;
+    }
+
+    return false;
+  };
+
+  // standard scripts
+  for (auto script = (CRunningScript *)CTheScripts::pActiveScripts; script;
+       script = script->GetNext()) {
+    if (CheckScript(script)) {
+      if (resultIndex == 0)
+        return script;
+      else
+        resultIndex--;
+    }
+  }
+
+  // custom scripts
+  if (CheckScript(CustomMission)) {
+    if (resultIndex == 0)
+      return CustomMission;
+    else
+      resultIndex--;
+  }
+
+  for (auto it = CustomScripts.begin(); it != CustomScripts.end(); ++it) {
+    auto cs = *it;
+    if (CheckScript(cs)) {
+      if (resultIndex == 0)
+        return cs;
+      else
+        resultIndex--;
+    }
+  }
+
+  return nullptr;
+}
+
+bool CScriptEngine::IsActiveScriptPtr(const CRunningScript *ptr) const {
+  for (auto script = (CRunningScript *)CTheScripts::pActiveScripts;
+       script != nullptr; script = script->GetNext()) {
+    if (script == ptr)
+      return ptr->IsActive();
+  }
+
+  for (const auto script : CustomScripts) {
+    if (script == ptr)
+      return ptr->IsActive();
+  }
+
+  return false;
+}
+
+bool CScriptEngine::IsValidScriptPtr(const CRunningScript *ptr) const {
+  for (auto script = (CRunningScript *)CTheScripts::pActiveScripts;
+       script != nullptr; script = script->GetNext()) {
+    if (script == ptr)
+      return true;
+  }
+
+  for (auto script = (CLEO::CRunningScript *)CTheScripts::pIdleScripts;
+       script != nullptr; script = script->GetNext()) {
+    if (script == ptr)
+      return true;
+  }
+
+  for (const auto script : CustomScripts) {
+    if (script == ptr)
+      return true;
+  }
+
+  for (const auto script : ScriptsWaitingForDelete) {
+    if (script == ptr)
+      return true;
+  }
+
+  return false;
+}
+
+void CScriptEngine::AddCustomScript(CCustomScript *cs) {
+  if (cs->IsMission()) {
+    TRACE("Registering custom mission named '%s'", cs->GetName().c_str());
+    CustomMission = cs;
+  } else {
+    TRACE("Registering custom script named '%s'", cs->GetName().c_str());
+    CustomScripts.push_back(cs);
+  }
+
+  cs->AddScriptToList((CRunningScript **)&CTheScripts::pActiveScripts);
+  cs->SetActive(true);
+
+  // run registered callbacks
+  for (void *func : CleoInstance.GetCallbacks(eCallbackId::ScriptRegister)) {
+    typedef void WINAPI callback(CCustomScript *);
+    ((callback *)func)(cs);
+  }
+}
+
+void CScriptEngine::RemoveScript(CRunningScript *script) {
+  if (script->IsMission())
+    CTheScripts::bAlreadyRunningAMissionScript = false;
+
+  if (script->IsCustom()) {
+    RemoveCustomScript((CCustomScript *)script);
+  } else // native script
+  {
+    auto cs = (CCustomScript *)script;
+    cs->RemoveScriptFromList((CRunningScript **)&CTheScripts::pActiveScripts);
+    cs->AddScriptToList((CRunningScript **)&CTheScripts::pIdleScripts);
+    cs->ShutdownThisScript();
+  }
+}
+
+void CScriptEngine::RemoveCustomScript(CCustomScript *cs) {
+  // run registered callbacks
+  for (void *func : CleoInstance.GetCallbacks(eCallbackId::ScriptUnregister)) {
+    typedef void WINAPI callback(CCustomScript *);
+    ((callback *)func)(cs);
+  }
+
+  if (cs == CustomMission) {
+    CustomMission = nullptr;
+    CTheScripts::bAlreadyRunningAMissionScript = false; // on_mission
+  }
+
+  if (cs->m_parentScript) {
+    cs->BaseIP = 0; // don't delete BaseIP if child thread
+  }
+
+  for (auto childThread : cs->m_childScripts) {
+    RemoveScript(childThread);
+  }
+
+  cs->SetActive(false);
+  cs->RemoveScriptFromList((CRunningScript **)&CTheScripts::pActiveScripts);
+  CustomScripts.remove(cs);
+
+  if (cs->m_saveEnabled && !cs->IsMission()) {
+    TRACE("Stopping custom script named '%s'", cs->GetName().c_str());
+    InactiveScriptHashes.insert(cs->GetCodeChecksum());
+  } else {
+    TRACE("Unregistering custom %s named '%s'",
+          cs->IsMission() ? "mission" : "script", cs->GetName().c_str());
+    ScriptsWaitingForDelete.push_back(cs);
+  }
+}
+
+void CScriptEngine::RemoveAllCustomScripts(void) {
+  TRACE("");
+  TRACE("Unloading scripts...");
+
+  if (CustomMission) {
+    RemoveCustomScript(CustomMission);
+  }
+
+  while (!CustomScripts.empty()) {
+    RemoveCustomScript(CustomScripts.back());
+  }
+
+  for (auto &script : ScriptsWaitingForDelete) {
+    TRACE(" Deleting inactive script named '%s'", script->GetName().c_str());
+    delete script;
+  }
+  ScriptsWaitingForDelete.clear();
+}
+
+void CScriptEngine::UnregisterAllCustomScripts() {
+  TRACE("Unregistering all custom scripts");
+  std::for_each(CustomScripts.begin(), CustomScripts.end(),
+                [this](CCustomScript *cs) {
+                  cs->RemoveScriptFromList(
+                      (CRunningScript **)&CTheScripts::pActiveScripts);
+                  cs->SetActive(false);
+                });
+}
+
+void CScriptEngine::ReregisterAllCustomScripts() {
+  TRACE("Reregistering all custom scripts");
+  std::for_each(
+      CustomScripts.begin(), CustomScripts.end(), [this](CCustomScript *cs) {
+        cs->AddScriptToList((CRunningScript **)&CTheScripts::pActiveScripts);
+        cs->SetActive(true);
+      });
+}
+} // namespace CLEO

--- a/source/CScriptEngine.h
+++ b/source/CScriptEngine.h
@@ -1,92 +1,103 @@
 #pragma once
 #include "CCustomScript.h"
 
-namespace CLEO
-{
-    const char cs_ext[] = ".cs";
-    const char cs4_ext[] = ".cs4";
-    const char cs3_ext[] = ".cs3";
+namespace CLEO {
+const char cs_ext[] = ".cs";
+const char cs4_ext[] = ".cs4";
+const char cs3_ext[] = ".cs3";
 
-    class CScriptEngine
-    {
-    public:
-        bool gameInProgress = false;
+class CScriptEngine {
+public:
+  bool gameInProgress = false;
 
-        BYTE* scmBlock = nullptr;
-        BYTE* missionBlock = nullptr;
-        int missionIndex = -1;
+  BYTE *scmBlock = nullptr;
+  BYTE *missionBlock = nullptr;
+  int missionIndex = -1;
 
-        friend class CCustomScript;
-        std::list<CCustomScript*> CustomScripts;
-        std::list<CCustomScript*> ScriptsWaitingForDelete;
-        std::set<unsigned long> InactiveScriptHashes;
-        CCustomScript *CustomMission = nullptr;
-        CCustomScript *LastScriptCreated = nullptr;
+  friend class CCustomScript;
+  std::list<CCustomScript *> CustomScripts;
+  std::list<CCustomScript *> ScriptsWaitingForDelete;
+  std::set<unsigned long> InactiveScriptHashes;
+  CCustomScript *CustomMission = nullptr;
+  CCustomScript *LastScriptCreated = nullptr;
 
-        CCustomScript* LoadScript(const char* filePath);
-        CCustomScript* CreateCustomScript(CRunningScript* fromThread, const char* filePath, int label);
+  CCustomScript *LoadScript(const char *filePath);
+  CCustomScript *CreateCustomScript(CRunningScript *fromThread,
+                                    const char *filePath, int label);
 
-        bool NativeScriptsDebugMode = false; // debug mode enabled?
-        eCLEO_Version NativeScriptsVersion = eCLEO_Version::CLEO_VER_CUR; // allows using legacy modes
-        std::string MainScriptFileDir;
-        std::string MainScriptFileName;
-        std::string MainScriptCurWorkDir;
+  bool NativeScriptsDebugMode = false; // debug mode enabled?
+  eCLEO_Version NativeScriptsVersion =
+      eCLEO_Version::CLEO_VER_CUR; // allows using legacy modes
+  std::string MainScriptFileDir;
+  std::string MainScriptFileName;
+  std::string MainScriptCurWorkDir;
 
-        static SCRIPT_VAR CleoVariables[0x400];
+  static SCRIPT_VAR CleoVariables[0x400];
 
-        CScriptEngine() = default;
-        CScriptEngine(const CScriptEngine&) = delete; // no copying
-        ~CScriptEngine();
-        
-        void Inject(CCodeInjector&); // Phase 1
-        void InjectLate(CCodeInjector&); // Phase 2
+  CScriptEngine() = default;
+  CScriptEngine(const CScriptEngine &) = delete; // no copying
+  ~CScriptEngine();
 
-        void GameBegin(); // call after new game started
-        void GameEnd();
+  void Inject(CCodeInjector &);     // Phase 1
+  void InjectLate(CCodeInjector &); // Phase 2
 
-        void LoadCustomScripts();
+  void GameBegin(); // call after new game started
+  void GameEnd();
 
-        // CLEO saves
-        void LoadState(int saveSlot);
-        void SaveState();
+  void LoadCustomScripts();
 
-        CRunningScript* FindScriptNamed(const char* threadName, bool standardScripts, bool customScripts, size_t resultIndex = 0); // can be called multiple times to find more scripts named threadName. resultIndex should be incremented until the method returns nullptr
-        CRunningScript* FindScriptByFilename(const char* path, size_t resultIndex = 0); // if path is not absolute it will be resolved with cleo directory as root
-        bool IsActiveScriptPtr(const CRunningScript*) const; // leads to active script? (regular or custom)
-        bool IsValidScriptPtr(const CRunningScript*) const; // leads to any script? (regular or custom)
-        void AddCustomScript(CCustomScript*);
-        void RemoveScript(CRunningScript*); // native or custom
-        void RemoveAllCustomScripts();
+  // CLEO saves
+  void LoadState(int saveSlot);
+  void SaveState();
 
-        // remove/re-add to active scripts queue
-        void UnregisterAllCustomScripts();
-        void ReregisterAllCustomScripts();
+  CRunningScript *
+  FindScriptNamed(const char *threadName, bool standardScripts,
+                  bool customScripts,
+                  size_t resultIndex =
+                      0); // can be called multiple times to find more scripts
+                          // named threadName. resultIndex should be incremented
+                          // until the method returns nullptr
+  CRunningScript *FindScriptByFilename(
+      const char *path,
+      size_t resultIndex = 0); // if path is not absolute it will be resolved
+                               // with cleo directory as root
+  bool IsActiveScriptPtr(const CRunningScript *)
+      const; // leads to active script? (regular or custom)
+  bool IsValidScriptPtr(
+      const CRunningScript *) const; // leads to any script? (regular or custom)
+  void AddCustomScript(CCustomScript *);
+  void RemoveScript(CRunningScript *); // native or custom
+  void RemoveAllCustomScripts();
 
-        inline CCustomScript* GetCustomMission() { return CustomMission; }
-        inline size_t WorkingScriptsCount() { return CustomScripts.size(); }
+  // remove/re-add to active scripts queue
+  void UnregisterAllCustomScripts();
+  void ReregisterAllCustomScripts();
 
-        static SCRIPT_VAR* GetScriptParamPointer(CRunningScript* thread);
+  inline CCustomScript *GetCustomMission() { return CustomMission; }
+  inline size_t WorkingScriptsCount() { return CustomScripts.size(); }
 
-        // params into/from opcodeParams array
-        static void GetScriptParams(CRunningScript* script, BYTE count);
-        static void SetScriptParams(CRunningScript* script, BYTE count);
+  static SCRIPT_VAR *GetScriptParamPointer(CRunningScript *thread);
 
-        static void DrawScriptText_Orig(char beforeFade);
+  // params into/from opcodeParams array
+  static void GetScriptParams(CRunningScript *script, BYTE count);
+  static void SetScriptParams(CRunningScript *script, BYTE count);
 
-    private:
-        void RemoveCustomScript(CCustomScript*);
+  static void DrawScriptText_Orig(char beforeFade);
 
-        static void __cdecl HOOK_DrawScriptText(char beforeFade);
-        void(__cdecl* DrawScriptTextBeforeFade_Orig)(char beforeFade) = nullptr;
-        void(__cdecl* DrawScriptTextAfterFade_Orig)(char beforeFade) = nullptr;
-        
-        static void __fastcall HOOK_ProcessScript(CLEO::CRunningScript*);
-        void(__fastcall* ProcessScript_Orig)(CLEO::CRunningScript*) = nullptr;
-    };
+private:
+  void RemoveCustomScript(CCustomScript *);
 
-    // reimplemented hook of original game's procedure
-    // returns buff or pointer provided by script, nullptr on fail
-    // WARNING: Null terminator ommited if not enought space in the buffer!
-    const char* __fastcall GetScriptStringParam(CRunningScript* thread, int dummy, char* buff, int buffLen); 
-}
+  static void __cdecl HOOK_DrawScriptText(char beforeFade);
+  void(__cdecl *DrawScriptTextBeforeFade_Orig)(char beforeFade) = nullptr;
+  void(__cdecl *DrawScriptTextAfterFade_Orig)(char beforeFade) = nullptr;
 
+  static void __fastcall HOOK_ProcessScript(CLEO::CRunningScript *);
+  void(__fastcall *ProcessScript_Orig)(CLEO::CRunningScript *) = nullptr;
+};
+
+// reimplemented hook of original game's procedure
+// returns buff or pointer provided by script, nullptr on fail
+// WARNING: Null terminator ommited if not enought space in the buffer!
+const char *__fastcall GetScriptStringParam(CRunningScript *thread, int dummy,
+                                            char *buff, int buffLen);
+} // namespace CLEO

--- a/source/CleoBase.cpp
+++ b/source/CleoBase.cpp
@@ -1,316 +1,333 @@
-#include "stdafx.h"
 #include "CleoBase.h"
 #include "Singleton.h"
+#include "stdafx.h"
 
+namespace CLEO {
+CCleoInstance CleoInstance;
 
-namespace CLEO
-{
-    CCleoInstance CleoInstance;
+inline CCleoInstance::~CCleoInstance() { Stop(); }
 
-    inline CCleoInstance::~CCleoInstance()
-    {
-        Stop();
-    }
+void __cdecl CCleoInstance::OnUpdateGameLogics() {
+  CleoInstance.CallCallbacks(
+      eCallbackId::GameProcessBefore); // execute registered callbacks
 
-    void __cdecl CCleoInstance::OnUpdateGameLogics()
-    {
-        CleoInstance.CallCallbacks(eCallbackId::GameProcessBefore); // execute registered callbacks
+  CleoInstance.UpdateGameLogics_Orig(); // call original function
 
-        CleoInstance.UpdateGameLogics_Orig(); // call original function
-
-        CleoInstance.CallCallbacks(eCallbackId::GameProcessAfter); // execute registered callbacks
-    }
-
-    HWND CCleoInstance::OnCreateMainWnd(HINSTANCE hinst)
-    {
-        CleoSingletonCheck(); // check once for CLEO.asi duplicates
-
-        auto window = CleoInstance.CreateMainWnd_Orig(hinst); // call original
-
-        // redirect window handling procedure
-        *((size_t*)&CleoInstance.MainWndProc_Orig) = GetWindowLongPtr(window, GWLP_WNDPROC); // store original address
-        SetWindowLongPtr(window, GWLP_WNDPROC, (LONG)OnMainWndProc);
-
-        return window;
-    }
-
-    LRESULT __stdcall CCleoInstance::OnMainWndProc(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
-    {
-        switch (msg)
-        {
-            case WM_ACTIVATE:
-                CleoInstance.CallCallbacks(eCallbackId::MainWindowFocus, wparam != 0);
-                break;
-
-            case WM_KILLFOCUS:
-                CleoInstance.CallCallbacks(eCallbackId::MainWindowFocus, false);
-                break;
-        }
-
-        return CleoInstance.MainWndProc_Orig(wnd, msg, wparam, lparam);
-    }
-
-    void CCleoInstance::OnScmInit1()
-    {
-        CleoInstance.ScmInit1_Orig(); // call original
-        CleoInstance.GameBegin();
-    }
-
-    void CCleoInstance::OnScmInit2() // load save
-    {
-        CleoInstance.ScmInit2_Orig(); // call original
-        CleoInstance.GameBegin();
-    }
-
-    void CCleoInstance::OnScmInit3()
-    {
-        CleoInstance.ScmInit3_Orig(); // call original
-        CleoInstance.GameBegin();
-    }
-
-    void __declspec(naked) CCleoInstance::OnGameShutdown()
-    {
-        CleoInstance.GameEnd();
-        static DWORD oriFunc;
-        oriFunc = (DWORD)(CleoInstance.GameShutdown_Orig);
-        _asm jmp oriFunc
-    }
-
-    void __declspec(naked) CCleoInstance::OnGameRestart1()
-    {
-        CleoInstance.GameEnd();
-        static DWORD oriFunc;
-        oriFunc = (DWORD)(CleoInstance.GameRestart1_Orig);
-        _asm jmp oriFunc
-    }
-
-    void __declspec(naked) CCleoInstance::OnGameRestart2()
-    {
-        CleoInstance.GameEnd();
-        static DWORD oriFunc;
-        oriFunc = (DWORD)(CleoInstance.GameRestart2_Orig);
-        _asm jmp oriFunc
-    }
-
-    void __declspec(naked) CCleoInstance::OnGameRestart3()
-    {
-        CleoInstance.GameEnd();
-        static DWORD oriFunc;
-        oriFunc = (DWORD)(CleoInstance.GameRestart3_Orig);
-        _asm jmp oriFunc
-    }
-
-    void __cdecl CCleoInstance::OnDebugDisplayTextBuffer_Idle()
-    {
-        CleoInstance.GameRestartDebugDisplayTextBuffer_IdleOrig(); // call original
-        CleoInstance.CallCallbacks(eCallbackId::DrawingFinished); // execute registered callbacks
-    }
-
-    void __cdecl CCleoInstance::OnDebugDisplayTextBuffer_Frontend()
-    {
-        CleoInstance.GameRestartDebugDisplayTextBuffer_FrontendOrig(); // call original
-        CleoInstance.CallCallbacks(eCallbackId::DrawingFinished); // execute registered callbacks
-    }
-
-    void CCleoInstance::Start(InitStage stage)
-    {
-        if (stage > InitStage::Done) return; // invalid argument
-
-        auto nextStage = InitStage(m_initStage + 1);
-        if (stage != nextStage) return;
-
-        if (stage == InitStage::Initial)
-        {
-            TRACE("CLEO initialization: Phase 1");
-
-            FS::create_directory(Filepath_Cleo);
-            FS::create_directory(Filepath_Cleo + "\\cleo_modules");
-            FS::create_directory(Filepath_Cleo + "\\cleo_plugins");
-            FS::create_directory(Filepath_Cleo + "\\cleo_saves");
-
-            OpcodeInfoDb.Load((Filepath_Cleo + "\\.config\\sa.json").c_str());
-
-            CodeInjector.OpenReadWriteAccess(); // must do this earlier to ensure plugins write access on init
-            GameMenu.Inject(CodeInjector);
-            DmaFix.Inject(CodeInjector);
-            OpcodeSystem.Inject(CodeInjector);
-            ScriptEngine.Inject(CodeInjector);
-
-            CodeInjector.ReplaceFunction(OnCreateMainWnd, VersionManager.TranslateMemoryAddress(MA_CALL_CREATE_MAIN_WINDOW), &CreateMainWnd_Orig);
-
-            CodeInjector.ReplaceFunction(OnScmInit1, VersionManager.TranslateMemoryAddress(MA_CALL_INIT_SCM1), &ScmInit1_Orig);
-            CodeInjector.ReplaceFunction(OnScmInit2, VersionManager.TranslateMemoryAddress(MA_CALL_INIT_SCM2), &ScmInit2_Orig);
-            CodeInjector.ReplaceFunction(OnScmInit3, VersionManager.TranslateMemoryAddress(MA_CALL_INIT_SCM3), &ScmInit3_Orig);
-
-            CodeInjector.ReplaceFunction(OnGameShutdown, VersionManager.TranslateMemoryAddress(MA_CALL_GAME_SHUTDOWN), &GameShutdown_Orig);
-
-            CodeInjector.ReplaceFunction(OnGameRestart1, VersionManager.TranslateMemoryAddress(MA_CALL_GAME_RESTART_1), &GameRestart1_Orig);
-            CodeInjector.ReplaceFunction(OnGameRestart2, VersionManager.TranslateMemoryAddress(MA_CALL_GAME_RESTART_2), &GameRestart2_Orig);
-            CodeInjector.ReplaceFunction(OnGameRestart3, VersionManager.TranslateMemoryAddress(MA_CALL_GAME_RESTART_3), &GameRestart3_Orig);
-
-            OpcodeSystem.Init();
-            PluginSystem.LoadPlugins();
-        }
-        
-        // delayed until menu background drawing
-        if (stage == InitStage::OnDraw)
-        {
-            TRACE("CLEO initialization: Phase 2");
-
-            const_cast<std::string&>(Filepath_User) = GetUserDirectory(); // force update now, as it could be modifed by PortableGTA.asi
-
-            ScriptEngine.InjectLate(CodeInjector);
-
-            CodeInjector.InjectFunction(GetScriptStringParam, gaddrof(::CRunningScript::ReadTextLabelFromScript));
-            CodeInjector.ReplaceFunction(OnDebugDisplayTextBuffer_Idle, VersionManager.TranslateMemoryAddress(MA_CALL_DEBUG_DISPLAY_TEXT_BUFFER_IDLE), &GameRestartDebugDisplayTextBuffer_IdleOrig);
-            CodeInjector.ReplaceFunction(OnDebugDisplayTextBuffer_Frontend, VersionManager.TranslateMemoryAddress(MA_CALL_DEBUG_DISPLAY_TEXT_BUFFER_FRONTEND), &GameRestartDebugDisplayTextBuffer_FrontendOrig);
-            CodeInjector.ReplaceFunction(OnUpdateGameLogics, VersionManager.TranslateMemoryAddress(MA_CALL_UPDATE_GAME_LOGICS), &UpdateGameLogics_Orig);
-
-            PluginSystem.LogLoadedPlugins();
-        }
-
-        m_initStage = stage;
-    }
-
-    void CCleoInstance::Stop()
-    {
-        GameEnd();
-        PluginSystem.UnloadPlugins();
-        m_initStage = InitStage::None;
-    }
-
-    void CCleoInstance::GameBegin()
-    {
-        if (m_bGameInProgress) return;
-        m_bGameInProgress = true;
-
-        saveSlot = FrontEndMenuManager.m_bWantToLoad ? FrontEndMenuManager.m_nSelectedSaveGame : -1;
-
-        TRACE("Starting new game session, save slot: %d", saveSlot);
-
-        // late initialization if not done yet
-        CleoInstance.Start(CCleoInstance::InitStage::OnDraw);
-
-        // execute registered callbacks
-        CleoInstance.CallCallbacks(eCallbackId::GameBegin, saveSlot);
-    }
-
-    void CCleoInstance::GameEnd()
-    {
-        if (!m_bGameInProgress) return;
-        m_bGameInProgress = false;
-
-        TRACE("Ending current game session");
-        CleoInstance.CallCallbacks(eCallbackId::GameEnd); // execute registered callbacks
-        ScriptEngine.GameEnd();
-        OpcodeSystem.FinalizeScriptObjects();
-
-        saveSlot = -1;
-    }
-
-    void CCleoInstance::AddCallback(eCallbackId id, void* func)
-    {
-        m_callbacks[id].insert(func);
-    }
-
-    void CCleoInstance::RemoveCallback(eCallbackId id, void* func)
-    {
-        m_callbacks[id].erase(func);
-    }
-
-    const std::set<void*>& CCleoInstance::GetCallbacks(eCallbackId id)
-    {
-        return m_callbacks[id];
-    }
-
-    void CCleoInstance::CallCallbacks(eCallbackId id)
-    {
-        for (void* func : GetCallbacks(id))
-        {
-            typedef void WINAPI callback(void);
-            ((callback*)func)();
-        }
-    }
-
-    void CCleoInstance::CallCallbacks(eCallbackId id, DWORD arg)
-    {
-        for (void* func : GetCallbacks(id))
-        {
-            typedef void WINAPI callback(DWORD);
-            ((callback*)func)(arg);
-        }
-    }
-
-    void WINAPI CLEO_ResolvePath(CLEO::CRunningScript* thread, char* inOutPath, DWORD pathMaxLen)
-    {
-        if (thread == nullptr || inOutPath == nullptr || pathMaxLen < 2)
-        {
-            return; // invalid param
-        }
-
-        auto resolved = reinterpret_cast<CCustomScript*>(thread)->ResolvePath(inOutPath);
-
-        if (resolved.length() >= pathMaxLen)
-            resolved.resize(pathMaxLen - 1); // and terminator character
-
-        std::memcpy(inOutPath, resolved.c_str(), resolved.length() + 1); // with terminator
-    }
-
-    void WINAPI CLEO_StringListFree(StringList list)
-    {
-        if (list.count > 0 && list.strings != nullptr)
-        {
-            for (DWORD i = 0; i < list.count; i++)
-            {
-                free(list.strings[i]);
-            }
-
-            free(list.strings);
-        }
-    }
-
-    StringList WINAPI CLEO_ListDirectory(CLEO::CRunningScript* thread, const char* searchPath, BOOL listDirs, BOOL listFiles)
-    {
-        if (searchPath == nullptr)
-            return {}; // invalid param
-
-        if (!listDirs && !listFiles)
-            return {}; // nothing to list, done
-
-        // make absolute
-        auto fsSearchPath = FS::path(searchPath);
-        if (!fsSearchPath.is_absolute())
-        {
-            if (thread != nullptr)
-                fsSearchPath = ((CCustomScript*)thread)->GetWorkDir() / fsSearchPath;
-            else
-                fsSearchPath = Filepath_Game / fsSearchPath;
-        }
-
-        WIN32_FIND_DATA wfd = { 0 };
-        HANDLE hSearch = FindFirstFile(fsSearchPath.string().c_str(), &wfd);
-        if (hSearch == INVALID_HANDLE_VALUE)
-            return {}; // nothing found
-
-        std::set<std::string> found;
-        do
-        {
-            if (!listDirs && (wfd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) 
-                continue; // skip directories
-
-            if (!listFiles && !(wfd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY))
-                continue; // skip files
-
-            auto path = FS::path(wfd.cFileName);
-            if (!path.is_absolute()) // keep absolute in case somebody hooked the APIs to return so
-                path = fsSearchPath.parent_path() / path;
-
-            found.insert(path.string());
-        } while (FindNextFile(hSearch, &wfd));
-
-        FindClose(hSearch);
-
-        return CreateStringList(found);
-    }
+  CleoInstance.CallCallbacks(
+      eCallbackId::GameProcessAfter); // execute registered callbacks
 }
 
+HWND CCleoInstance::OnCreateMainWnd(HINSTANCE hinst) {
+  CleoSingletonCheck(); // check once for CLEO.asi duplicates
+
+  auto window = CleoInstance.CreateMainWnd_Orig(hinst); // call original
+
+  // redirect window handling procedure
+  *((size_t *)&CleoInstance.MainWndProc_Orig) =
+      GetWindowLongPtr(window, GWLP_WNDPROC); // store original address
+  SetWindowLongPtr(window, GWLP_WNDPROC, (LONG)OnMainWndProc);
+
+  return window;
+}
+
+LRESULT __stdcall CCleoInstance::OnMainWndProc(HWND wnd, UINT msg,
+                                               WPARAM wparam, LPARAM lparam) {
+  switch (msg) {
+  case WM_ACTIVATE:
+    CleoInstance.CallCallbacks(eCallbackId::MainWindowFocus, wparam != 0);
+    break;
+
+  case WM_KILLFOCUS:
+    CleoInstance.CallCallbacks(eCallbackId::MainWindowFocus, false);
+    break;
+  }
+
+  return CleoInstance.MainWndProc_Orig(wnd, msg, wparam, lparam);
+}
+
+void CCleoInstance::OnScmInit1() {
+  CleoInstance.ScmInit1_Orig(); // call original
+  CleoInstance.GameBegin();
+}
+
+void CCleoInstance::OnScmInit2() // load save
+{
+  CleoInstance.ScmInit2_Orig(); // call original
+  CleoInstance.GameBegin();
+}
+
+void CCleoInstance::OnScmInit3() {
+  CleoInstance.ScmInit3_Orig(); // call original
+  CleoInstance.GameBegin();
+}
+
+void __declspec(naked) CCleoInstance::OnGameShutdown() {
+  CleoInstance.GameEnd();
+  static DWORD oriFunc;
+  oriFunc = (DWORD)(CleoInstance.GameShutdown_Orig);
+  _asm jmp oriFunc
+}
+
+void __declspec(naked) CCleoInstance::OnGameRestart1() {
+  CleoInstance.GameEnd();
+  static DWORD oriFunc;
+  oriFunc = (DWORD)(CleoInstance.GameRestart1_Orig);
+  _asm jmp oriFunc
+}
+
+void __declspec(naked) CCleoInstance::OnGameRestart2() {
+  CleoInstance.GameEnd();
+  static DWORD oriFunc;
+  oriFunc = (DWORD)(CleoInstance.GameRestart2_Orig);
+  _asm jmp oriFunc
+}
+
+void __declspec(naked) CCleoInstance::OnGameRestart3() {
+  CleoInstance.GameEnd();
+  static DWORD oriFunc;
+  oriFunc = (DWORD)(CleoInstance.GameRestart3_Orig);
+  _asm jmp oriFunc
+}
+
+void __cdecl CCleoInstance::OnDebugDisplayTextBuffer_Idle() {
+  CleoInstance.GameRestartDebugDisplayTextBuffer_IdleOrig(); // call original
+  CleoInstance.CallCallbacks(
+      eCallbackId::DrawingFinished); // execute registered callbacks
+}
+
+void __cdecl CCleoInstance::OnDebugDisplayTextBuffer_Frontend() {
+  CleoInstance
+      .GameRestartDebugDisplayTextBuffer_FrontendOrig(); // call original
+  CleoInstance.CallCallbacks(
+      eCallbackId::DrawingFinished); // execute registered callbacks
+}
+
+void CCleoInstance::Start(InitStage stage) {
+  if (stage > InitStage::Done)
+    return; // invalid argument
+
+  auto nextStage = InitStage(m_initStage + 1);
+  if (stage != nextStage)
+    return;
+
+  if (stage == InitStage::Initial) {
+    TRACE("CLEO initialization: Phase 1");
+
+    FS::create_directory(Filepath_Cleo);
+    FS::create_directory(Filepath_Cleo + "\\cleo_modules");
+    FS::create_directory(Filepath_Cleo + "\\cleo_plugins");
+    FS::create_directory(Filepath_Cleo + "\\cleo_saves");
+
+    OpcodeInfoDb.Load((Filepath_Cleo + "\\.config\\sa.json").c_str());
+
+    CodeInjector.OpenReadWriteAccess(); // must do this earlier to ensure
+                                        // plugins write access on init
+    GameMenu.Inject(CodeInjector);
+    DmaFix.Inject(CodeInjector);
+    OpcodeSystem.Inject(CodeInjector);
+    ScriptEngine.Inject(CodeInjector);
+
+    CodeInjector.ReplaceFunction(
+        OnCreateMainWnd,
+        VersionManager.TranslateMemoryAddress(MA_CALL_CREATE_MAIN_WINDOW),
+        &CreateMainWnd_Orig);
+
+    CodeInjector.ReplaceFunction(
+        OnScmInit1, VersionManager.TranslateMemoryAddress(MA_CALL_INIT_SCM1),
+        &ScmInit1_Orig);
+    CodeInjector.ReplaceFunction(
+        OnScmInit2, VersionManager.TranslateMemoryAddress(MA_CALL_INIT_SCM2),
+        &ScmInit2_Orig);
+    CodeInjector.ReplaceFunction(
+        OnScmInit3, VersionManager.TranslateMemoryAddress(MA_CALL_INIT_SCM3),
+        &ScmInit3_Orig);
+
+    CodeInjector.ReplaceFunction(
+        OnGameShutdown,
+        VersionManager.TranslateMemoryAddress(MA_CALL_GAME_SHUTDOWN),
+        &GameShutdown_Orig);
+
+    CodeInjector.ReplaceFunction(
+        OnGameRestart1,
+        VersionManager.TranslateMemoryAddress(MA_CALL_GAME_RESTART_1),
+        &GameRestart1_Orig);
+    CodeInjector.ReplaceFunction(
+        OnGameRestart2,
+        VersionManager.TranslateMemoryAddress(MA_CALL_GAME_RESTART_2),
+        &GameRestart2_Orig);
+    CodeInjector.ReplaceFunction(
+        OnGameRestart3,
+        VersionManager.TranslateMemoryAddress(MA_CALL_GAME_RESTART_3),
+        &GameRestart3_Orig);
+
+    OpcodeSystem.Init();
+    PluginSystem.LoadPlugins();
+  }
+
+  // delayed until menu background drawing
+  if (stage == InitStage::OnDraw) {
+    TRACE("CLEO initialization: Phase 2");
+
+    const_cast<std::string &>(Filepath_User) =
+        GetUserDirectory(); // force update now, as it could be modifed by
+                            // PortableGTA.asi
+
+    ScriptEngine.InjectLate(CodeInjector);
+
+    CodeInjector.InjectFunction(
+        GetScriptStringParam,
+        gaddrof(::CRunningScript::ReadTextLabelFromScript));
+    CodeInjector.ReplaceFunction(OnDebugDisplayTextBuffer_Idle,
+                                 VersionManager.TranslateMemoryAddress(
+                                     MA_CALL_DEBUG_DISPLAY_TEXT_BUFFER_IDLE),
+                                 &GameRestartDebugDisplayTextBuffer_IdleOrig);
+    CodeInjector.ReplaceFunction(
+        OnDebugDisplayTextBuffer_Frontend,
+        VersionManager.TranslateMemoryAddress(
+            MA_CALL_DEBUG_DISPLAY_TEXT_BUFFER_FRONTEND),
+        &GameRestartDebugDisplayTextBuffer_FrontendOrig);
+    CodeInjector.ReplaceFunction(
+        OnUpdateGameLogics,
+        VersionManager.TranslateMemoryAddress(MA_CALL_UPDATE_GAME_LOGICS),
+        &UpdateGameLogics_Orig);
+
+    PluginSystem.LogLoadedPlugins();
+  }
+
+  m_initStage = stage;
+}
+
+void CCleoInstance::Stop() {
+  GameEnd();
+  PluginSystem.UnloadPlugins();
+  m_initStage = InitStage::None;
+}
+
+void CCleoInstance::GameBegin() {
+  if (m_bGameInProgress)
+    return;
+  m_bGameInProgress = true;
+
+  saveSlot = FrontEndMenuManager.m_bWantToLoad
+                 ? FrontEndMenuManager.m_nSelectedSaveGame
+                 : -1;
+
+  TRACE("Starting new game session, save slot: %d", saveSlot);
+
+  // late initialization if not done yet
+  CleoInstance.Start(CCleoInstance::InitStage::OnDraw);
+
+  // execute registered callbacks
+  CleoInstance.CallCallbacks(eCallbackId::GameBegin, saveSlot);
+}
+
+void CCleoInstance::GameEnd() {
+  if (!m_bGameInProgress)
+    return;
+  m_bGameInProgress = false;
+
+  TRACE("Ending current game session");
+  CleoInstance.CallCallbacks(
+      eCallbackId::GameEnd); // execute registered callbacks
+  ScriptEngine.GameEnd();
+  OpcodeSystem.FinalizeScriptObjects();
+
+  saveSlot = -1;
+}
+
+void CCleoInstance::AddCallback(eCallbackId id, void *func) {
+  m_callbacks[id].insert(func);
+}
+
+void CCleoInstance::RemoveCallback(eCallbackId id, void *func) {
+  m_callbacks[id].erase(func);
+}
+
+const std::set<void *> &CCleoInstance::GetCallbacks(eCallbackId id) {
+  return m_callbacks[id];
+}
+
+void CCleoInstance::CallCallbacks(eCallbackId id) {
+  for (void *func : GetCallbacks(id)) {
+    typedef void WINAPI callback(void);
+    ((callback *)func)();
+  }
+}
+
+void CCleoInstance::CallCallbacks(eCallbackId id, DWORD arg) {
+  for (void *func : GetCallbacks(id)) {
+    typedef void WINAPI callback(DWORD);
+    ((callback *)func)(arg);
+  }
+}
+
+void WINAPI CLEO_ResolvePath(CLEO::CRunningScript *thread, char *inOutPath,
+                             DWORD pathMaxLen) {
+  if (thread == nullptr || inOutPath == nullptr || pathMaxLen < 2) {
+    return; // invalid param
+  }
+
+  auto resolved =
+      reinterpret_cast<CCustomScript *>(thread)->ResolvePath(inOutPath);
+
+  if (resolved.length() >= pathMaxLen)
+    resolved.resize(pathMaxLen - 1); // and terminator character
+
+  std::memcpy(inOutPath, resolved.c_str(),
+              resolved.length() + 1); // with terminator
+}
+
+void WINAPI CLEO_StringListFree(StringList list) {
+  if (list.count > 0 && list.strings != nullptr) {
+    for (DWORD i = 0; i < list.count; i++) {
+      free(list.strings[i]);
+    }
+
+    free(list.strings);
+  }
+}
+
+StringList WINAPI CLEO_ListDirectory(CLEO::CRunningScript *thread,
+                                     const char *searchPath, BOOL listDirs,
+                                     BOOL listFiles) {
+  if (searchPath == nullptr)
+    return {}; // invalid param
+
+  if (!listDirs && !listFiles)
+    return {}; // nothing to list, done
+
+  // make absolute
+  auto fsSearchPath = FS::path(searchPath);
+  if (!fsSearchPath.is_absolute()) {
+    if (thread != nullptr)
+      fsSearchPath = ((CCustomScript *)thread)->GetWorkDir() / fsSearchPath;
+    else
+      fsSearchPath = Filepath_Game / fsSearchPath;
+  }
+
+  WIN32_FIND_DATA wfd = {0};
+  HANDLE hSearch = FindFirstFile(fsSearchPath.string().c_str(), &wfd);
+  if (hSearch == INVALID_HANDLE_VALUE)
+    return {}; // nothing found
+
+  std::set<std::string> found;
+  do {
+    if (!listDirs && (wfd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY))
+      continue; // skip directories
+
+    if (!listFiles && !(wfd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY))
+      continue; // skip files
+
+    auto path = FS::path(wfd.cFileName);
+    if (!path.is_absolute()) // keep absolute in case somebody hooked the APIs
+                             // to return so
+      path = fsSearchPath.parent_path() / path;
+
+    found.insert(path.string());
+  } while (FindNextFile(hSearch, &wfd));
+
+  FindClose(hSearch);
+
+  return CreateStringList(found);
+}
+} // namespace CLEO

--- a/source/CleoBase.h
+++ b/source/CleoBase.h
@@ -1,103 +1,93 @@
 #pragma once
 
 #include "CCodeInjector.h"
-#include "CGameVersionManager.h"
+#include "CCustomOpcodeSystem.h"
 #include "CDmaFix.h"
 #include "CGameMenu.h"
+#include "CGameVersionManager.h"
 #include "CModuleSystem.h"
 #include "CPluginSystem.h"
 #include "CScriptEngine.h"
-#include "CCustomOpcodeSystem.h"
 #include "OpcodeInfoDatabase.h"
 
-namespace CLEO
-{
-    class CCleoInstance
-    {
-    public:
-        enum InitStage : size_t
-        {
-            None,
-            Initial,
-            OnDraw,
-            Done = OnDraw
-        };
+namespace CLEO {
+class CCleoInstance {
+public:
+  enum InitStage : size_t { None, Initial, OnDraw, Done = OnDraw };
 
-        // order here defines init and deinit order!
-        CDmaFix					DmaFix;
-        CGameMenu				GameMenu;
-        CCodeInjector			CodeInjector;
-        CPluginSystem			PluginSystem;
-        CGameVersionManager		VersionManager;
-        CScriptEngine			ScriptEngine;
-        CCustomOpcodeSystem		OpcodeSystem;
-        CModuleSystem			ModuleSystem;
-        OpcodeInfoDatabase		OpcodeInfoDb;
+  // order here defines init and deinit order!
+  CDmaFix DmaFix;
+  CGameMenu GameMenu;
+  CCodeInjector CodeInjector;
+  CPluginSystem PluginSystem;
+  CGameVersionManager VersionManager;
+  CScriptEngine ScriptEngine;
+  CCustomOpcodeSystem OpcodeSystem;
+  CModuleSystem ModuleSystem;
+  OpcodeInfoDatabase OpcodeInfoDb;
 
-        int saveSlot = -1; // -1 if not loaded from save
+  int saveSlot = -1; // -1 if not loaded from save
 
-        CCleoInstance() = default;
-        virtual ~CCleoInstance();
+  CCleoInstance() = default;
+  virtual ~CCleoInstance();
 
-        void Start(InitStage stage);
-        void Stop();
+  void Start(InitStage stage);
+  void Stop();
 
-        void GameBegin();
-        void GameEnd();
+  void GameBegin();
+  void GameEnd();
 
-        bool IsStarted() const { return m_initStage != InitStage::None; }
+  bool IsStarted() const { return m_initStage != InitStage::None; }
 
-        void AddCallback(eCallbackId id, void* func);
-        void RemoveCallback(eCallbackId id, void* func);
-        const std::set<void*>& GetCallbacks(eCallbackId id);
-        void CallCallbacks(eCallbackId id);
-        void CallCallbacks(eCallbackId id, DWORD arg);
+  void AddCallback(eCallbackId id, void *func);
+  void RemoveCallback(eCallbackId id, void *func);
+  const std::set<void *> &GetCallbacks(eCallbackId id);
+  void CallCallbacks(eCallbackId id);
+  void CallCallbacks(eCallbackId id, DWORD arg);
 
-        void(__cdecl* UpdateGameLogics_Orig)() = nullptr;
-        static void __cdecl OnUpdateGameLogics();
+  void(__cdecl *UpdateGameLogics_Orig)() = nullptr;
+  static void __cdecl OnUpdateGameLogics();
 
-        // call for InitInstance
-        HWND(__cdecl* CreateMainWnd_Orig)(HINSTANCE) = nullptr;
-        static HWND __cdecl OnCreateMainWnd(HINSTANCE hinst);
+  // call for InitInstance
+  HWND(__cdecl *CreateMainWnd_Orig)(HINSTANCE) = nullptr;
+  static HWND __cdecl OnCreateMainWnd(HINSTANCE hinst);
 
-        // main window procedure hook
-        LRESULT(__stdcall* MainWndProc_Orig)(HWND, UINT, WPARAM, LPARAM) = nullptr;
-        static LRESULT __stdcall OnMainWndProc(HWND, UINT, WPARAM, LPARAM);
+  // main window procedure hook
+  LRESULT(__stdcall *MainWndProc_Orig)(HWND, UINT, WPARAM, LPARAM) = nullptr;
+  static LRESULT __stdcall OnMainWndProc(HWND, UINT, WPARAM, LPARAM);
 
-        // calls to CTheScripts::Init
-        void(__cdecl* ScmInit1_Orig)() = nullptr;
-        void(__cdecl* ScmInit2_Orig)() = nullptr;
-        void(__cdecl* ScmInit3_Orig)() = nullptr;
-        static void OnScmInit1();
-        static void OnScmInit2();
-        static void OnScmInit3();
+  // calls to CTheScripts::Init
+  void(__cdecl *ScmInit1_Orig)() = nullptr;
+  void(__cdecl *ScmInit2_Orig)() = nullptr;
+  void(__cdecl *ScmInit3_Orig)() = nullptr;
+  static void OnScmInit1();
+  static void OnScmInit2();
+  static void OnScmInit3();
 
-        // call for Game::Shutdown
-        void(__cdecl* GameShutdown_Orig)() = nullptr;
-        static void OnGameShutdown();
+  // call for Game::Shutdown
+  void(__cdecl *GameShutdown_Orig)() = nullptr;
+  static void OnGameShutdown();
 
-        // calls for Game::ShutDownForRestart
-        void(__cdecl* GameRestart1_Orig)() = nullptr;
-        void(__cdecl* GameRestart2_Orig)() = nullptr;
-        void(__cdecl* GameRestart3_Orig)() = nullptr;
-        static void OnGameRestart1();
-        static void OnGameRestart2();
-        static void OnGameRestart3();
+  // calls for Game::ShutDownForRestart
+  void(__cdecl *GameRestart1_Orig)() = nullptr;
+  void(__cdecl *GameRestart2_Orig)() = nullptr;
+  void(__cdecl *GameRestart3_Orig)() = nullptr;
+  static void OnGameRestart1();
+  static void OnGameRestart2();
+  static void OnGameRestart3();
 
-        // calls to CDebug::DebugDisplayTextBuffer()
-        void(__cdecl* GameRestartDebugDisplayTextBuffer_IdleOrig)() = nullptr;
-        static void OnDebugDisplayTextBuffer_Idle();
+  // calls to CDebug::DebugDisplayTextBuffer()
+  void(__cdecl *GameRestartDebugDisplayTextBuffer_IdleOrig)() = nullptr;
+  static void OnDebugDisplayTextBuffer_Idle();
 
-        void(__cdecl* GameRestartDebugDisplayTextBuffer_FrontendOrig)() = nullptr;
-        static void OnDebugDisplayTextBuffer_Frontend();
-        
+  void(__cdecl *GameRestartDebugDisplayTextBuffer_FrontendOrig)() = nullptr;
+  static void OnDebugDisplayTextBuffer_Frontend();
 
-    private:
-        InitStage m_initStage = InitStage::None;
-        bool m_bGameInProgress;
-        std::map<eCallbackId, std::set<void*>> m_callbacks;
-    };
+private:
+  InitStage m_initStage = InitStage::None;
+  bool m_bGameInProgress;
+  std::map<eCallbackId, std::set<void *>> m_callbacks;
+};
 
-    extern CCleoInstance CleoInstance;
-}
-
+extern CCleoInstance CleoInstance;
+} // namespace CLEO

--- a/source/FileEnumerator.h
+++ b/source/FileEnumerator.h
@@ -1,18 +1,17 @@
 #pragma once
 #include "..\cleo_sdk\CLEO.h"
 
-template<typename T>
-void FilesWalk(const char* directory, const char* extension, T callback)
-{
-    auto filePattern = std::string(directory);
-    filePattern += "\\*";
-    filePattern += extension;
+template <typename T>
+void FilesWalk(const char *directory, const char *extension, T callback) {
+  auto filePattern = std::string(directory);
+  filePattern += "\\*";
+  filePattern += extension;
 
-    auto list = CLEO::CLEO_ListDirectory(nullptr, filePattern.c_str(), false, true);
-    for (DWORD i = 0; i < list.count; i++)
-    {
-        auto fsPath = FS::path(list.strings[i]);
-        callback(list.strings[i], fsPath.filename().string().c_str());
-    }
-    CLEO::CLEO_StringListFree(list);
+  auto list =
+      CLEO::CLEO_ListDirectory(nullptr, filePattern.c_str(), false, true);
+  for (DWORD i = 0; i < list.count; i++) {
+    auto fsPath = FS::path(list.strings[i]);
+    callback(list.strings[i], fsPath.filename().string().c_str());
+  }
+  CLEO::CLEO_StringListFree(list);
 }

--- a/source/Mem.h
+++ b/source/Mem.h
@@ -1,90 +1,86 @@
 #pragma once
 
-#define OP_NOP			0x90
-#define OP_RET			0xC3
-#define OP_CALL			0xE8
-#define OP_JMP			0xE9
-#define OP_JMPSHORT		0xEB
+#define OP_NOP 0x90
+#define OP_RET 0xC3
+#define OP_CALL 0xE8
+#define OP_JMP 0xE9
+#define OP_JMPSHORT 0xEB
 
-template<typename T, typename U>
-inline void MemWrite(U p, const T v) { *(T*)p = v; }
-template<typename T, typename U>
-inline void MemWrite(U p, const T v, int n) { memcpy((void*)p, &v, n); }
-template<typename T, typename U>
-inline T MemRead(U p) { return *(T*)p; }
-template<typename T, typename U>
-inline void MemFill(U p, T v, int n) { memset((void*)p, (int)v, n); }
-template<typename T, typename U>
-inline void MemCopy(U p, const T v) { memcpy((void*)p, &v, sizeof(T)); }
-template<typename T, typename U>
-inline void MemCopy(U p, const T v, int n) { memcpy((void*)p, &v, n); }
-template<typename T, typename U>
-inline void MemCopy(U p, const T* v) { memcpy((void*)p, v, sizeof(T)); }
-template<typename T, typename U>
-inline void MemCopy(U p, const T* v, int n) { memcpy((void*)p, v, n); }
+template <typename T, typename U> inline void MemWrite(U p, const T v) {
+  *(T *)p = v;
+}
+template <typename T, typename U> inline void MemWrite(U p, const T v, int n) {
+  memcpy((void *)p, &v, n);
+}
+template <typename T, typename U> inline T MemRead(U p) { return *(T *)p; }
+template <typename T, typename U> inline void MemFill(U p, T v, int n) {
+  memset((void *)p, (int)v, n);
+}
+template <typename T, typename U> inline void MemCopy(U p, const T v) {
+  memcpy((void *)p, &v, sizeof(T));
+}
+template <typename T, typename U> inline void MemCopy(U p, const T v, int n) {
+  memcpy((void *)p, &v, n);
+}
+template <typename T, typename U> inline void MemCopy(U p, const T *v) {
+  memcpy((void *)p, v, sizeof(T));
+}
+template <typename T, typename U> inline void MemCopy(U p, const T *v, int n) {
+  memcpy((void *)p, v, n);
+}
 
 // Write a jump to v to the address at p and copy the replaced jump address to r
-template<typename T, typename U>
-inline void MemJump(U p, const T v, T *r = nullptr)
-{
-    if (r != nullptr)
-    {
-        *r = MemReadInstrucionDestination<std::remove_pointer<T>::type>(p);
-    }
+template <typename T, typename U>
+inline void MemJump(U p, const T v, T *r = nullptr) {
+  if (r != nullptr) {
+    *r = MemReadInstrucionDestination<std::remove_pointer<T>::type>(p);
+  }
 
-    MemWrite<BYTE>(p++, OP_JMP);
-    MemWrite<DWORD>(p, ((DWORD)v - (DWORD)p) - 4);
+  MemWrite<BYTE>(p++, OP_JMP);
+  MemWrite<DWORD>(p, ((DWORD)v - (DWORD)p) - 4);
 }
 
 // Write a call to v to the address at p and copy the replaced call address to r
-template<typename T, typename U>
-inline void MemCall(U p, const T v, T *r = nullptr)
-{
-    if (r != nullptr)
-    {
-        *r = MemReadInstrucionDestination<std::remove_pointer<T>::type>(p);
-    }
+template <typename T, typename U>
+inline void MemCall(U p, const T v, T *r = nullptr) {
+  if (r != nullptr) {
+    *r = MemReadInstrucionDestination<std::remove_pointer<T>::type>(p);
+  }
 
-    MemWrite<BYTE>(p++, OP_CALL);
-    MemWrite<DWORD>(p, (DWORD)v - (DWORD)p - 4);
+  MemWrite<BYTE>(p++, OP_CALL);
+  MemWrite<DWORD>(p, (DWORD)v - (DWORD)p - 4);
 }
 
 // Read and convert a relative offset to absolute address
-template<typename T, typename U>
-T MemReadOffsetPtr(U p)
-{
-    return (T)((size_t)MemRead<T>(p) + (size_t)p + sizeof(T));
+template <typename T, typename U> T MemReadOffsetPtr(U p) {
+  return (T)((size_t)MemRead<T>(p) + (size_t)p + sizeof(T));
 }
 
 // Read absolute target address of jump or call instruction
-template<typename T, typename U>
-T MemReadInstrucionDestination(U p)
-{
-    auto ptr = (BYTE*)p;
-    BYTE opcode = *ptr;
-    ptr++;
+template <typename T, typename U> T MemReadInstrucionDestination(U p) {
+  auto ptr = (BYTE *)p;
+  BYTE opcode = *ptr;
+  ptr++;
 
-    T dest = (T)nullptr;
-    switch (opcode)
-    {
-    case OP_CALL:
-        dest = MemReadOffsetPtr<DWORD>(ptr);
-        break;
+  T dest = (T) nullptr;
+  switch (opcode) {
+  case OP_CALL:
+    dest = MemReadOffsetPtr<DWORD>(ptr);
+    break;
 
-    case OP_JMP:
-        dest = MemReadOffsetPtr<DWORD>(ptr);
-        break;
+  case OP_JMP:
+    dest = MemReadOffsetPtr<DWORD>(ptr);
+    break;
 
-    case OP_JMPSHORT:
-        dest = MemReadOffsetPtr<BYTE>(ptr);
-        break;
-    }
+  case OP_JMPSHORT:
+    dest = MemReadOffsetPtr<BYTE>(ptr);
+    break;
+  }
 
-    return dest;
+  return dest;
 }
 
-inline void MemGrantAccess(size_t address, size_t size)
-{
-    DWORD oldProtect;
-    VirtualProtect((LPVOID)address, size, PAGE_EXECUTE_READWRITE, &oldProtect);
+inline void MemGrantAccess(size_t address, size_t size) {
+  DWORD oldProtect;
+  VirtualProtect((LPVOID)address, size, PAGE_EXECUTE_READWRITE, &oldProtect);
 }

--- a/source/OpcodeInfoDatabase.cpp
+++ b/source/OpcodeInfoDatabase.cpp
@@ -1,227 +1,190 @@
-#include "stdafx.h"
 #include "OpcodeInfoDatabase.h"
-
+#include "stdafx.h"
 
 using namespace std;
 using namespace simdjson;
 
-bool OpcodeInfoDatabase::Load(const char* filepath)
-{
-	Clear();
+bool OpcodeInfoDatabase::Load(const char *filepath) {
+  Clear();
 
-	dom::parser parser;
-	dom::element root;
+  dom::parser parser;
+  dom::element root;
 
-	auto error = parser.load(filepath).get(root);
-	if (error) 
-	{ 
-		TRACE("Failed to parse opcodes database '%s' file. Code %d", filepath, error);
-		return false;
-	}
+  auto error = parser.load(filepath).get(root);
+  if (error) {
+    TRACE("Failed to parse opcodes database '%s' file. Code %d", filepath,
+          error);
+    return false;
+  }
 
-	const char* version;
-	if (root["meta"]["version"].get_c_str().get(version))
-	{
-		TRACE("Invalid opcodes database '%s' file.", filepath);
-		return false;
-	}
+  const char *version;
+  if (root["meta"]["version"].get_c_str().get(version)) {
+    TRACE("Invalid opcodes database '%s' file.", filepath);
+    return false;
+  }
 
-	dom::array ext;
-	if (root["extensions"].get_array().get(ext))
-	{
-		TRACE("Invalid opcodes database '%s' file.", filepath);
-		return false;
-	}
+  dom::array ext;
+  if (root["extensions"].get_array().get(ext)) {
+    TRACE("Invalid opcodes database '%s' file.", filepath);
+    return false;
+  }
 
-	for (auto& e : ext)
-	{
-		Extension extension;
+  for (auto &e : ext) {
+    Extension extension;
 
-		const char* name;
-		if (e["name"].get_c_str().get(name))
-		{
-			continue; // invalid extension
-		}
-		extension.name = name;
+    const char *name;
+    if (e["name"].get_c_str().get(name)) {
+      continue; // invalid extension
+    }
+    extension.name = name;
 
-		dom::array commands;
-		if (e["commands"].get_array().get(commands))
-		{
-			continue; // invalid extension
-		}
+    dom::array commands;
+    if (e["commands"].get_array().get(commands)) {
+      continue; // invalid extension
+    }
 
-		for (auto& c : commands)
-		{
-			bool unsupported;
-			if (!c["attrs"]["is_unsupported"].get_bool().get(unsupported) && unsupported)
-			{
-				continue; // command defined as unsupported
-			}
+    for (auto &c : commands) {
+      bool unsupported;
+      if (!c["attrs"]["is_unsupported"].get_bool().get(unsupported) &&
+          unsupported) {
+        continue; // command defined as unsupported
+      }
 
-			const char* commandId;
-			if (c["id"].get_c_str().get(commandId))
-			{
-				continue; // invalid command
-			}
+      const char *commandId;
+      if (c["id"].get_c_str().get(commandId)) {
+        continue; // invalid command
+      }
 
-			const char* commandName;
-			if (c["name"].get_c_str().get(commandName))
-			{
-				continue; // invalid command
-			}
+      const char *commandName;
+      if (c["name"].get_c_str().get(commandName)) {
+        continue; // invalid command
+      }
 
-			auto idLong = stoul(commandId, nullptr, 16);
-			if (idLong > 0x7FFF)
-			{
-				continue; // opcode out of bounds
-			}
-			auto id = (uint16_t)idLong;
+      auto idLong = stoul(commandId, nullptr, 16);
+      if (idLong > 0x7FFF) {
+        continue; // opcode out of bounds
+      }
+      auto id = (uint16_t)idLong;
 
-			extension.opcodes.emplace(piecewise_construct, make_tuple(id), make_tuple(id, commandName));
-			auto& opcode = extension.opcodes.at(id);
+      extension.opcodes.emplace(piecewise_construct, make_tuple(id),
+                                make_tuple(id, commandName));
+      auto &opcode = extension.opcodes.at(id);
 
-			// read arguments info
-			dom::array inputArgs;
-			if (!c["input"].get_array().get(inputArgs))
-			{
-				for (auto& p : inputArgs)
-				{
-					const char* argName;
-					if (!p["name"].get_c_str().get(argName))
-					{
-						opcode.arguments.emplace_back(argName);
-					}
-				}
-			}
-		}
+      // read arguments info
+      dom::array inputArgs;
+      if (!c["input"].get_array().get(inputArgs)) {
+        for (auto &p : inputArgs) {
+          const char *argName;
+          if (!p["name"].get_c_str().get(argName)) {
+            opcode.arguments.emplace_back(argName);
+          }
+        }
+      }
+    }
 
-		if (!extension.opcodes.empty())
-		{
-			extensions[extension.name] = move(extension);
-		}
-	}
+    if (!extension.opcodes.empty()) {
+      extensions[extension.name] = move(extension);
+    }
+  }
 
-	TRACE("Opcodes database version %s loaded from '%s'", version, filepath);
-	ok = true;
-	return true;
+  TRACE("Opcodes database version %s loaded from '%s'", version, filepath);
+  ok = true;
+  return true;
 }
 
-void OpcodeInfoDatabase::Clear()
-{
-	ok = false;
-	extensions.clear();
+void OpcodeInfoDatabase::Clear() {
+  ok = false;
+  extensions.clear();
 }
 
-const char* OpcodeInfoDatabase::GetExtensionName(uint16_t opcode) const
-{
-	if (ok)
-	{
-		for (auto& entry : extensions)
-		{
-			auto& extension = entry.second;
-			auto& opcodes = extension.opcodes;
+const char *OpcodeInfoDatabase::GetExtensionName(uint16_t opcode) const {
+  if (ok) {
+    for (auto &entry : extensions) {
+      auto &extension = entry.second;
+      auto &opcodes = extension.opcodes;
 
-			if (opcodes.find(opcode) != opcodes.end())
-			{
-				return extension.name.c_str();
-			}
-		}
-	}
+      if (opcodes.find(opcode) != opcodes.end()) {
+        return extension.name.c_str();
+      }
+    }
+  }
 
-	return nullptr;
+  return nullptr;
 }
 
-const char* OpcodeInfoDatabase::GetExtensionName(const char* commandName) const
-{
-	if (ok)
-	{
-		for (auto& entry : extensions)
-		{
-			auto& extension = entry.second;
-			auto& opcodes = extension.opcodes;
+const char *
+OpcodeInfoDatabase::GetExtensionName(const char *commandName) const {
+  if (ok) {
+    for (auto &entry : extensions) {
+      auto &extension = entry.second;
+      auto &opcodes = extension.opcodes;
 
-			for (auto& opcode : opcodes)
-			{
-				if (_strcmpi(commandName, opcode.second.name.c_str()) == 0)
-				{
-					return extension.name.c_str();
-				}
-			}
-		}
-	}
+      for (auto &opcode : opcodes) {
+        if (_strcmpi(commandName, opcode.second.name.c_str()) == 0) {
+          return extension.name.c_str();
+        }
+      }
+    }
+  }
 
-	return nullptr;
+  return nullptr;
 }
 
-uint16_t OpcodeInfoDatabase::GetOpcode(const char* commandName) const
-{
-	if (ok)
-	{
-		for (auto& entry : extensions)
-		{
-			auto& extension = entry.second;
-			auto& opcodes = extension.opcodes;
+uint16_t OpcodeInfoDatabase::GetOpcode(const char *commandName) const {
+  if (ok) {
+    for (auto &entry : extensions) {
+      auto &extension = entry.second;
+      auto &opcodes = extension.opcodes;
 
-			for (auto& opcode : opcodes)
-			{
-				if (_strcmpi(commandName, opcode.second.name.c_str()) == 0)
-				{
-					return opcode.first;
-				}
-			}
-		}
-	}
+      for (auto &opcode : opcodes) {
+        if (_strcmpi(commandName, opcode.second.name.c_str()) == 0) {
+          return opcode.first;
+        }
+      }
+    }
+  }
 
-	return 0xFFFF;
+  return 0xFFFF;
 }
 
-const char* OpcodeInfoDatabase::GetCommandName(uint16_t opcode) const
-{
-	if (ok)
-	{
-		for (auto& entry : extensions)
-		{
-			auto& opcodes = entry.second.opcodes;
+const char *OpcodeInfoDatabase::GetCommandName(uint16_t opcode) const {
+  if (ok) {
+    for (auto &entry : extensions) {
+      auto &opcodes = entry.second.opcodes;
 
-			if (opcodes.find(opcode) != opcodes.end())
-			{
-				return opcodes.at(opcode).name.c_str();
-			}
-		}
-	}
+      if (opcodes.find(opcode) != opcodes.end()) {
+        return opcodes.at(opcode).name.c_str();
+      }
+    }
+  }
 
-	return nullptr;
+  return nullptr;
 }
 
-const char* OpcodeInfoDatabase::GetArgumentName(uint16_t opcode, size_t paramIdx) const
-{
-	if (ok)
-	{
-		for (auto& entry : extensions)
-		{
-			auto& opcodes = entry.second.opcodes;
+const char *OpcodeInfoDatabase::GetArgumentName(uint16_t opcode,
+                                                size_t paramIdx) const {
+  if (ok) {
+    for (auto &entry : extensions) {
+      auto &opcodes = entry.second.opcodes;
 
-			if (opcodes.find(opcode) != opcodes.end())
-			{
-				if(paramIdx < opcodes.at(opcode).arguments.size())
-				{
-					return opcodes.at(opcode).arguments[paramIdx].name.c_str();
-				}
-			}
-		}
-	}
+      if (opcodes.find(opcode) != opcodes.end()) {
+        if (paramIdx < opcodes.at(opcode).arguments.size()) {
+          return opcodes.at(opcode).arguments[paramIdx].name.c_str();
+        }
+      }
+    }
+  }
 
-	return nullptr;
+  return nullptr;
 }
 
-std::string OpcodeInfoDatabase::GetExtensionMissingMessage(uint16_t opcode) const
-{
-	auto extensionName = GetExtensionName(opcode);
-	if (extensionName == nullptr)
-	{
-		return {};
-	}
+std::string
+OpcodeInfoDatabase::GetExtensionMissingMessage(uint16_t opcode) const {
+  auto extensionName = GetExtensionName(opcode);
+  if (extensionName == nullptr) {
+    return {};
+  }
 
-	return CLEO::StringPrintf("CLEO extension plugin \"%s\" is missing!", extensionName);
+  return CLEO::StringPrintf("CLEO extension plugin \"%s\" is missing!",
+                            extensionName);
 }
-

--- a/source/OpcodeInfoDatabase.h
+++ b/source/OpcodeInfoDatabase.h
@@ -3,54 +3,47 @@
 #include <map>
 #include <string>
 
+class OpcodeInfoDatabase {
+  struct OpcodeArgument {
+    std::string name;
 
-class OpcodeInfoDatabase
-{
-	struct OpcodeArgument
-	{
-		std::string name;
+    OpcodeArgument() = default;
+    OpcodeArgument(const char *name) : name(name) {}
+  };
 
-		OpcodeArgument() = default;
-		OpcodeArgument(const char* name) : name(name)
-		{
-		}
-	};
+  struct Opcode {
+    uint16_t id;
+    std::string name;
+    std::vector<OpcodeArgument> arguments;
 
-	struct Opcode
-	{
-		uint16_t id;
-		std::string name;
-		std::vector<OpcodeArgument> arguments;
+    Opcode() = default;
+    Opcode(uint16_t id, std::string name) : id(id), name(name) {}
+  };
 
-		Opcode() = default;
-		Opcode(uint16_t id, std::string name) : id(id), name(name)
-		{
-		}
-	};
+  struct Extension {
+    std::string name;
+    std::map<uint16_t, Opcode> opcodes;
+  };
 
-	struct Extension
-	{
-		std::string name;
-		std::map<uint16_t, Opcode> opcodes;
-	};
-
-	std::atomic<bool> ok = false;
-	std::map<std::string, Extension> extensions;
+  std::atomic<bool> ok = false;
+  std::map<std::string, Extension> extensions;
 
 public:
-	OpcodeInfoDatabase() = default;
+  OpcodeInfoDatabase() = default;
 
-	void Clear();
-	bool Load(const char* filepath); // triggers asynchronic load
+  void Clear();
+  bool Load(const char *filepath); // triggers asynchronic load
 
-	const char* GetExtensionName(uint16_t opcode) const; // nullptr if not found
-	const char* GetExtensionName(const char* commandName) const; // nullptr if not found
+  const char *GetExtensionName(uint16_t opcode) const; // nullptr if not found
+  const char *
+  GetExtensionName(const char *commandName) const; // nullptr if not found
 
-	uint16_t GetOpcode(const char* commandName) const; // 0xFFFF if not found
-	const char* GetCommandName(uint16_t opcode) const; // nullptr if not found
+  uint16_t GetOpcode(const char *commandName) const; // 0xFFFF if not found
+  const char *GetCommandName(uint16_t opcode) const; // nullptr if not found
 
-	const char* GetArgumentName(uint16_t opcode, size_t paramIdx) const; // nullptr if not found
+  const char *GetArgumentName(uint16_t opcode,
+                              size_t paramIdx) const; // nullptr if not found
 
-	std::string GetExtensionMissingMessage(uint16_t opcode) const; // extension "x" missing message if known, empty text otherwise
+  std::string GetExtensionMissingMessage(uint16_t opcode)
+      const; // extension "x" missing message if known, empty text otherwise
 };
-

--- a/source/ScmFunction.cpp
+++ b/source/ScmFunction.cpp
@@ -1,124 +1,120 @@
-#include "stdafx.h"
 #include "ScmFunction.h"
 #include "CCustomOpcodeSystem.h"
 #include "CScriptEngine.h"
+#include "stdafx.h"
 
+namespace CLEO {
+ScmFunction *ScmFunction::store[Store_Size] = {0};
+size_t ScmFunction::allocationPlace = 0;
 
-namespace CLEO
-{
-	ScmFunction* ScmFunction::store[Store_Size] = { 0 };
-	size_t ScmFunction::allocationPlace = 0;
+ScmFunction *ScmFunction::Get(unsigned short idx) {
+  if (idx >= Store_Size)
+    return nullptr;
 
-	ScmFunction* ScmFunction::Get(unsigned short idx)
-	{
-		if (idx >= Store_Size)
-			return nullptr;
+  return store[idx];
+}
 
-		return store[idx];
-	}
+void ScmFunction::Clear() {
+  for each (ScmFunction *scmFunc in store) {
+    if (scmFunc != nullptr)
+      delete scmFunc;
+  }
+  ScmFunction::allocationPlace = 0;
+}
 
-	void ScmFunction::Clear()
-	{
-		for each (ScmFunction* scmFunc in store)
-		{
-			if (scmFunc != nullptr) delete scmFunc;
-		}
-		ScmFunction::allocationPlace = 0;
-	}
+void *ScmFunction::operator new(size_t size) {
+  size_t start_search = allocationPlace;
+  while (store[allocationPlace] !=
+         nullptr) // find first unused position in store
+  {
+    if (++allocationPlace >= Store_Size)
+      allocationPlace = 0; // end of store reached
+    if (allocationPlace == start_search) {
+      SHOW_ERROR("CLEO function storage stack overfllow!");
+      throw std::bad_alloc(); // the store is filled up
+    }
+  }
+  ScmFunction *obj = reinterpret_cast<ScmFunction *>(::operator new(size));
+  store[allocationPlace] = obj;
+  return obj;
+}
 
-	void* ScmFunction::operator new(size_t size)
-	{
-		size_t start_search = allocationPlace;
-		while (store[allocationPlace] != nullptr) // find first unused position in store
-		{
-			if (++allocationPlace >= Store_Size) allocationPlace = 0; // end of store reached
-			if (allocationPlace == start_search)
-			{
-				SHOW_ERROR("CLEO function storage stack overfllow!");
-				throw std::bad_alloc();	// the store is filled up
-			}
-		}
-		ScmFunction* obj = reinterpret_cast<ScmFunction*>(::operator new(size));
-		store[allocationPlace] = obj;
-		return obj;
-	}
+void ScmFunction::operator delete(void *mem) {
+  store[reinterpret_cast<ScmFunction *>(mem)->thisScmFunctionId] = nullptr;
+  ::operator delete(mem);
+}
 
-	void ScmFunction::operator delete(void* mem)
-	{
-		store[reinterpret_cast<ScmFunction*>(mem)->thisScmFunctionId] = nullptr;
-		::operator delete(mem);
-	}
+ScmFunction::ScmFunction(CLEO::CRunningScript *thread)
+    : prevScmFunctionId(
+          reinterpret_cast<CCustomScript *>(thread)->GetScmFunction()) {
+  auto cs = reinterpret_cast<CCustomScript *>(thread);
 
-	ScmFunction::ScmFunction(CLEO::CRunningScript* thread) :
-		prevScmFunctionId(reinterpret_cast<CCustomScript*>(thread)->GetScmFunction())
-	{
-		auto cs = reinterpret_cast<CCustomScript*>(thread);
+  // create snapshot of current scope
+  savedBaseIP = cs->BaseIP;
+  savedCodeSize = cs->IsCustom() ? cs->GetCodeSize() : -1;
 
-		// create snapshot of current scope
-		savedBaseIP = cs->BaseIP;
-		savedCodeSize = cs->IsCustom() ? cs->GetCodeSize() : -1;
+  std::copy(std::begin(cs->Stack), std::end(cs->Stack), std::begin(savedStack));
+  savedSP = cs->SP;
 
-		std::copy(std::begin(cs->Stack), std::end(cs->Stack), std::begin(savedStack));
-		savedSP = cs->SP;
+  auto scope = cs->IsMission() ? missionLocals : cs->LocalVar;
+  std::copy(scope, scope + _countof(CRunningScript::LocalVar), savedTls);
 
-		auto scope = cs->IsMission() ? missionLocals : cs->LocalVar;
-		std::copy(scope, scope + _countof(CRunningScript::LocalVar), savedTls);
+  savedCondResult = cs->bCondResult;
+  savedLogicalOp = cs->LogicalOp;
+  savedNotFlag = cs->NotFlag;
 
-		savedCondResult = cs->bCondResult;
-		savedLogicalOp = cs->LogicalOp;
-		savedNotFlag = cs->NotFlag;
+  savedScriptFileDir = cs->GetScriptFileDir();
+  savedScriptFileName = cs->GetScriptFileName();
 
-		savedScriptFileDir = cs->GetScriptFileDir();
-		savedScriptFileName = cs->GetScriptFileName();
+  // init new scope
+  std::fill(std::begin(cs->Stack), std::end(cs->Stack), nullptr);
+  cs->SP = 0;
+  cs->bCondResult = false;
+  cs->LogicalOp = eLogicalOperation::NONE;
+  cs->NotFlag = false;
 
-		// init new scope
-		std::fill(std::begin(cs->Stack), std::end(cs->Stack), nullptr);
-		cs->SP = 0;
-		cs->bCondResult = false;
-		cs->LogicalOp = eLogicalOperation::NONE;
-		cs->NotFlag = false;
+  cs->SetScmFunction(thisScmFunctionId = (unsigned short)allocationPlace);
+}
 
-		cs->SetScmFunction(thisScmFunctionId = (unsigned short)allocationPlace);
-	}
+void ScmFunction::Return(CRunningScript *thread) {
+  auto cs = reinterpret_cast<CCustomScript *>(thread);
 
-	void ScmFunction::Return(CRunningScript* thread)
-	{
-		auto cs = reinterpret_cast<CCustomScript*>(thread);
+  cs->BaseIP = savedBaseIP;
+  if (cs->IsCustom())
+    cs->SetCodeSize(savedCodeSize);
 
-		cs->BaseIP = savedBaseIP;
-		if (cs->IsCustom()) cs->SetCodeSize(savedCodeSize);
+  // restore parent scope's gosub call stack
+  std::copy(std::begin(savedStack), std::end(savedStack),
+            std::begin(cs->Stack));
+  cs->SP = savedSP;
 
-		// restore parent scope's gosub call stack
-		std::copy(std::begin(savedStack), std::end(savedStack), std::begin(cs->Stack));
-		cs->SP = savedSP;
+  // restore parent scope's local variables
+  std::copy(savedTls, savedTls + 32,
+            cs->IsMission() ? missionLocals : cs->LocalVar);
 
-		// restore parent scope's local variables
-		std::copy(savedTls, savedTls + 32, cs->IsMission() ? missionLocals : cs->LocalVar);
+  // process conditional result of just ended function in parent scope
+  bool condResult = cs->bCondResult;
+  if (savedNotFlag)
+    condResult = !condResult;
 
-		// process conditional result of just ended function in parent scope
-		bool condResult = cs->bCondResult;
-		if (savedNotFlag) condResult = !condResult;
+  if (savedLogicalOp >= eLogicalOperation::ANDS_1 &&
+      savedLogicalOp < eLogicalOperation::AND_END) {
+    cs->bCondResult = savedCondResult && condResult;
+    cs->LogicalOp = --savedLogicalOp;
+  } else if (savedLogicalOp >= eLogicalOperation::ORS_1 &&
+             savedLogicalOp < eLogicalOperation::OR_END) {
+    cs->bCondResult = savedCondResult || condResult;
+    cs->LogicalOp = --savedLogicalOp;
+  } else // eLogicalOperation::NONE
+  {
+    cs->bCondResult = condResult;
+    cs->LogicalOp = savedLogicalOp;
+  }
 
-		if (savedLogicalOp >= eLogicalOperation::ANDS_1 && savedLogicalOp < eLogicalOperation::AND_END)
-		{
-			cs->bCondResult = savedCondResult && condResult;
-			cs->LogicalOp = --savedLogicalOp;
-		}
-		else if (savedLogicalOp >= eLogicalOperation::ORS_1 && savedLogicalOp < eLogicalOperation::OR_END)
-		{
-			cs->bCondResult = savedCondResult || condResult;
-			cs->LogicalOp = --savedLogicalOp;
-		}
-		else // eLogicalOperation::NONE
-		{
-			cs->bCondResult = condResult;
-			cs->LogicalOp = savedLogicalOp;
-		}
+  cs->SetScriptFileDir(savedScriptFileDir.c_str());
+  cs->SetScriptFileName(savedScriptFileName.c_str());
 
-		cs->SetScriptFileDir(savedScriptFileDir.c_str());
-		cs->SetScriptFileName(savedScriptFileName.c_str());
-
-		cs->SetIp(retnAddress);
-		cs->SetScmFunction(prevScmFunctionId);
-	}
-};
+  cs->SetIp(retnAddress);
+  cs->SetScmFunction(prevScmFunctionId);
+}
+}; // namespace CLEO

--- a/source/ScmFunction.h
+++ b/source/ScmFunction.h
@@ -2,38 +2,35 @@
 #include "..\cleo_sdk\CLEO.h"
 #include "CDebug.h"
 
+namespace CLEO {
+struct ScmFunction {
+  static const size_t Store_Size = 0x400;
+  static ScmFunction *store[Store_Size];
+  static size_t allocationPlace; // contains an index of last allocated object
+  static ScmFunction *Get(unsigned short idx);
+  static void Clear();
 
-namespace CLEO
-{
-	struct ScmFunction
-	{
-		static const size_t Store_Size = 0x400;
-		static ScmFunction* store[Store_Size];
-		static size_t allocationPlace; // contains an index of last allocated object
-		static ScmFunction* Get(unsigned short idx);
-		static void Clear();
+  unsigned short prevScmFunctionId, thisScmFunctionId;
+  BYTE callArgCount = 0; // args provided to cleo_call
 
-		unsigned short prevScmFunctionId, thisScmFunctionId;
-		BYTE callArgCount = 0; // args provided to cleo_call
+  // saved nesting context state
+  void *savedBaseIP;
+  size_t savedCodeSize; // Custom Scripts only
+  BYTE *retnAddress;
+  BYTE *savedStack[8]; // gosub stack
+  WORD savedSP;
+  SCRIPT_VAR savedTls[32];
+  std::list<std::string> stringParams; // texts with this scope lifetime
+  bool savedCondResult;
+  eLogicalOperation savedLogicalOp;
+  bool savedNotFlag;
+  std::string savedScriptFileDir;  // modules switching
+  std::string savedScriptFileName; // modules switching
 
-		// saved nesting context state
-		void* savedBaseIP;
-		size_t savedCodeSize; // Custom Scripts only
-		BYTE* retnAddress;
-		BYTE* savedStack[8]; // gosub stack
-		WORD savedSP;
-		SCRIPT_VAR savedTls[32];
-		std::list<std::string> stringParams; // texts with this scope lifetime
-		bool savedCondResult;
-		eLogicalOperation savedLogicalOp;
-		bool savedNotFlag;
-		std::string savedScriptFileDir; // modules switching
-		std::string savedScriptFileName; // modules switching
+  void *operator new(size_t size);
+  void operator delete(void *mem);
+  ScmFunction(CRunningScript *thread);
 
-		void* operator new(size_t size);
-		void operator delete(void* mem);
-		ScmFunction(CRunningScript* thread);
-
-		void Return(CRunningScript* thread);
-	};
-}
+  void Return(CRunningScript *thread);
+};
+} // namespace CLEO

--- a/source/ScriptDelegate.h
+++ b/source/ScriptDelegate.h
@@ -2,25 +2,23 @@
 #include "../cleo_sdk/CLEO.h"
 #include <vector>
 
-namespace CLEO
-{
-	struct ScriptDeleteDelegate
-	{
-		std::vector<FuncScriptDeleteDelegateT> funcs;
+namespace CLEO {
+struct ScriptDeleteDelegate {
+  std::vector<FuncScriptDeleteDelegateT> funcs;
 
-		template<class FuncScriptDeleteDelegateT> void operator+=(FuncScriptDeleteDelegateT mFunc)
-		{
-			funcs.push_back(mFunc);
-		}
+  template <class FuncScriptDeleteDelegateT>
+  void operator+=(FuncScriptDeleteDelegateT mFunc) {
+    funcs.push_back(mFunc);
+  }
 
-		template<class FuncScriptDeleteDelegateT> void operator-=(FuncScriptDeleteDelegateT mFunc)
-		{
-			funcs.erase(std::remove(funcs.begin(), funcs.end(), mFunc), funcs.end());
-		}
+  template <class FuncScriptDeleteDelegateT>
+  void operator-=(FuncScriptDeleteDelegateT mFunc) {
+    funcs.erase(std::remove(funcs.begin(), funcs.end(), mFunc), funcs.end());
+  }
 
-		void operator()(CRunningScript* script)
-		{
-			for (auto& f : funcs) f(script);
-		}
-	};
-}
+  void operator()(CRunningScript *script) {
+    for (auto &f : funcs)
+      f(script);
+  }
+};
+} // namespace CLEO

--- a/source/ScriptUtils.h
+++ b/source/ScriptUtils.h
@@ -1,23 +1,25 @@
 #pragma once
 #include "..\cleo_sdk\CLEO.h"
 
-namespace CLEO
-{
-    // check for extra SCM data at the end of script block
-    static DWORD GetExtraInfoSize(BYTE* scriptData, DWORD size)
-    {
-        static constexpr char SB_Footer_Sig[] = { '_', '_', 'S', 'B', 'F', 'T', 'R', '\0' };
+namespace CLEO {
+// check for extra SCM data at the end of script block
+static DWORD GetExtraInfoSize(BYTE *scriptData, DWORD size) {
+  static constexpr char SB_Footer_Sig[] = {'_', '_', 'S', 'B',
+                                           'F', 'T', 'R', '\0'};
 
-        if (size < (sizeof(SB_Footer_Sig) + sizeof(DWORD))) return 0; // not enough data for signature + size
+  if (size < (sizeof(SB_Footer_Sig) + sizeof(DWORD)))
+    return 0; // not enough data for signature + size
 
-        auto ptr = scriptData + size; // data end
-        ptr -= sizeof(SB_Footer_Sig);
-        if (memcmp(ptr, &SB_Footer_Sig, sizeof(SB_Footer_Sig))) return 0; // signature not present
+  auto ptr = scriptData + size; // data end
+  ptr -= sizeof(SB_Footer_Sig);
+  if (memcmp(ptr, &SB_Footer_Sig, sizeof(SB_Footer_Sig)))
+    return 0; // signature not present
 
-        ptr -= sizeof(DWORD);
-        auto codeSize = *reinterpret_cast<DWORD*>(ptr);
-        if (codeSize > size) return 0; // error: reported size greater than script block
+  ptr -= sizeof(DWORD);
+  auto codeSize = *reinterpret_cast<DWORD *>(ptr);
+  if (codeSize > size)
+    return 0; // error: reported size greater than script block
 
-        return size - codeSize;
-    }
+  return size - codeSize;
 }
+} // namespace CLEO

--- a/source/Singleton.h
+++ b/source/Singleton.h
@@ -5,38 +5,36 @@
 static bool CleoSingletonChecked = false;
 
 // search for CLEO.asi modules loaded, terminate game if duplicate found
-static void CleoSingletonCheck()
-{
-    if(!CleoSingletonChecked)
-    {
-        MODULEENTRY32 module;
-        module.dwSize = sizeof(MODULEENTRY32);
-        HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPMODULE, GetCurrentProcessId());
+static void CleoSingletonCheck() {
+  if (!CleoSingletonChecked) {
+    MODULEENTRY32 module;
+    module.dwSize = sizeof(MODULEENTRY32);
+    HANDLE snapshot =
+        CreateToolhelp32Snapshot(TH32CS_SNAPMODULE, GetCurrentProcessId());
 
-        Module32First(snapshot, &module);
-        if (snapshot != INVALID_HANDLE_VALUE)
-        {
-            size_t count = 0;
-            do
-            {
-                if (_strcmpi(module.szModule, "CLEO.asi") == 0)
-                {
-                    count++;
+    Module32First(snapshot, &module);
+    if (snapshot != INVALID_HANDLE_VALUE) {
+      size_t count = 0;
+      do {
+        if (_strcmpi(module.szModule, "CLEO.asi") == 0) {
+          count++;
 
-                    if(count > 1)
-                    {
-                        CloseHandle(snapshot);
-                        MessageBox(NULL, "Another copy of CLEO.asi is already loaded!\nPlease remove duplicated files.", "CLEO error", MB_SYSTEMMODAL | MB_TOPMOST | MB_ICONERROR | MB_OK);
-                        exit(1); // terminate the game
-                        break;
-                    }
-                }
-            } while (Module32Next(snapshot, &module));
-
+          if (count > 1) {
             CloseHandle(snapshot);
+            MessageBox(NULL,
+                       "Another copy of CLEO.asi is already loaded!\nPlease "
+                       "remove duplicated files.",
+                       "CLEO error",
+                       MB_SYSTEMMODAL | MB_TOPMOST | MB_ICONERROR | MB_OK);
+            exit(1); // terminate the game
+            break;
+          }
         }
+      } while (Module32Next(snapshot, &module));
 
-        CleoSingletonChecked = true;
+      CloseHandle(snapshot);
     }
-}
 
+    CleoSingletonChecked = true;
+  }
+}

--- a/source/crc32.cpp
+++ b/source/crc32.cpp
@@ -1,6 +1,5 @@
-#include "stdafx.h"
 #include "crc32.h"
-
+#include "stdafx.h"
 
 static const unsigned long crcTable[256] = {
     0x00000000UL, 0x77073096UL, 0xee0e612cUL, 0x990951baUL, 0x076dc419UL,
@@ -54,39 +53,33 @@ static const unsigned long crcTable[256] = {
     0xbdbdf21cUL, 0xcabac28aUL, 0x53b39330UL, 0x24b4a3a6UL, 0xbad03605UL,
     0xcdd70693UL, 0x54de5729UL, 0x23d967bfUL, 0xb3667a2eUL, 0xc4614ab8UL,
     0x5d681b02UL, 0x2a6f2b94UL, 0xb40bbe37UL, 0xc30c8ea1UL, 0x5a05df1bUL,
-    0x2d02ef8dUL
-};
+    0x2d02ef8dUL};
 
-unsigned long crc32FromUpcaseString(const char *str)
-{
-    unsigned long crc = 0xFFFFFFFF;
-    while (*str)
-        crc = crcTable[(crc^toupper(*str++)) & 0xff] ^ (crc >> 8);
-    return crc;
+unsigned long crc32FromUpcaseString(const char *str) {
+  unsigned long crc = 0xFFFFFFFF;
+  while (*str)
+    crc = crcTable[(crc ^ toupper(*str++)) & 0xff] ^ (crc >> 8);
+  return crc;
 }
 
-unsigned long crc32FromUpcaseStdString(const std::string& str)
-{
-    return crc32FromUpcaseString(str.c_str());
+unsigned long crc32FromUpcaseStdString(const std::string &str) {
+  return crc32FromUpcaseString(str.c_str());
 }
 
-unsigned long crc32FromString(const char *str)
-{
-    unsigned long crc = 0xFFFFFFFF;
-    while (*str)
-        crc = crcTable[(crc ^ (*str++)) & 0xff] ^ (crc >> 8);
-    return crc;
+unsigned long crc32FromString(const char *str) {
+  unsigned long crc = 0xFFFFFFFF;
+  while (*str)
+    crc = crcTable[(crc ^ (*str++)) & 0xff] ^ (crc >> 8);
+  return crc;
 }
 
-unsigned long crc32FromStdString(const std::string& str)
-{
-    return crc32FromString(str.c_str());
+unsigned long crc32FromStdString(const std::string &str) {
+  return crc32FromString(str.c_str());
 }
 
-unsigned long crc32(const unsigned char *buf, unsigned long len)
-{
-    unsigned long crc = 0xFFFFFFFF;
-    for (unsigned i = 0; i < len; i++)
-        crc = crcTable[(crc^buf[i]) & 0xFF] ^ (crc >> 8);
-    return crc;
+unsigned long crc32(const unsigned char *buf, unsigned long len) {
+  unsigned long crc = 0xFFFFFFFF;
+  for (unsigned i = 0; i < len; i++)
+    crc = crcTable[(crc ^ buf[i]) & 0xFF] ^ (crc >> 8);
+  return crc;
 }

--- a/source/crc32.h
+++ b/source/crc32.h
@@ -3,6 +3,6 @@
 
 unsigned long crc32(const unsigned char *buf, unsigned long len);
 unsigned long crc32FromUpcaseString(const char *str);
-unsigned long crc32FromUpcaseStdString(const std::string& str);
+unsigned long crc32FromUpcaseStdString(const std::string &str);
 unsigned long crc32FromString(const char *str);
-unsigned long crc32FromStdString(const std::string& str);
+unsigned long crc32FromStdString(const std::string &str);

--- a/source/dllmain.cpp
+++ b/source/dllmain.cpp
@@ -1,76 +1,69 @@
-#include "stdafx.h"
-#include "CleoBase.h"
 #include "CDebug.h"
-
+#include "CleoBase.h"
+#include "stdafx.h"
 
 using namespace CLEO;
 
-class Starter
-{
-    static Starter dummy;
-    Starter()
-    {
-        auto gv = CleoInstance.VersionManager.GetGameVersion();
-        TRACE("Started on game of version: %s",
-            (gv == GV_US10) ? "SA 1.0 us" :
-            (gv == GV_EU11) ? "SA 1.01 eu" :
-            (gv == GV_EU10) ? "SA 1.0 eu" :
-            (gv == GV_STEAM) ? "SA 3.0 steam" :
-            "<!unknown!>");
+class Starter {
+  static Starter dummy;
+  Starter() {
+    auto gv = CleoInstance.VersionManager.GetGameVersion();
+    TRACE("Started on game of version: %s", (gv == GV_US10)    ? "SA 1.0 us"
+                                            : (gv == GV_EU11)  ? "SA 1.01 eu"
+                                            : (gv == GV_EU10)  ? "SA 1.0 eu"
+                                            : (gv == GV_STEAM) ? "SA 3.0 steam"
+                                                               : "<!unknown!>");
 
-        if (gv != GV_US10 && gv != GV_EU11 && gv != GV_EU10 && gv != GV_STEAM)
-            TRACE(
-                "Unknown game version.\n"
-                "The list of all known executables:\n\n"
-                "  1) gta_sa.exe, original 1.0 us, 14 405 632 bytes;\n"
-                "  2) gta_sa.exe, public no-dvd 1.0 us, 14 383 616 bytes;\n"
-                "  3) gta_sa_compact.exe, listener's executable, 5 189 632 bytes;\n"
-                "  4) gta_sa.exe, original 1.01 eu, 14 405 632 bytes;\n"
-                "  5) gta_sa.exe, public no-dvd 1.01 eu, 15 806 464 bytes;\n"
-                "  6) gta_sa.exe, 1C localization, 15 806 464 bytes;\n"
-                "  7) gta_sa.exe, original 1.0 eu, unknown size;\n"
-                "  8) gta_sa.exe, public no-dvd 1.0eu, 14 386 176 bytes;\n"
-                "  9) gta_sa.exe, original 3.0 steam executable, unknown size;"
-                " 10) gta_sa.exe, decrypted 3.0 steam executable, 5 697 536 bytes."
-            );
+    if (gv != GV_US10 && gv != GV_EU11 && gv != GV_EU10 && gv != GV_STEAM)
+      TRACE(
+          "Unknown game version.\n"
+          "The list of all known executables:\n\n"
+          "  1) gta_sa.exe, original 1.0 us, 14 405 632 bytes;\n"
+          "  2) gta_sa.exe, public no-dvd 1.0 us, 14 383 616 bytes;\n"
+          "  3) gta_sa_compact.exe, listener's executable, 5 189 632 bytes;\n"
+          "  4) gta_sa.exe, original 1.01 eu, 14 405 632 bytes;\n"
+          "  5) gta_sa.exe, public no-dvd 1.01 eu, 15 806 464 bytes;\n"
+          "  6) gta_sa.exe, 1C localization, 15 806 464 bytes;\n"
+          "  7) gta_sa.exe, original 1.0 eu, unknown size;\n"
+          "  8) gta_sa.exe, public no-dvd 1.0eu, 14 386 176 bytes;\n"
+          "  9) gta_sa.exe, original 3.0 steam executable, unknown size;"
+          " 10) gta_sa.exe, decrypted 3.0 steam executable, 5 697 536 bytes.");
 
-        // incompatible game version
-        if (gv != GV_US10)
-        {
-            const auto versionMsg = \
-                "Unsupported game version! \n" \
-                "Like most of GTA SA mods, CLEO is meant to work with game version 1.0. \n" \
-                "Please downgrade your game's executable file to GTA SA 1.0 US, or so called \"Hoodlum\" or \"Compact\" variant.";
+    // incompatible game version
+    if (gv != GV_US10) {
+      const auto versionMsg =
+          "Unsupported game version! \n"
+          "Like most of GTA SA mods, CLEO is meant to work with game version "
+          "1.0. \n"
+          "Please downgrade your game's executable file to GTA SA 1.0 US, or "
+          "so called \"Hoodlum\" or \"Compact\" variant.";
 
-            int prevVersion = GetPrivateProfileInt("Internal", "ReportedGameVersion", GV_US10, Filepath_Config.c_str());
-            if (gv != prevVersion) // we not nagged user yet
-            {
-                SHOW_ERROR(versionMsg);
-            }
-            else
-            {
-                TRACE("");
-                TRACE(versionMsg);
-                TRACE("");
-            }
+      int prevVersion = GetPrivateProfileInt("Internal", "ReportedGameVersion",
+                                             GV_US10, Filepath_Config.c_str());
+      if (gv != prevVersion) // we not nagged user yet
+      {
+        SHOW_ERROR(versionMsg);
+      } else {
+        TRACE("");
+        TRACE(versionMsg);
+        TRACE("");
+      }
 
-            char strValue[32];
-            _itoa_s(gv, strValue, 10);
-            WritePrivateProfileString("Internal", "ReportedGameVersion", strValue, Filepath_Config.c_str());
-        }
-
-        CleoInstance.Start(CCleoInstance::InitStage::Initial);
+      char strValue[32];
+      _itoa_s(gv, strValue, 10);
+      WritePrivateProfileString("Internal", "ReportedGameVersion", strValue,
+                                Filepath_Config.c_str());
     }
 
-    ~Starter()
-    {
-        CleoInstance.Stop();
-    }
+    CleoInstance.Start(CCleoInstance::InitStage::Initial);
+  }
+
+  ~Starter() { CleoInstance.Stop(); }
 };
 
 Starter Starter::dummy;
 
-extern "C" BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
-{
-    return TRUE;
+extern "C" BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason,
+                               LPVOID lpvReserved) {
+  return TRUE;
 }

--- a/source/exports.cpp
+++ b/source/exports.cpp
@@ -1,486 +1,460 @@
-#include "stdafx.h"
 #include "CleoBase.h"
+#include "stdafx.h"
 
+namespace CLEO {
+extern "C" {
+DWORD WINAPI CLEO_GetVersion() { return CLEO_VERSION; }
 
-namespace CLEO
-{
-extern "C"
-{
-    DWORD WINAPI CLEO_GetVersion()
-    {
-        return CLEO_VERSION;
+LPCSTR WINAPI CLEO_GetVersionStr() { return CLEO_VERSION_STR; }
+
+eGameVersion WINAPI CLEO_GetGameVersion() { return DetermineGameVersion(); }
+
+BOOL WINAPI CLEO_RegisterOpcode(WORD opcode, CustomOpcodeHandler callback) {
+  return CCustomOpcodeSystem::RegisterOpcode(opcode, callback);
+}
+
+BOOL WINAPI CLEO_RegisterCommand(const char *commandName,
+                                 CustomOpcodeHandler callback) {
+  WORD opcode = CleoInstance.OpcodeInfoDb.GetOpcode(commandName);
+  if (opcode == 0xFFFF) {
+    LOG_WARNING(0,
+                "Failed to register opcode [%s]! Command name not found in the "
+                "database.",
+                commandName);
+    return false;
+  }
+
+  return CCustomOpcodeSystem::RegisterOpcode(opcode, callback);
+}
+
+OpcodeResult WINAPI CLEO_CallNativeOpcode(CRunningScript *script, WORD opcode) {
+  return CCustomOpcodeSystem::CallNativeOpcode(script, opcode);
+}
+
+void WINAPI CLEO_RegisterCallback(eCallbackId id, void *func) {
+  CleoInstance.AddCallback(id, func);
+}
+
+void WINAPI CLEO_UnregisterCallback(eCallbackId id, void *func) {
+  CleoInstance.RemoveCallback(id, func);
+}
+
+void WINAPI CLEO_AddScriptDeleteDelegate(FuncScriptDeleteDelegateT func) {
+  CleoInstance.OpcodeSystem.scriptDeleteDelegate += func;
+}
+
+void WINAPI CLEO_RemoveScriptDeleteDelegate(FuncScriptDeleteDelegateT func) {
+  CleoInstance.OpcodeSystem.scriptDeleteDelegate -= func;
+}
+
+BOOL WINAPI CLEO_IsScriptRunning(const CLEO::CRunningScript *thread) {
+  return CleoInstance.ScriptEngine.IsActiveScriptPtr(thread);
+}
+
+void WINAPI CLEO_GetScriptInfoStr(CLEO::CRunningScript *thread,
+                                  bool currLineInfo, char *buf, DWORD bufSize) {
+  if (thread == nullptr || buf == nullptr || bufSize < 2) {
+    return; // invalid param
+  }
+
+  auto text =
+      reinterpret_cast<CCustomScript *>(thread)->GetInfoStr(currLineInfo);
+
+  if (text.length() >= bufSize)
+    text.resize(bufSize - 1); // and terminator character
+
+  std::memcpy(buf, text.c_str(), text.length() + 1); // with terminator
+}
+
+void WINAPI CLEO_GetScriptParamInfoStr(int idexOffset, char *buf,
+                                       DWORD bufSize) {
+  auto curr = idexOffset - 1 + CleoInstance.OpcodeSystem.handledParamCount;
+  auto name = CleoInstance.OpcodeInfoDb.GetArgumentName(
+      CleoInstance.OpcodeSystem.lastOpcode, curr);
+
+  curr++; // 1-based argument index display
+
+  std::string msg;
+  if (name != nullptr)
+    msg = StringPrintf("#%d \"%s\"", curr, name);
+  else
+    msg = StringPrintf("#%d", curr);
+
+  strncpy_s(buf, bufSize, msg.c_str(), bufSize);
+}
+
+DWORD WINAPI CLEO_GetScriptBaseRelativeOffset(const CRunningScript *script,
+                                              const BYTE *codePos) {
+  auto base = (BYTE *)script->BaseIP;
+  if (base == 0)
+    base = CleoInstance.ScriptEngine.scmBlock;
+
+  if (script->IsMission() && !script->IsCustom()) {
+    if (codePos >= CleoInstance.ScriptEngine.missionBlock) {
+      // we are in mission code buffer
+      // native missions are loaded from script file into mission block area
+      codePos += ((DWORD *)CTheScripts::MultiScriptArray)
+          [CleoInstance.ScriptEngine.missionIndex]; // start offset of this
+                                                    // mission within source
+                                                    // script file
+    } else {
+      base = CleoInstance.ScriptEngine
+                 .scmBlock; // seems that mission uses main scm code
     }
+  }
 
-    LPCSTR WINAPI CLEO_GetVersionStr()
-    {
-        return CLEO_VERSION_STR;
+  return codePos - base;
+}
+
+eCLEO_Version WINAPI CLEO_GetScriptVersion(const CRunningScript *thread) {
+  if (thread->IsCustom())
+    return reinterpret_cast<const CCustomScript *>(thread)->GetCompatibility();
+  else
+    return CleoInstance.ScriptEngine.NativeScriptsVersion;
+}
+
+void WINAPI CLEO_SetScriptVersion(CRunningScript *thread,
+                                  eCLEO_Version version) {
+  if (thread->IsCustom())
+    ((CCustomScript *)thread)->SetCompatibility(version);
+  else
+    CleoInstance.ScriptEngine.NativeScriptsVersion = version;
+}
+
+LPCSTR WINAPI CLEO_GetScriptFilename(const CRunningScript *thread) {
+  if (!CleoInstance.ScriptEngine.IsValidScriptPtr(thread)) {
+    return nullptr;
+  }
+
+  auto cs = (CCustomScript *)thread;
+  return cs->GetScriptFileName();
+}
+
+LPCSTR WINAPI CLEO_GetScriptWorkDir(const CRunningScript *thread) {
+  auto cs = (CCustomScript *)thread;
+  return cs->GetWorkDir();
+}
+
+void WINAPI CLEO_SetScriptWorkDir(CRunningScript *thread, const char *path) {
+  auto cs = (CCustomScript *)thread;
+  cs->SetWorkDir(path);
+}
+
+void WINAPI CLEO_SetThreadCondResult(CLEO::CRunningScript *thread,
+                                     BOOL result) {
+  ((::CRunningScript *)thread)
+      ->UpdateCompareFlag(result != FALSE); // CRunningScript from Plugin SDK
+}
+
+void WINAPI CLEO_ThreadJumpAtLabelPtr(CLEO::CRunningScript *thread,
+                                      int offset) {
+  thread->SetIp(offset < 0 ? thread->GetBasePointer() - offset
+                           : CleoInstance.ScriptEngine.scmBlock + offset);
+}
+
+void WINAPI CLEO_TerminateScript(CLEO::CRunningScript *thread) {
+  CleoInstance.ScriptEngine.RemoveScript(thread);
+}
+
+int WINAPI CLEO_GetOperandType(const CLEO::CRunningScript *thread) {
+  return (int)thread->PeekDataType();
+}
+
+DWORD WINAPI CLEO_GetVarArgCount(CLEO::CRunningScript *thread) {
+  return GetVarArgCount(thread);
+}
+
+SCRIPT_VAR *opcodeParams;
+SCRIPT_VAR *missionLocals;
+CRunningScript *staticThreads;
+
+BYTE *WINAPI CLEO_GetScmMainData() {
+  return CleoInstance.ScriptEngine.scmBlock;
+}
+
+SCRIPT_VAR *WINAPI CLEO_GetOpcodeParamsArray() { return CLEO::opcodeParams; }
+
+BYTE WINAPI CLEO_GetParamsHandledCount() {
+  return CleoInstance.OpcodeSystem.handledParamCount;
+}
+
+SCRIPT_VAR *WINAPI
+CLEO_GetPointerToScriptVariable(CLEO::CRunningScript *thread) {
+  return CScriptEngine::GetScriptParamPointer(thread);
+}
+
+void WINAPI CLEO_RetrieveOpcodeParams(CLEO::CRunningScript *thread, int count) {
+  CScriptEngine::GetScriptParams(thread, count);
+}
+
+DWORD WINAPI CLEO_GetIntOpcodeParam(CLEO::CRunningScript *thread) {
+  CScriptEngine::GetScriptParams(thread, 1);
+  return opcodeParams[0].dwParam;
+}
+
+float WINAPI CLEO_GetFloatOpcodeParam(CLEO::CRunningScript *thread) {
+  CScriptEngine::GetScriptParams(thread, 1);
+  return opcodeParams[0].fParam;
+}
+
+LPCSTR WINAPI CLEO_ReadStringOpcodeParam(CLEO::CRunningScript *thread,
+                                         char *buff, int buffSize) {
+  static char internal_buff[MAX_STR_LEN + 1]; // and terminator
+  if (!buff) {
+    buff = internal_buff;
+    buffSize = (buffSize > 0)
+                   ? std::min<int>(buffSize, sizeof(internal_buff))
+                   : sizeof(internal_buff); // allow user's length limit
+  }
+
+  auto result = ReadStringParam(thread, buff, buffSize);
+  return (result != nullptr) ? buff : nullptr;
+}
+
+LPCSTR WINAPI CLEO_ReadStringPointerOpcodeParam(CLEO::CRunningScript *thread,
+                                                char *buff, int buffSize) {
+  static char internal_buff[MAX_STR_LEN + 1]; // and terminator
+  bool userBuffer = buff != nullptr;
+  if (!userBuffer) {
+    buff = internal_buff;
+    buffSize = (buffSize > 0)
+                   ? std::min<int>(buffSize, sizeof(internal_buff))
+                   : sizeof(internal_buff); // allow user's length limit
+  }
+
+  return ReadStringParam(thread, buff, buffSize);
+}
+
+void WINAPI CLEO_ReadStringParamWriteBuffer(CLEO::CRunningScript *thread,
+                                            char **outBuf, int *outBufSize,
+                                            BOOL *outNeedsTerminator) {
+  if (thread == nullptr || outBuf == nullptr || outBufSize == nullptr ||
+      outNeedsTerminator == nullptr) {
+    LOG_WARNING(
+        thread,
+        "Invalid argument of CLEO_ReadStringParamWriteBuffer in script %s",
+        ((CCustomScript *)thread)->GetInfoStr().c_str());
+    return;
+  }
+
+  auto target = GetStringParamWriteBuffer(thread);
+  *outBuf = target.data;
+  *outBufSize = target.size;
+  *outNeedsTerminator = target.needTerminator;
+}
+
+char *WINAPI CLEO_ReadParamsFormatted(CLEO::CRunningScript *thread,
+                                      const char *format, char *buf,
+                                      int bufSize) {
+  static char internal_buf[MAX_STR_LEN * 4];
+  if (!buf) {
+    buf = internal_buf;
+    bufSize = sizeof(internal_buf);
+  }
+  if (!bufSize)
+    bufSize = MAX_STR_LEN;
+
+  if (ReadFormattedString(thread, buf, bufSize, format) == -1) // error?
+  {
+    return nullptr; // error
+  }
+
+  return buf;
+}
+
+DWORD WINAPI CLEO_PeekIntOpcodeParam(CLEO::CRunningScript *thread) {
+  // store state
+  auto param = CLEO::opcodeParams[0];
+  auto ip = thread->CurrentIP;
+  auto count = CleoInstance.OpcodeSystem.handledParamCount;
+
+  CScriptEngine::GetScriptParams(thread, 1);
+  DWORD result = CLEO::opcodeParams[0].dwParam;
+
+  // restore state
+  thread->CurrentIP = ip;
+  CleoInstance.OpcodeSystem.handledParamCount = count;
+  CLEO::opcodeParams[0] = param;
+
+  return result;
+}
+
+float WINAPI CLEO_PeekFloatOpcodeParam(CLEO::CRunningScript *thread) {
+  // store state
+  auto param = CLEO::opcodeParams[0];
+  auto ip = thread->CurrentIP;
+  auto count = CleoInstance.OpcodeSystem.handledParamCount;
+
+  CScriptEngine::GetScriptParams(thread, 1);
+  float result = CLEO::opcodeParams[0].fParam;
+
+  // restore state
+  thread->CurrentIP = ip;
+  CleoInstance.OpcodeSystem.handledParamCount = count;
+  CLEO::opcodeParams[0] = param;
+
+  return result;
+}
+
+SCRIPT_VAR *WINAPI
+CLEO_PeekPointerToScriptVariable(CLEO::CRunningScript *thread) {
+  // store state
+  auto ip = thread->CurrentIP;
+  auto count = CleoInstance.OpcodeSystem.handledParamCount;
+
+  auto result = CScriptEngine::GetScriptParamPointer(thread);
+
+  // restore state
+  thread->CurrentIP = ip;
+  CleoInstance.OpcodeSystem.handledParamCount = count;
+
+  return result;
+}
+
+void WINAPI CLEO_SkipOpcodeParams(CLEO::CRunningScript *thread, int count) {
+  if (count < 1)
+    return;
+
+  for (int i = 0; i < count; i++) {
+    switch (thread->ReadDataType()) {
+    case DT_VAR:
+    case DT_LVAR:
+    case DT_VAR_STRING:
+    case DT_LVAR_STRING:
+    case DT_VAR_TEXTLABEL:
+    case DT_LVAR_TEXTLABEL:
+      thread->IncPtr(2);
+      break;
+    case DT_VAR_ARRAY:
+    case DT_LVAR_ARRAY:
+    case DT_VAR_TEXTLABEL_ARRAY:
+    case DT_LVAR_TEXTLABEL_ARRAY:
+    case DT_VAR_STRING_ARRAY:
+    case DT_LVAR_STRING_ARRAY:
+      thread->IncPtr(6);
+      break;
+    case DT_BYTE:
+      // case DT_END: // should be only skipped with var args dediacated
+      // functions
+      thread->IncPtr();
+      break;
+    case DT_WORD:
+      thread->IncPtr(2);
+      break;
+    case DT_DWORD:
+    case DT_FLOAT:
+      thread->IncPtr(4);
+      break;
+    case DT_VARLEN_STRING:
+      thread->IncPtr(
+          (int)1 +
+          *thread->GetBytePointer()); // as unsigned! length byte + string data
+      break;
+
+    case DT_TEXTLABEL:
+      thread->IncPtr(8);
+      break;
+    case DT_STRING:
+      thread->IncPtr(16);
+      break;
     }
-
-    eGameVersion WINAPI CLEO_GetGameVersion()
-    {
-        return DetermineGameVersion();
-    }
-
-    BOOL WINAPI CLEO_RegisterOpcode(WORD opcode, CustomOpcodeHandler callback)
-    {
-        return CCustomOpcodeSystem::RegisterOpcode(opcode, callback);
-    }
-
-    BOOL WINAPI CLEO_RegisterCommand(const char* commandName, CustomOpcodeHandler callback)
-    {
-        WORD opcode = CleoInstance.OpcodeInfoDb.GetOpcode(commandName);
-        if (opcode == 0xFFFF)
-        {
-            LOG_WARNING(0, "Failed to register opcode [%s]! Command name not found in the database.", commandName);
-            return false;
-        }
-
-        return CCustomOpcodeSystem::RegisterOpcode(opcode, callback);
-    }
-
-    OpcodeResult WINAPI CLEO_CallNativeOpcode(CRunningScript* script, WORD opcode)
-    {
-        return CCustomOpcodeSystem::CallNativeOpcode(script, opcode);
-    }
-
-    void WINAPI CLEO_RegisterCallback(eCallbackId id, void* func)
-    {
-        CleoInstance.AddCallback(id, func);
-    }
-
-    void WINAPI CLEO_UnregisterCallback(eCallbackId id, void* func)
-    {
-        CleoInstance.RemoveCallback(id, func);
-    }
-
-    void WINAPI CLEO_AddScriptDeleteDelegate(FuncScriptDeleteDelegateT func)
-    {
-        CleoInstance.OpcodeSystem.scriptDeleteDelegate += func;
-    }
-
-    void WINAPI CLEO_RemoveScriptDeleteDelegate(FuncScriptDeleteDelegateT func)
-    {
-        CleoInstance.OpcodeSystem.scriptDeleteDelegate -= func;
-    }
-
-    BOOL WINAPI CLEO_IsScriptRunning(const CLEO::CRunningScript* thread)
-    {
-        return CleoInstance.ScriptEngine.IsActiveScriptPtr(thread);
-    }
-
-    void WINAPI CLEO_GetScriptInfoStr(CLEO::CRunningScript* thread, bool currLineInfo, char* buf, DWORD bufSize)
-    {
-        if (thread == nullptr || buf == nullptr || bufSize < 2)
-        {
-            return; // invalid param
-        }
-
-        auto text = reinterpret_cast<CCustomScript*>(thread)->GetInfoStr(currLineInfo);
-
-        if (text.length() >= bufSize)
-            text.resize(bufSize - 1); // and terminator character
-
-        std::memcpy(buf, text.c_str(), text.length() + 1); // with terminator
-    }
-
-    void WINAPI CLEO_GetScriptParamInfoStr(int idexOffset, char* buf, DWORD bufSize)
-    {
-        auto curr = idexOffset - 1 + CleoInstance.OpcodeSystem.handledParamCount;
-        auto name = CleoInstance.OpcodeInfoDb.GetArgumentName(CleoInstance.OpcodeSystem.lastOpcode, curr);
-
-        curr++; // 1-based argument index display
-
-        std::string msg;
-        if (name != nullptr) msg = StringPrintf("#%d \"%s\"", curr, name);
-        else msg = StringPrintf("#%d", curr);
-
-        strncpy_s(buf, bufSize, msg.c_str(), bufSize);
-    }
-
-    DWORD WINAPI CLEO_GetScriptBaseRelativeOffset(const CRunningScript* script, const BYTE* codePos)
-    {
-        auto base = (BYTE*)script->BaseIP;
-        if (base == 0) base = CleoInstance.ScriptEngine.scmBlock;
-
-        if (script->IsMission() && !script->IsCustom())
-        {
-            if (codePos >= CleoInstance.ScriptEngine.missionBlock)
-            {
-                // we are in mission code buffer
-                // native missions are loaded from script file into mission block area
-                codePos += ((DWORD*)CTheScripts::MultiScriptArray)[CleoInstance.ScriptEngine.missionIndex]; // start offset of this mission within source script file
-            }
-            else
-            {
-                base = CleoInstance.ScriptEngine.scmBlock; // seems that mission uses main scm code
-            }
-        }
-
-        return codePos - base;
-    }
-
-    eCLEO_Version WINAPI CLEO_GetScriptVersion(const CRunningScript* thread)
-    {
-        if (thread->IsCustom())
-            return reinterpret_cast<const CCustomScript*>(thread)->GetCompatibility();
-        else
-            return CleoInstance.ScriptEngine.NativeScriptsVersion;
-    }
-
-    void WINAPI CLEO_SetScriptVersion(CRunningScript* thread, eCLEO_Version version)
-    {
-        if (thread->IsCustom())
-            ((CCustomScript*)thread)->SetCompatibility(version);
-        else
-            CleoInstance.ScriptEngine.NativeScriptsVersion = version;
-    }
-
-    LPCSTR WINAPI CLEO_GetScriptFilename(const CRunningScript* thread)
-    {
-        if (!CleoInstance.ScriptEngine.IsValidScriptPtr(thread))
-        {
-            return nullptr;
-        }
-
-        auto cs = (CCustomScript*)thread;
-        return cs->GetScriptFileName();
-    }
-
-    LPCSTR WINAPI CLEO_GetScriptWorkDir(const CRunningScript* thread)
-    {
-        auto cs = (CCustomScript*)thread;
-        return cs->GetWorkDir();
-    }
-
-    void WINAPI CLEO_SetScriptWorkDir(CRunningScript* thread, const char* path)
-    {
-        auto cs = (CCustomScript*)thread;
-        cs->SetWorkDir(path);
-    }
-
-    void WINAPI CLEO_SetThreadCondResult(CLEO::CRunningScript* thread, BOOL result)
-    {
-        ((::CRunningScript*)thread)->UpdateCompareFlag(result != FALSE); // CRunningScript from Plugin SDK
-    }
-
-    void WINAPI CLEO_ThreadJumpAtLabelPtr(CLEO::CRunningScript* thread, int offset)
-    {
-        thread->SetIp(offset < 0 ? thread->GetBasePointer() - offset : CleoInstance.ScriptEngine.scmBlock + offset);
-    }
-
-    void WINAPI CLEO_TerminateScript(CLEO::CRunningScript* thread)
-    {
-        CleoInstance.ScriptEngine.RemoveScript(thread);
-    }
-
-    int WINAPI CLEO_GetOperandType(const CLEO::CRunningScript* thread)
-    {
-        return (int)thread->PeekDataType();
-    }
-
-    DWORD WINAPI CLEO_GetVarArgCount(CLEO::CRunningScript* thread)
-    {
-        return GetVarArgCount(thread);
-    }
-
-    SCRIPT_VAR* opcodeParams;
-    SCRIPT_VAR* missionLocals;
-    CRunningScript* staticThreads;
-
-    BYTE* WINAPI CLEO_GetScmMainData()
-    {
-        return CleoInstance.ScriptEngine.scmBlock;
-    }
-
-    SCRIPT_VAR* WINAPI CLEO_GetOpcodeParamsArray()
-    {
-        return CLEO::opcodeParams;
-    }
-
-    BYTE WINAPI CLEO_GetParamsHandledCount()
-    {
-        return CleoInstance.OpcodeSystem.handledParamCount;
-    }
-
-    SCRIPT_VAR* WINAPI CLEO_GetPointerToScriptVariable(CLEO::CRunningScript* thread)
-    {
-        return CScriptEngine::GetScriptParamPointer(thread);
-    }
-
-    void WINAPI CLEO_RetrieveOpcodeParams(CLEO::CRunningScript* thread, int count)
-    {
-        CScriptEngine::GetScriptParams(thread, count);
-    }
-
-    DWORD WINAPI CLEO_GetIntOpcodeParam(CLEO::CRunningScript* thread)
-    {
-        CScriptEngine::GetScriptParams(thread, 1);
-        return opcodeParams[0].dwParam;
-    }
-
-    float WINAPI CLEO_GetFloatOpcodeParam(CLEO::CRunningScript* thread)
-    {
-        CScriptEngine::GetScriptParams(thread, 1);
-        return opcodeParams[0].fParam;
-    }
-
-    LPCSTR WINAPI CLEO_ReadStringOpcodeParam(CLEO::CRunningScript* thread, char* buff, int buffSize)
-    {
-        static char internal_buff[MAX_STR_LEN + 1]; // and terminator
-        if (!buff)
-        {
-            buff = internal_buff;
-            buffSize = (buffSize > 0) ? std::min<int>(buffSize, sizeof(internal_buff)) : sizeof(internal_buff); // allow user's length limit
-        }
-
-        auto result = ReadStringParam(thread, buff, buffSize);
-        return (result != nullptr) ? buff : nullptr;
-    }
-
-    LPCSTR WINAPI CLEO_ReadStringPointerOpcodeParam(CLEO::CRunningScript* thread, char* buff, int buffSize)
-    {
-        static char internal_buff[MAX_STR_LEN + 1]; // and terminator
-        bool userBuffer = buff != nullptr;
-        if (!userBuffer)
-        {
-            buff = internal_buff;
-            buffSize = (buffSize > 0) ? std::min<int>(buffSize, sizeof(internal_buff)) : sizeof(internal_buff); // allow user's length limit
-        }
-
-        return ReadStringParam(thread, buff, buffSize);
-    }
-
-    void WINAPI CLEO_ReadStringParamWriteBuffer(CLEO::CRunningScript* thread, char** outBuf, int* outBufSize, BOOL* outNeedsTerminator)
-    {
-        if (thread == nullptr ||
-            outBuf == nullptr ||
-            outBufSize == nullptr ||
-            outNeedsTerminator == nullptr)
-        {
-            LOG_WARNING(thread, "Invalid argument of CLEO_ReadStringParamWriteBuffer in script %s", ((CCustomScript*)thread)->GetInfoStr().c_str());
-            return;
-        }
-
-        auto target = GetStringParamWriteBuffer(thread);
-        *outBuf = target.data;
-        *outBufSize = target.size;
-        *outNeedsTerminator = target.needTerminator;
-    }
-
-    char* WINAPI CLEO_ReadParamsFormatted(CLEO::CRunningScript* thread, const char* format, char* buf, int bufSize)
-    {
-        static char internal_buf[MAX_STR_LEN * 4];
-        if (!buf) { buf = internal_buf; bufSize = sizeof(internal_buf); }
-        if (!bufSize) bufSize = MAX_STR_LEN;
-
-        if (ReadFormattedString(thread, buf, bufSize, format) == -1) // error?
-        {
-            return nullptr; // error
-        }
-
-        return buf;
-    }
-
-    DWORD WINAPI CLEO_PeekIntOpcodeParam(CLEO::CRunningScript* thread)
-    {
-        // store state
-        auto param = CLEO::opcodeParams[0];
-        auto ip = thread->CurrentIP;
-        auto count = CleoInstance.OpcodeSystem.handledParamCount;
-
-        CScriptEngine::GetScriptParams(thread, 1);
-        DWORD result = CLEO::opcodeParams[0].dwParam;
-
-        // restore state
-        thread->CurrentIP = ip;
-        CleoInstance.OpcodeSystem.handledParamCount = count;
-        CLEO::opcodeParams[0] = param;
-
-        return result;
-    }
-
-    float WINAPI CLEO_PeekFloatOpcodeParam(CLEO::CRunningScript* thread)
-    {
-        // store state
-        auto param = CLEO::opcodeParams[0];
-        auto ip = thread->CurrentIP;
-        auto count = CleoInstance.OpcodeSystem.handledParamCount;
-
-        CScriptEngine::GetScriptParams(thread, 1);
-        float result = CLEO::opcodeParams[0].fParam;
-
-        // restore state
-        thread->CurrentIP = ip;
-        CleoInstance.OpcodeSystem.handledParamCount = count;
-        CLEO::opcodeParams[0] = param;
-
-        return result;
-    }
-
-    SCRIPT_VAR* WINAPI CLEO_PeekPointerToScriptVariable(CLEO::CRunningScript* thread)
-    {
-        // store state
-        auto ip = thread->CurrentIP;
-        auto count = CleoInstance.OpcodeSystem.handledParamCount;
-
-        auto result = CScriptEngine::GetScriptParamPointer(thread);
-
-        // restore state
-        thread->CurrentIP = ip;
-        CleoInstance.OpcodeSystem.handledParamCount = count;
-
-        return result;
-    }
-
-    void WINAPI CLEO_SkipOpcodeParams(CLEO::CRunningScript* thread, int count)
-    {
-        if (count < 1) return;
-
-        for (int i = 0; i < count; i++)
-        {
-            switch (thread->ReadDataType())
-            {
-            case DT_VAR:
-            case DT_LVAR:
-            case DT_VAR_STRING:
-            case DT_LVAR_STRING:
-            case DT_VAR_TEXTLABEL:
-            case DT_LVAR_TEXTLABEL:
-                thread->IncPtr(2);
-                break;
-            case DT_VAR_ARRAY:
-            case DT_LVAR_ARRAY:
-            case DT_VAR_TEXTLABEL_ARRAY:
-            case DT_LVAR_TEXTLABEL_ARRAY:
-            case DT_VAR_STRING_ARRAY:
-            case DT_LVAR_STRING_ARRAY:
-                thread->IncPtr(6);
-                break;
-            case DT_BYTE:
-                //case DT_END: // should be only skipped with var args dediacated functions
-                thread->IncPtr();
-                break;
-            case DT_WORD:
-                thread->IncPtr(2);
-                break;
-            case DT_DWORD:
-            case DT_FLOAT:
-                thread->IncPtr(4);
-                break;
-            case DT_VARLEN_STRING:
-                thread->IncPtr((int)1 + *thread->GetBytePointer()); // as unsigned! length byte + string data
-                break;
-
-            case DT_TEXTLABEL:
-                thread->IncPtr(8);
-                break;
-            case DT_STRING:
-                thread->IncPtr(16);
-                break;
-            }
-        }
-
-        CleoInstance.OpcodeSystem.handledParamCount += count;
-    }
-
-    void WINAPI CLEO_SkipUnusedVarArgs(CLEO::CRunningScript* thread)
-    {
-        SkipUnusedVarArgs(thread);
-    }
-
-    void WINAPI CLEO_RecordOpcodeParams(CLEO::CRunningScript* thread, int count)
-    {
-        CScriptEngine::SetScriptParams(thread, count);
-    }
-
-    void WINAPI CLEO_SetIntOpcodeParam(CLEO::CRunningScript* thread, DWORD value)
-    {
-        CLEO::opcodeParams[0].dwParam = value;
-        CScriptEngine::SetScriptParams(thread, 1);
-    }
-
-    void WINAPI CLEO_SetFloatOpcodeParam(CLEO::CRunningScript* thread, float value)
-    {
-        CLEO::opcodeParams[0].fParam = value;
-        CScriptEngine::SetScriptParams(thread, 1);
-    }
-
-    void WINAPI CLEO_WriteStringOpcodeParam(CLEO::CRunningScript* thread, const char* str)
-    {
-        if (!WriteStringParam(thread, str))
-            LOG_WARNING(thread, "%s in script %s", CCustomOpcodeSystem::lastErrorMsg.c_str(), ((CCustomScript*)thread)->GetInfoStr().c_str());
-    }
-
-    BOOL WINAPI CLEO_GetScriptDebugMode(const CLEO::CRunningScript* thread)
-    {
-        return reinterpret_cast<const CCustomScript*>(thread)->GetDebugMode();
-    }
-
-    void WINAPI CLEO_SetScriptDebugMode(CLEO::CRunningScript* thread, BOOL enabled)
-    {
-        reinterpret_cast<CCustomScript*>(thread)->SetDebugMode(enabled);
-    }
-
-    CLEO::CRunningScript* WINAPI CLEO_CreateCustomScript(CLEO::CRunningScript* fromThread, const char* filePath, int label)
-    {
-        return (CLEO::CRunningScript*)CleoInstance.ScriptEngine.CreateCustomScript(fromThread, filePath, label);
-    }
-
-    CLEO::CRunningScript* WINAPI CLEO_GetLastCreatedCustomScript()
-    {
-        return CleoInstance.ScriptEngine.LastScriptCreated;
-    }
-
-    CLEO::CRunningScript* WINAPI CLEO_GetScriptByName(const char* threadName, BOOL standardScripts, BOOL customScripts, DWORD resultIndex)
-    {
-        return CleoInstance.ScriptEngine.FindScriptNamed(threadName, standardScripts, customScripts, resultIndex);
-    }
-
-    CLEO::CRunningScript* WINAPI CLEO_GetScriptByFilename(const char* path, DWORD resultIndex)
-    {
-        return CleoInstance.ScriptEngine.FindScriptByFilename(path, resultIndex);
-    }
-
-    DWORD WINAPI CLEO_GetScriptTextureById(CLEO::CRunningScript* thread, int id)
-    {
-        HMODULE textPlugin = GetModuleHandleA("SA.Text.cleo");
-        if (textPlugin == nullptr)
-        {
-            return (DWORD)nullptr;
-        }
-
-        auto GetScriptTexture = (RwTexture* (__cdecl*)(CLEO::CRunningScript*, DWORD)) GetProcAddress(textPlugin, "GetScriptTexture");
-        if (GetScriptTexture == nullptr)
-        {
-            return (DWORD)nullptr;
-        }
-
-        return (DWORD)GetScriptTexture(thread, id);
-    }
-
-    DWORD WINAPI CLEO_GetInternalAudioStream(CLEO::CRunningScript* unused, DWORD audioStreamPtr)
-    {
-        return *(DWORD*)(audioStreamPtr + 0x4); // CAudioStream->streamInternal
-    }
-
-    // void WINAPI CLEO_StringListFree(StringList list)
-    // void WINAPI CLEO_ResolvePath(CLEO::CRunningScript* thread, char* inOutPath, DWORD pathMaxLen)
-    // StringList WINAPI CLEO_ListDirectory(CLEO::CRunningScript* thread, const char* searchPath, BOOL listDirs, BOOL listFiles)
-    // defined in CleoBase.h
-
-    LPCSTR WINAPI CLEO_GetGameDirectory()
-    {
-        return Filepath_Game.c_str();
-    }
-
-    LPCSTR WINAPI CLEO_GetUserDirectory()
-    {
-        return Filepath_User.c_str();
-    }
-
-    void WINAPI CLEO_Log(eLogLevel level, const char* msg)
-    {
-        Debug.Trace(level, msg);
-    }
+  }
+
+  CleoInstance.OpcodeSystem.handledParamCount += count;
+}
+
+void WINAPI CLEO_SkipUnusedVarArgs(CLEO::CRunningScript *thread) {
+  SkipUnusedVarArgs(thread);
+}
+
+void WINAPI CLEO_RecordOpcodeParams(CLEO::CRunningScript *thread, int count) {
+  CScriptEngine::SetScriptParams(thread, count);
+}
+
+void WINAPI CLEO_SetIntOpcodeParam(CLEO::CRunningScript *thread, DWORD value) {
+  CLEO::opcodeParams[0].dwParam = value;
+  CScriptEngine::SetScriptParams(thread, 1);
+}
+
+void WINAPI CLEO_SetFloatOpcodeParam(CLEO::CRunningScript *thread,
+                                     float value) {
+  CLEO::opcodeParams[0].fParam = value;
+  CScriptEngine::SetScriptParams(thread, 1);
+}
+
+void WINAPI CLEO_WriteStringOpcodeParam(CLEO::CRunningScript *thread,
+                                        const char *str) {
+  if (!WriteStringParam(thread, str))
+    LOG_WARNING(thread, "%s in script %s",
+                CCustomOpcodeSystem::lastErrorMsg.c_str(),
+                ((CCustomScript *)thread)->GetInfoStr().c_str());
+}
+
+BOOL WINAPI CLEO_GetScriptDebugMode(const CLEO::CRunningScript *thread) {
+  return reinterpret_cast<const CCustomScript *>(thread)->GetDebugMode();
+}
+
+void WINAPI CLEO_SetScriptDebugMode(CLEO::CRunningScript *thread,
+                                    BOOL enabled) {
+  reinterpret_cast<CCustomScript *>(thread)->SetDebugMode(enabled);
+}
+
+CLEO::CRunningScript *WINAPI CLEO_CreateCustomScript(
+    CLEO::CRunningScript *fromThread, const char *filePath, int label) {
+  return (CLEO::CRunningScript *)CleoInstance.ScriptEngine.CreateCustomScript(
+      fromThread, filePath, label);
+}
+
+CLEO::CRunningScript *WINAPI CLEO_GetLastCreatedCustomScript() {
+  return CleoInstance.ScriptEngine.LastScriptCreated;
+}
+
+CLEO::CRunningScript *WINAPI CLEO_GetScriptByName(const char *threadName,
+                                                  BOOL standardScripts,
+                                                  BOOL customScripts,
+                                                  DWORD resultIndex) {
+  return CleoInstance.ScriptEngine.FindScriptNamed(threadName, standardScripts,
+                                                   customScripts, resultIndex);
+}
+
+CLEO::CRunningScript *WINAPI CLEO_GetScriptByFilename(const char *path,
+                                                      DWORD resultIndex) {
+  return CleoInstance.ScriptEngine.FindScriptByFilename(path, resultIndex);
+}
+
+DWORD WINAPI CLEO_GetScriptTextureById(CLEO::CRunningScript *thread, int id) {
+  HMODULE textPlugin = GetModuleHandleA("SA.Text.cleo");
+  if (textPlugin == nullptr) {
+    return (DWORD) nullptr;
+  }
+
+  auto GetScriptTexture =
+      (RwTexture * (__cdecl *)(CLEO::CRunningScript *, DWORD))
+          GetProcAddress(textPlugin, "GetScriptTexture");
+  if (GetScriptTexture == nullptr) {
+    return (DWORD) nullptr;
+  }
+
+  return (DWORD)GetScriptTexture(thread, id);
+}
+
+DWORD WINAPI CLEO_GetInternalAudioStream(CLEO::CRunningScript *unused,
+                                         DWORD audioStreamPtr) {
+  return *(DWORD *)(audioStreamPtr + 0x4); // CAudioStream->streamInternal
+}
+
+// void WINAPI CLEO_StringListFree(StringList list)
+// void WINAPI CLEO_ResolvePath(CLEO::CRunningScript* thread, char* inOutPath,
+// DWORD pathMaxLen) StringList WINAPI CLEO_ListDirectory(CLEO::CRunningScript*
+// thread, const char* searchPath, BOOL listDirs, BOOL listFiles) defined in
+// CleoBase.h
+
+LPCSTR WINAPI CLEO_GetGameDirectory() { return Filepath_Game.c_str(); }
+
+LPCSTR WINAPI CLEO_GetUserDirectory() { return Filepath_User.c_str(); }
+
+void WINAPI CLEO_Log(eLogLevel level, const char *msg) {
+  Debug.Trace(level, msg);
 }
 }
+} // namespace CLEO

--- a/source/resource.h
+++ b/source/resource.h
@@ -3,12 +3,12 @@
 // Used by CLEO4.rc
 
 // Next default values for new objects
-// 
+//
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
-#define _APS_NEXT_RESOURCE_VALUE        101
-#define _APS_NEXT_COMMAND_VALUE         40001
-#define _APS_NEXT_CONTROL_VALUE         1001
-#define _APS_NEXT_SYMED_VALUE           101
+#define _APS_NEXT_RESOURCE_VALUE 101
+#define _APS_NEXT_COMMAND_VALUE 40001
+#define _APS_NEXT_CONTROL_VALUE 1001
+#define _APS_NEXT_SYMED_VALUE 101
 #endif
 #endif

--- a/source/stdafx.h
+++ b/source/stdafx.h
@@ -4,34 +4,33 @@
 #define WIN32_LEAN_AND_MEAN
 #undef UNICODE
 
-#include <windows.h>
 #include <assert.h>
 #include <ctype.h>
 #include <psapi.h>
 #include <shellapi.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <windows.h>
 
 #include <algorithm>
+#include <array>
 #include <cstdint>
 #include <filesystem>
-#include <fstream>
-#include <memory>
-#include <array>
 #include <forward_list>
+#include <fstream>
 #include <list>
 #include <map>
+#include <memory>
 #include <set>
-#include <vector>
-#include <string>
 #include <sstream>
+#include <string>
+#include <vector>
 
 #include "..\cleo_sdk\CLEO.h"
 #include "..\cleo_sdk\CLEO_Utils.h"
 
 #include "simdjson.h"
 
-#include <plugin.h>
 #include <CFont.h>
 #include <CGame.h>
 #include <CMenuManager.h>
@@ -45,29 +44,30 @@
 #include <Patch.h>
 #include <RenderWare.h>
 #include <extensions/Screen.h>
-
+#include <plugin.h>
 
 // global constant paths. Initialize before anything else
 namespace FS = std::filesystem;
 
 static std::string GetGameDirectory() // already stored in Filepath_Game
 {
-    std::string path;
-    path.resize(MAX_PATH);
-    GetModuleFileNameA(NULL, path.data(), path.size()); // game exe absolute path
-    path.resize(CLEO::FilepathGetParent(path).length());
-    CLEO::FilepathNormalize(path);
-    return std::move(path);
+  std::string path;
+  path.resize(MAX_PATH);
+  GetModuleFileNameA(NULL, path.data(), path.size()); // game exe absolute path
+  path.resize(CLEO::FilepathGetParent(path).length());
+  CLEO::FilepathNormalize(path);
+  return std::move(path);
 }
 
 static std::string GetUserDirectory() // already stored in Filepath_User
 {
-    static const auto GTA_InitUserDirectories = (char* (__cdecl*)())0x00744FB0; // SA 1.0 US - CFileMgr::InitUserDirectories
+  static const auto GTA_InitUserDirectories = (char *(
+      __cdecl *)())0x00744FB0; // SA 1.0 US - CFileMgr::InitUserDirectories
 
-    std::string path = GTA_InitUserDirectories();
-    CLEO::FilepathNormalize(path);
+  std::string path = GTA_InitUserDirectories();
+  CLEO::FilepathNormalize(path);
 
-    return std::move(path);
+  return std::move(path);
 }
 
 inline const std::string Filepath_Game = GetGameDirectory();


### PR DESCRIPTION
Closes https://github.com/cleolibrary/CLEO5/issues/438

- Added CI to check clang-format-check with Clang 20 with LLVM style.
- Updated workflows.

Runned `find . -type f \( -name '*.cpp' -o -name '*.h' \) -not -path './third-party/*' -exec clang-format-20 -i --style=llvm {} +` command to automatically format all the code.
We can upgrade to Clang 21 (or 22) later after clang-format-check action gets update.

After formatting, build fails because of `stdafx`. I couldn't fixed it so help from you will be appreciated.
Maybe just reverting clang-formatization of `stdafx` will fix it but didn't touched.
Tried to fix it via AI, it fixed build after too many attempts but as you guess, it's not worked well on game.