### PR TITLE
fix use-after-free crash on game exit due to duplicate copies of scripts being deleted

### DIFF
--- a/source/CScriptEngine.cpp
+++ b/source/CScriptEngine.cpp
@@ -822,7 +822,7 @@ namespace CLEO
         else
         {
             TRACE("Unregistering custom %s named '%s'", cs->IsMission() ? "mission" : "script", cs->GetName().c_str());
-            ScriptsWaitingForDelete.push_back(cs);
+            ScriptsWaitingForDelete.insert(cs);
         }
     }
 

--- a/source/CScriptEngine.h
+++ b/source/CScriptEngine.h
@@ -18,7 +18,7 @@ namespace CLEO
 
         friend class CCustomScript;
         std::list<CCustomScript*> CustomScripts;
-        std::list<CCustomScript*> ScriptsWaitingForDelete;
+        std::set<CCustomScript*> ScriptsWaitingForDelete;
         std::set<unsigned long> InactiveScriptHashes;
         CCustomScript *CustomMission = nullptr;
         CCustomScript *LastScriptCreated = nullptr;


### PR DESCRIPTION
Fix #448 