### PR TITLE
Refactor: replaced tabs with 4 spaces

### DIFF
--- a/cleo_plugins/FileSystemOperations/FileUtils.cpp
+++ b/cleo_plugins/FileSystemOperations/FileUtils.cpp
@@ -18,34 +18,34 @@ DWORD File::FUNC_ferror = 0;
 
 void File::initialize(CLEO::eGameVersion version)
 {
-	// GV_US10, GV_US11, GV_EU10, GV_EU11, GV_STEAM
-	const DWORD MA_FOPEN_FUNCTION[] =	{ 0x008232D8, 0, 0x00823318, 0x00824098, 0x0085C75E };
-	const DWORD MA_FCLOSE_FUNCTION[] =	{ 0x0082318B, 0, 0x008231CB, 0x00823F4B, 0x0085C396 };
-	const DWORD MA_FGETC_FUNCTION[] =	{ 0x008231DC, 0, 0x0082321C, 0x00823F9C, 0x0085C680 };
-	const DWORD MA_FGETS_FUNCTION[] =	{ 0x00823798, 0, 0x008237D8, 0x00824558, 0x0085D00C };
-	const DWORD MA_FPUTS_FUNCTION[] =	{ 0x008262B8, 0, 0x008262F8, 0x00826BA8, 0x008621F1 };
-	const DWORD MA_FREAD_FUNCTION[] =	{ 0x00823521, 0, 0x00823561, 0x008242E1, 0x0085CD04 };
-	const DWORD MA_FWRITE_FUNCTION[] =	{ 0x00823674, 0, 0x008236B4, 0x00824434, 0x0085CE7E };
-	const DWORD MA_FSEEK_FUNCTION[] =	{ 0x0082374F, 0, 0x0082378F, 0x0082450F, 0x0085CF87 };
-	const DWORD MA_FPRINTF_FUNCTION[] = { 0x00823A30, 0, 0x00823A70, 0x008247F0, 0x0085D464 };
-	const DWORD MA_FTELL_FUNCTION[] =	{ 0x00826261, 0, 0x008262A1, 0x00826B51, 0x00862183 };
-	const DWORD MA_FFLUSH_FUNCTION[] =	{ 0x00823E86, 0, 0x00823EC6, 0x00824C46, 0x0085DDDD };
-	const DWORD MA_FEOF_FUNCTION[] =	{ 0x008262A2, 0, 0x008262E2, 0x00826B92, 0x0085D193 };
-	const DWORD MA_FERROR_FUNCTION[] =	{ 0x008262AD, 0, 0x008262ED, 0x00826B9D, 0x0085D1C2 };
+    // GV_US10, GV_US11, GV_EU10, GV_EU11, GV_STEAM
+    const DWORD MA_FOPEN_FUNCTION[] =   { 0x008232D8, 0, 0x00823318, 0x00824098, 0x0085C75E };
+    const DWORD MA_FCLOSE_FUNCTION[] =  { 0x0082318B, 0, 0x008231CB, 0x00823F4B, 0x0085C396 };
+    const DWORD MA_FGETC_FUNCTION[] =   { 0x008231DC, 0, 0x0082321C, 0x00823F9C, 0x0085C680 };
+    const DWORD MA_FGETS_FUNCTION[] =   { 0x00823798, 0, 0x008237D8, 0x00824558, 0x0085D00C };
+    const DWORD MA_FPUTS_FUNCTION[] =   { 0x008262B8, 0, 0x008262F8, 0x00826BA8, 0x008621F1 };
+    const DWORD MA_FREAD_FUNCTION[] =   { 0x00823521, 0, 0x00823561, 0x008242E1, 0x0085CD04 };
+    const DWORD MA_FWRITE_FUNCTION[] =  { 0x00823674, 0, 0x008236B4, 0x00824434, 0x0085CE7E };
+    const DWORD MA_FSEEK_FUNCTION[] =   { 0x0082374F, 0, 0x0082378F, 0x0082450F, 0x0085CF87 };
+    const DWORD MA_FPRINTF_FUNCTION[] = { 0x00823A30, 0, 0x00823A70, 0x008247F0, 0x0085D464 };
+    const DWORD MA_FTELL_FUNCTION[] =   { 0x00826261, 0, 0x008262A1, 0x00826B51, 0x00862183 };
+    const DWORD MA_FFLUSH_FUNCTION[] =  { 0x00823E86, 0, 0x00823EC6, 0x00824C46, 0x0085DDDD };
+    const DWORD MA_FEOF_FUNCTION[] =    { 0x008262A2, 0, 0x008262E2, 0x00826B92, 0x0085D193 };
+    const DWORD MA_FERROR_FUNCTION[] =  { 0x008262AD, 0, 0x008262ED, 0x00826B9D, 0x0085D1C2 };
 
-	FUNC_fopen = MA_FOPEN_FUNCTION[version];
-	FUNC_fclose = MA_FCLOSE_FUNCTION[version];
-	FUNC_fread = MA_FREAD_FUNCTION[version];
-	FUNC_fwrite = MA_FWRITE_FUNCTION[version];
-	FUNC_fgetc = MA_FGETC_FUNCTION[version];
-	FUNC_fgets = MA_FGETS_FUNCTION[version];
-	FUNC_fputs = MA_FPUTS_FUNCTION[version];
-	FUNC_fseek = MA_FSEEK_FUNCTION[version];
-	FUNC_fprintf = MA_FPRINTF_FUNCTION[version];
-	FUNC_ftell = MA_FTELL_FUNCTION[version];
-	FUNC_fflush = MA_FFLUSH_FUNCTION[version];
-	FUNC_feof = MA_FEOF_FUNCTION[version];
-	FUNC_ferror = MA_FERROR_FUNCTION[version];;
+    FUNC_fopen = MA_FOPEN_FUNCTION[version];
+    FUNC_fclose = MA_FCLOSE_FUNCTION[version];
+    FUNC_fread = MA_FREAD_FUNCTION[version];
+    FUNC_fwrite = MA_FWRITE_FUNCTION[version];
+    FUNC_fgetc = MA_FGETC_FUNCTION[version];
+    FUNC_fgets = MA_FGETS_FUNCTION[version];
+    FUNC_fputs = MA_FPUTS_FUNCTION[version];
+    FUNC_fseek = MA_FSEEK_FUNCTION[version];
+    FUNC_fprintf = MA_FPRINTF_FUNCTION[version];
+    FUNC_ftell = MA_FTELL_FUNCTION[version];
+    FUNC_fflush = MA_FFLUSH_FUNCTION[version];
+    FUNC_feof = MA_FEOF_FUNCTION[version];
+    FUNC_ferror = MA_FERROR_FUNCTION[version];;
 }
 
 bool File::isLegacy(DWORD handle) { return (handle & 0x1) == 0; }
@@ -54,429 +54,429 @@ FILE* File::handleToFile(DWORD handle) { return (FILE*)(handle & ~0x1); }
 
 DWORD File::fileToHandle(FILE* file, bool legacy)
 {
-	if (file == nullptr) return 0;
+    if (file == nullptr) return 0;
 
-	auto handle = (DWORD)file;
-	if (!legacy) handle |= 0x1;
-	return handle;
+    auto handle = (DWORD)file;
+    if (!legacy) handle |= 0x1;
+    return handle;
 }
 
 void File::updateState(DWORD handle)
 {
-	// RW streams needs synchronization of read and write positions (https://en.wikibooks.org/wiki/C_Programming/stdio.h/fopen)
-	if (isOk(handle) && !isEndOfFile(handle))
-	{
-		seek(handle, 0, SEEK_CUR);
-	}
+    // RW streams needs synchronization of read and write positions (https://en.wikibooks.org/wiki/C_Programming/stdio.h/fopen)
+    if (isOk(handle) && !isEndOfFile(handle))
+    {
+        seek(handle, 0, SEEK_CUR);
+    }
 }
 
 bool File::flush(DWORD handle)
 {
-	FILE* file = handleToFile(handle);
-	if (file == nullptr) return false;
+    FILE* file = handleToFile(handle);
+    if (file == nullptr) return false;
 
-	int result = 0;
-	if (isLegacy(handle))
-	{
-		_asm
-		{
-			push file
-			call FUNC_fflush
-			add esp, 0x4
-			mov result, eax
-		}
-	}
-	else
-		result = fflush(file);
+    int result = 0;
+    if (isLegacy(handle))
+    {
+        _asm
+        {
+            push file
+            call FUNC_fflush
+            add esp, 0x4
+            mov result, eax
+        }
+    }
+    else
+        result = fflush(file);
 
-	return result == 0;
+    return result == 0;
 }
 
 DWORD File::open(const char* filename, const char* mode, bool legacy)
 {
-	// validate the mode argument
-	if (!legacy)
-	{
-		static char modeUpdated[12];
-		const std::string allowed = "+abcnrtwxDRST"; // https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/fopen-wfopen?view=msvc-170
+    // validate the mode argument
+    if (!legacy)
+    {
+        static char modeUpdated[12];
+        const std::string allowed = "+abcnrtwxDRST"; // https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/fopen-wfopen?view=msvc-170
 
-		bool valid = false;
-		bool binary = false;
-		bool text = false;
-		auto modeLen = mode != nullptr ? strlen(mode) : 0;
-		if (modeLen > 0 && modeLen < (sizeof(modeUpdated) - 1)) // keep space for extra binary mode char
-		{
-			valid = true;
+        bool valid = false;
+        bool binary = false;
+        bool text = false;
+        auto modeLen = mode != nullptr ? strlen(mode) : 0;
+        if (modeLen > 0 && modeLen < (sizeof(modeUpdated) - 1)) // keep space for extra binary mode char
+        {
+            valid = true;
 
-			for (auto ch : std::string_view(mode))
-			{
-				if (allowed.find(ch) == std::string_view::npos)
-				{
-					valid = false;
-					break; // invalid character
-				}
+            for (auto ch : std::string_view(mode))
+            {
+                if (allowed.find(ch) == std::string_view::npos)
+                {
+                    valid = false;
+                    break; // invalid character
+                }
 
-				if (ch == 'b') binary = true;
-				if (ch == 't') text = true;
-			}
+                if (ch == 'b') binary = true;
+                if (ch == 't') text = true;
+            }
 
-			if (binary && text) valid = false;
+            if (binary && text) valid = false;
 
-			// By default open as binary mode.
-			// Generally text mode is not well documented in C and many file related functions has undefined behavior. For example 'ftell' returns invalid values.
-			if (valid && (!binary && !text))
-			{
-				strcpy_s(modeUpdated, mode);
-				strcat_s(modeUpdated, "b");
-				mode = modeUpdated;
-			}
-		}
+            // By default open as binary mode.
+            // Generally text mode is not well documented in C and many file related functions has undefined behavior. For example 'ftell' returns invalid values.
+            if (valid && (!binary && !text))
+            {
+                strcpy_s(modeUpdated, mode);
+                strcat_s(modeUpdated, "b");
+                mode = modeUpdated;
+            }
+        }
 
-		if (!valid)
-		{
-			LOG_WARNING(0, "Invalid mode argument '%s' while opening file \"%s\" stream!", mode, filename);
-			return 0; // invalid handle
-		}
-	}
+        if (!valid)
+        {
+            LOG_WARNING(0, "Invalid mode argument '%s' while opening file \"%s\" stream!", mode, filename);
+            return 0; // invalid handle
+        }
+    }
 
-	FILE* file = nullptr;
-	if (legacy)
-	{
-		_asm
-		{
-			push mode
-			push filename
-			call FUNC_fopen
-			add esp, 8
-			mov file, eax
-		}
-	}
-	else
-		fopen_s(&file, filename, mode);
+    FILE* file = nullptr;
+    if (legacy)
+    {
+        _asm
+        {
+            push mode
+            push filename
+            call FUNC_fopen
+            add esp, 8
+            mov file, eax
+        }
+    }
+    else
+        fopen_s(&file, filename, mode);
 
-	return fileToHandle(file, legacy);
+    return fileToHandle(file, legacy);
 }
 
 void File::close(DWORD handle)
 {
-	FILE* file = handleToFile(handle);
-	if (file == nullptr) return;
+    FILE* file = handleToFile(handle);
+    if (file == nullptr) return;
 
-	if (isLegacy(handle))
-	{
-		_asm
-		{
-			push file
-			call FUNC_fclose
-			add esp, 4
-		}
-	}
-	else
-		fclose(file);
+    if (isLegacy(handle))
+    {
+        _asm
+        {
+            push file
+            call FUNC_fclose
+            add esp, 4
+        }
+    }
+    else
+        fclose(file);
 }
 
 bool File::isOk(DWORD handle)
 {
-	FILE* file = handleToFile(handle);
-	if (file == nullptr) return false;
+    FILE* file = handleToFile(handle);
+    if (file == nullptr) return false;
 
-	int result = 0;
-	if (isLegacy(handle))
-	{
-		_asm
-		{
-			push file
-			call FUNC_ferror
-			add esp, 0x4
-		}
-	}
-	else
-		result = ferror(file);
+    int result = 0;
+    if (isLegacy(handle))
+    {
+        _asm
+        {
+            push file
+            call FUNC_ferror
+            add esp, 0x4
+        }
+    }
+    else
+        result = ferror(file);
 
-	return result == 0;
+    return result == 0;
 }
 
 DWORD File::getSize(DWORD handle)
 {
-	auto pos = getPos(handle);
-	seek(handle, 0, SEEK_END);
-	DWORD size = getPos(handle);
-	seek(handle, pos, SEEK_SET);
-	return size;
+    auto pos = getPos(handle);
+    seek(handle, 0, SEEK_END);
+    DWORD size = getPos(handle);
+    seek(handle, pos, SEEK_SET);
+    return size;
 }
 
 bool File::seek(DWORD handle, int offset, DWORD orign)
 {
-	FILE* file = handleToFile(handle);
-	if (file == nullptr) return false;
+    FILE* file = handleToFile(handle);
+    if (file == nullptr) return false;
 
-	int result = 0;
-	if (isLegacy(handle))
-	{
-		auto off = offset; // 'offset' is keyword in asm
-		_asm
-		{
-			push orign
-			push off
-			push file
-			call FUNC_fseek
-			add esp, 0xC
-			mov result, eax
-		}
-	}
-	else
-		result = fseek(file, offset, orign);
+    int result = 0;
+    if (isLegacy(handle))
+    {
+        auto off = offset; // 'offset' is keyword in asm
+        _asm
+        {
+            push orign
+            push off
+            push file
+            call FUNC_fseek
+            add esp, 0xC
+            mov result, eax
+        }
+    }
+    else
+        result = fseek(file, offset, orign);
 
-	return result == 0;
+    return result == 0;
 }
 
 DWORD File::getPos(DWORD handle)
 {
-	FILE* file = handleToFile(handle);
-	if (file == nullptr) return 0;
+    FILE* file = handleToFile(handle);
+    if (file == nullptr) return 0;
 
-	DWORD pos = 0;
-	if (isLegacy(handle))
-	{
-		_asm
-		{
-			push file
-			call FUNC_ftell
-			add esp, 0x4
-			mov pos, eax
-		}
-	}
-	else
-		pos = (DWORD)ftell(file);
+    DWORD pos = 0;
+    if (isLegacy(handle))
+    {
+        _asm
+        {
+            push file
+            call FUNC_ftell
+            add esp, 0x4
+            mov pos, eax
+        }
+    }
+    else
+        pos = (DWORD)ftell(file);
 
-	return pos;
+    return pos;
 }
 
 bool File::isEndOfFile(DWORD handle)
 {
-	FILE* file = handleToFile(handle);
-	if (file == nullptr) return true;
+    FILE* file = handleToFile(handle);
+    if (file == nullptr) return true;
 
-	int result = 0;
-	if (isLegacy(handle))
-	{
-		_asm
-		{
-			push file
-			call FUNC_feof
-			add esp, 0x4
-			mov result, eax
-		}
-	}
-	else
-		result = feof(file);
+    int result = 0;
+    if (isLegacy(handle))
+    {
+        _asm
+        {
+            push file
+            call FUNC_feof
+            add esp, 0x4
+            mov result, eax
+        }
+    }
+    else
+        result = feof(file);
 
-	return result != 0;
+    return result != 0;
 }
 
 DWORD File::read(DWORD handle, void* buffer, DWORD size)
 {
-	FILE* file = handleToFile(handle);
-	if (file == nullptr) return 0;
+    FILE* file = handleToFile(handle);
+    if (file == nullptr) return 0;
 
-	DWORD read = 0;
-	if (isLegacy(handle))
-	{
-		auto siz = size; // 'size' is keyword in asm
-		_asm
-		{
-			push file
-			push siz
-			push 1
-			push buffer
-			call FUNC_fread
-			add esp, 0x10
-			mov read, eax
-		}
-	}
-	else
-		read = fread(buffer, 1, size, file);
+    DWORD read = 0;
+    if (isLegacy(handle))
+    {
+        auto siz = size; // 'size' is keyword in asm
+        _asm
+        {
+            push file
+            push siz
+            push 1
+            push buffer
+            call FUNC_fread
+            add esp, 0x10
+            mov read, eax
+        }
+    }
+    else
+        read = fread(buffer, 1, size, file);
 
-	updateState(handle);
+    updateState(handle);
 
-	return read;
+    return read;
 }
 
 char File::readChar(DWORD handle)
 {
-	FILE* file = handleToFile(handle);
-	if (file == nullptr) return 0;
+    FILE* file = handleToFile(handle);
+    if (file == nullptr) return 0;
 
-	char result = '_';
-	if (isLegacy(handle))
-	{
-		_asm
-		{
-			push file
-			call FUNC_fgetc
-			add esp, 0x4
-			mov result, al
-		}
-	}
-	else
-		result = fgetc(file);
+    char result = '_';
+    if (isLegacy(handle))
+    {
+        _asm
+        {
+            push file
+            call FUNC_fgetc
+            add esp, 0x4
+            mov result, al
+        }
+    }
+    else
+        result = fgetc(file);
 
-	updateState(handle);
+    updateState(handle);
 
-	return result;
+    return result;
 }
 
 char* File::readString(DWORD handle, char* buffer, DWORD bufferSize)
 {
-	FILE* file = handleToFile(handle);
-	if (file == nullptr) return nullptr;
+    FILE* file = handleToFile(handle);
+    if (file == nullptr) return nullptr;
 
-	char* result = nullptr;
-	if (isLegacy(handle))
-	{
-		_asm
-		{
-			push file
-			push bufferSize
-			push buffer
-			call FUNC_fgets
-			add esp, 0xC
-			mov result, eax
-		}
-	}
-	else
-		result = fgets(buffer, bufferSize, file);
+    char* result = nullptr;
+    if (isLegacy(handle))
+    {
+        _asm
+        {
+            push file
+            push bufferSize
+            push buffer
+            call FUNC_fgets
+            add esp, 0xC
+            mov result, eax
+        }
+    }
+    else
+        result = fgets(buffer, bufferSize, file);
 
-	updateState(handle);
+    updateState(handle);
 
-	return result;
+    return result;
 }
 
 DWORD File::write(DWORD handle, const void* buffer, DWORD size)
 {
-	FILE* file = handleToFile(handle);
-	if (file == nullptr) return 0;
+    FILE* file = handleToFile(handle);
+    if (file == nullptr) return 0;
 
-	DWORD writen = 0;
-	if (isLegacy(handle))
-	{
-		auto siz = size; // 'size' is keyword in asm
-		_asm
-		{
-			push file
-			push siz
-			push 1
-			push buffer
-			call FUNC_fwrite
-			add esp, 0x10
-			mov writen, eax
-		}
-	}
-	else
-		writen = (DWORD)fwrite(buffer, 1, size, file);
+    DWORD writen = 0;
+    if (isLegacy(handle))
+    {
+        auto siz = size; // 'size' is keyword in asm
+        _asm
+        {
+            push file
+            push siz
+            push 1
+            push buffer
+            call FUNC_fwrite
+            add esp, 0x10
+            mov writen, eax
+        }
+    }
+    else
+        writen = (DWORD)fwrite(buffer, 1, size, file);
 
-	updateState(handle);
+    updateState(handle);
 
-	return writen;
+    return writen;
 }
 
 bool File::writeString(DWORD handle, const char* text)
 {
-	FILE* file = handleToFile(handle);
-	if (file == nullptr) return 0;
+    FILE* file = handleToFile(handle);
+    if (file == nullptr) return 0;
 
-	int result = 0;
-	if (isLegacy(handle))
-	{
-		_asm
-		{
-			push file
-			push text
-			call FUNC_fputs
-			add esp, 0x8
-			mov result, eax
-		}
-	}
-	else
-		result = (DWORD)fputs(text, file);
+    int result = 0;
+    if (isLegacy(handle))
+    {
+        _asm
+        {
+            push file
+            push text
+            call FUNC_fputs
+            add esp, 0x8
+            mov result, eax
+        }
+    }
+    else
+        result = (DWORD)fputs(text, file);
 
-	updateState(handle);
+    updateState(handle);
 
-	return result >= 0;
+    return result >= 0;
 }
 
 DWORD File::scan(DWORD handle, const char* format, void** outputParams)
 {
-	FILE* file = handleToFile(handle);
-	if (file == nullptr) return 0;
+    FILE* file = handleToFile(handle);
+    if (file == nullptr) return 0;
 
-	int read = 0;
-	if (isLegacy(handle))
-	{
-		// fscanf for game file streams not existent in game's code. Emulate it
+    int read = 0;
+    if (isLegacy(handle))
+    {
+        // fscanf for game file streams not existent in game's code. Emulate it
 
-		size_t paramCount = 0;
-		const char* f = format;
-		while(*f != '\0')
-		{
-			if (*f == '%')
-			{
-				if (*(f + 1) != '%') // not escaped %
-					paramCount++;
-				else
-					f++; // skip escaped
-			}
-			f++;
-		}
+        size_t paramCount = 0;
+        const char* f = format;
+        while(*f != '\0')
+        {
+            if (*f == '%')
+            {
+                if (*(f + 1) != '%') // not escaped %
+                    paramCount++;
+                else
+                    f++; // skip escaped
+            }
+            f++;
+        }
 
-		auto newFormat = std::string(format) + "%n"; // %n returns characters processed by
-		DWORD charRead = 0;
-		outputParams[paramCount] = &charRead;
+        auto newFormat = std::string(format) + "%n"; // %n returns characters processed by
+        DWORD charRead = 0;
+        outputParams[paramCount] = &charRead;
 
-		DWORD prevCharRead = 0;
-		std::string readText;
-		while(true)
-		{
-			readText += readChar(handle);
+        DWORD prevCharRead = 0;
+        std::string readText;
+        while(true)
+        {
+            readText += readChar(handle);
 
-			prevCharRead = charRead;
-			auto p = outputParams;
-			#pragma warning(suppress: 4996) // sscanf_s would expect additional arg after each %s arg
-			read = sscanf(readText.c_str(), newFormat.c_str(),
-				p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8], p[9], // 10
-				p[10], p[11], p[12], p[13], p[14], p[15], p[16], p[17], p[18], p[19], // 20
-				p[20], p[21], p[22], p[23], p[24], p[25], p[26], p[27], p[28], p[29], // 30
-				p[30], p[31], p[32], p[33], p[34]); // 35
+            prevCharRead = charRead;
+            auto p = outputParams;
+            #pragma warning(suppress: 4996) // sscanf_s would expect additional arg after each %s arg
+            read = sscanf(readText.c_str(), newFormat.c_str(),
+                p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8], p[9], // 10
+                p[10], p[11], p[12], p[13], p[14], p[15], p[16], p[17], p[18], p[19], // 20
+                p[20], p[21], p[22], p[23], p[24], p[25], p[26], p[27], p[28], p[29], // 30
+                p[30], p[31], p[32], p[33], p[34]); // 35
 
-			if (!isOk(handle)) break;
+            if (!isOk(handle)) break;
 
-			if (read == paramCount)
-			{
-				if (charRead == prevCharRead) // all params collected and scan doesn't consume input text anymore
-				{
-					seek(handle, -1, SEEK_CUR); // return the character not used by scan
-					break;
-				}
+            if (read == paramCount)
+            {
+                if (charRead == prevCharRead) // all params collected and scan doesn't consume input text anymore
+                {
+                    seek(handle, -1, SEEK_CUR); // return the character not used by scan
+                    break;
+                }
 
-				if (isEndOfFile(handle))
-				{
-					break;
-				}
-			}
-		}
-	}
-	else
-	{
-		auto p = outputParams;
-		#pragma warning(suppress: 4996) // fscanf_s would expect additional arg after each %s arg
-		read = 	fscanf(file, format, 
-			p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8], p[9], // 10
-			p[10], p[11], p[12], p[13], p[14], p[15], p[16], p[17], p[18], p[19], // 20
-			p[20], p[21], p[22], p[23], p[24], p[25], p[26], p[27], p[28], p[29], // 30
-			p[30], p[31], p[32], p[33], p[34]); // 35
-	}
+                if (isEndOfFile(handle))
+                {
+                    break;
+                }
+            }
+        }
+    }
+    else
+    {
+        auto p = outputParams;
+        #pragma warning(suppress: 4996) // fscanf_s would expect additional arg after each %s arg
+        read =     fscanf(file, format, 
+            p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8], p[9], // 10
+            p[10], p[11], p[12], p[13], p[14], p[15], p[16], p[17], p[18], p[19], // 20
+            p[20], p[21], p[22], p[23], p[24], p[25], p[26], p[27], p[28], p[29], // 30
+            p[30], p[31], p[32], p[33], p[34]); // 35
+    }
 
-	updateState(handle);
+    updateState(handle);
 
-	return read;
+    return read;
 }

--- a/cleo_plugins/FileSystemOperations/FileUtils.h
+++ b/cleo_plugins/FileSystemOperations/FileUtils.h
@@ -6,45 +6,45 @@
 class File
 {
 public:
-	static void initialize(CLEO::eGameVersion version);
+    static void initialize(CLEO::eGameVersion version);
 
-	static DWORD open(const char* filename, const char* mode, bool legacy);
-	static void close(DWORD handle);
+    static DWORD open(const char* filename, const char* mode, bool legacy);
+    static void close(DWORD handle);
 
-	static bool isOk(DWORD handle);
+    static bool isOk(DWORD handle);
 
-	static DWORD getSize(DWORD handle);
-	static bool seek(DWORD handle, int offset, DWORD orign);
-	static DWORD getPos(DWORD handle);
-	static bool isEndOfFile(DWORD handle);
+    static DWORD getSize(DWORD handle);
+    static bool seek(DWORD handle, int offset, DWORD orign);
+    static DWORD getPos(DWORD handle);
+    static bool isEndOfFile(DWORD handle);
 
-	static DWORD read(DWORD handle, void* buffer, DWORD size);
-	static char readChar(DWORD handle);
-	static char* readString(DWORD handle, char* buffer, DWORD bufferSize);
+    static DWORD read(DWORD handle, void* buffer, DWORD size);
+    static char readChar(DWORD handle);
+    static char* readString(DWORD handle, char* buffer, DWORD bufferSize);
 
-	static DWORD write(DWORD handle, const void* buffer, DWORD size);
-	static bool writeString(DWORD handle, const char* text);
-	static DWORD scan(DWORD handle, const char* format, void** outputParams);
-	static bool flush(DWORD handle);
+    static DWORD write(DWORD handle, const void* buffer, DWORD size);
+    static bool writeString(DWORD handle, const char* text);
+    static DWORD scan(DWORD handle, const char* format, void** outputParams);
+    static bool flush(DWORD handle);
 
-	static bool isLegacy(DWORD handle); // Legacy modes for CLEO 3
-	static FILE* handleToFile(DWORD handle);
-	
+    static bool isLegacy(DWORD handle); // Legacy modes for CLEO 3
+    static FILE* handleToFile(DWORD handle);
+    
 private:
-	static DWORD FUNC_fopen;
-	static DWORD FUNC_fclose;
-	static DWORD FUNC_fread;
-	static DWORD FUNC_fwrite;
-	static DWORD FUNC_fgetc;
-	static DWORD FUNC_fgets;
-	static DWORD FUNC_fputs;
-	static DWORD FUNC_fseek;
-	static DWORD FUNC_fprintf;
-	static DWORD FUNC_ftell;
-	static DWORD FUNC_fflush;
-	static DWORD FUNC_feof;
-	static DWORD FUNC_ferror;
+    static DWORD FUNC_fopen;
+    static DWORD FUNC_fclose;
+    static DWORD FUNC_fread;
+    static DWORD FUNC_fwrite;
+    static DWORD FUNC_fgetc;
+    static DWORD FUNC_fgets;
+    static DWORD FUNC_fputs;
+    static DWORD FUNC_fseek;
+    static DWORD FUNC_fprintf;
+    static DWORD FUNC_ftell;
+    static DWORD FUNC_fflush;
+    static DWORD FUNC_feof;
+    static DWORD FUNC_ferror;
 
-	static DWORD fileToHandle(FILE* file, bool legacy);
-	static void updateState(DWORD handle);
+    static DWORD fileToHandle(FILE* file, bool legacy);
+    static void updateState(DWORD handle);
 };

--- a/cleo_plugins/GameEntities/GameEntities.cpp
+++ b/cleo_plugins/GameEntities/GameEntities.cpp
@@ -15,425 +15,425 @@ using namespace std;
 class GameEntities
 {
 public:
-	std::map<CRunningScript*, int> charSearchState; // for get_random_char_in_sphere_no_save_recursive
-	std::map<CRunningScript*, int> carSearchState; // for get_random_car_in_sphere_no_save_recursive
-	std::map<CRunningScript*, int> objectSearchState; // for get_random_object_in_sphere_no_save_recursive
-
-	GameEntities()
-	{
-		if (!PluginCheckCleoVersion()) return;
-
-		// register opcodes
-		CLEO_RegisterOpcode(0x0AB5, opcode_0AB5); // store_closest_entities
-		CLEO_RegisterOpcode(0x0AB6, opcode_0AB6); // get_target_blip_coords
-		CLEO_RegisterOpcode(0x0AB7, opcode_0AB7); // get_car_number_of_gears
-		CLEO_RegisterOpcode(0x0AB8, opcode_0AB8); // get_car_current_gear
-		CLEO_RegisterOpcode(0x0ABD, opcode_0ABD); // is_car_siren_on
-		CLEO_RegisterOpcode(0x0ABE, opcode_0ABE); // is_car_engine_on
-		CLEO_RegisterOpcode(0x0ABF, opcode_0ABF); // cleo_set_car_engine_on
-		CLEO_RegisterOpcode(0x0AD2, opcode_0AD2); // get_char_player_is_targeting
-		CLEO_RegisterOpcode(0x0ADD, opcode_0ADD); // spawn_vehicle_by_cheating
-		CLEO_RegisterOpcode(0x0AE1, opcode_0AE1); // get_random_char_in_sphere_no_save_recursive
-		CLEO_RegisterOpcode(0x0AE2, opcode_0AE2); // get_random_car_in_sphere_no_save_recursive
-		CLEO_RegisterOpcode(0x0AE3, opcode_0AE3); // get_random_object_in_sphere_no_save_recursive
-
-		// register event callbacks
-		CLEO_RegisterCallback(eCallbackId::ScriptsFinalize, OnScriptsFinalize);
-	}
-
-	~GameEntities()
-	{
-		CLEO_UnregisterCallback(eCallbackId::ScriptsFinalize, OnScriptsFinalize);
-	}
-
-	static void __stdcall OnScriptsFinalize()
-	{
-		Instance.charSearchState.clear();
-		Instance.carSearchState.clear();
-		Instance.objectSearchState.clear();
-	}
-
-	// store_closest_entities
-	// [var carHandle: Car], [var charHandle: Char] = store_closest_entities [Char]
-	static OpcodeResult __stdcall opcode_0AB5(CRunningScript* thread)
-	{
-		auto pedHandle = OPCODE_READ_PARAM_PED_HANDLE();
-
-		auto ped = CPools::GetPed(pedHandle);
-		if (ped == nullptr || ped->m_pIntelligence == nullptr)
-		{
-			OPCODE_WRITE_PARAM_INT(-1);
-			OPCODE_WRITE_PARAM_INT(-1);
-			return OR_CONTINUE;
-		}
-
-		DWORD foundCar = -1;
-		const auto& cars = ped->m_pIntelligence->m_vehicleScanner.m_apEntities;
-		for (size_t i = 0; i < std::size(cars); i++)
-		{
-			auto car = (CVehicle*)cars[i];
-			if (car != nullptr &&
-				car->m_nCreatedBy != eVehicleCreatedBy::MISSION_VEHICLE &&
-				!car->bFadeOut)
-			{
-				foundCar = CPools::GetVehicleRef(car); // get handle
-				break;
-			}
-		}
-
-		DWORD foundPed = -1;
-		const auto& peds = ped->m_pIntelligence->m_pedScanner.m_apEntities;
-		for (size_t i = 0; i < std::size(peds); i++)
-		{
-			auto ped = (CPed*)peds[i];
-			if (ped != nullptr &&
-				ped->m_nCreatedBy == 1 && // random pedestrian
-				!ped->bFadeOut)
-			{
-				foundPed = CPools::GetPedRef(ped); // get handle
-				break;
-			}
-		}
-
-		OPCODE_WRITE_PARAM_INT(foundCar);
-		OPCODE_WRITE_PARAM_INT(foundPed);
-		return OR_CONTINUE;
-	}
-
-	// get_target_blip_coords
-	// [var x: float], [var y: float], [var z: float] = get_target_blip_coords (logical)
-	static OpcodeResult __stdcall opcode_0AB6(CRunningScript* thread)
-	{
-		auto blipIdx = CRadar::GetActualBlipArrayIndex(FrontEndMenuManager.m_nTargetBlipIndex);
-		if (blipIdx == -1)
-		{
-			OPCODE_SKIP_PARAMS(3); // x, y, z
-			OPCODE_CONDITION_RESULT(false); // no target marker placed
-			return OR_CONTINUE;
-		}
-
-		CVector pos = CRadar::ms_RadarTrace[blipIdx].m_vecPos; // TODO: support for Fastman92's Limit Adjuster
-
-		// TODO: load world collisions for the coords
-		pos.z = CWorld::FindGroundZForCoord(pos.x, pos.y);
-
-		OPCODE_WRITE_PARAM_FLOAT(pos.x);
-		OPCODE_WRITE_PARAM_FLOAT(pos.y);
-		OPCODE_WRITE_PARAM_FLOAT(pos.z);
-		OPCODE_CONDITION_RESULT(true);
-		return OR_CONTINUE;
-	}
-
-	// get_car_number_of_gears
-	// [var numGear: int] = get_car_number_of_gears [Car]
-	static OpcodeResult __stdcall opcode_0AB7(CRunningScript* thread)
-	{
-		auto handle = OPCODE_READ_PARAM_VEHICLE_HANDLE();
-
-		auto vehicle = CPools::GetVehicle(handle);
-		auto gears = vehicle->m_pHandlingData->m_transmissionData.m_nNumberOfGears;
-
-		OPCODE_WRITE_PARAM_INT(gears);
-		return OR_CONTINUE;
-	}
-
-	// get_car_current_gear
-	// [var gear: int] = get_car_current_gear [Car]
-	static OpcodeResult __stdcall opcode_0AB8(CRunningScript* thread)
-	{
-		auto handle = OPCODE_READ_PARAM_VEHICLE_HANDLE();
-
-		auto vehicle = CPools::GetVehicle(handle);
-		auto gear = vehicle->m_nCurrentGear;
-
-		OPCODE_WRITE_PARAM_INT(gear);
-		return OR_CONTINUE;
-	}
-
-	// is_car_siren_on
-	// is_car_siren_on [Car] (logical)
-	static OpcodeResult __stdcall opcode_0ABD(CRunningScript* thread)
-	{
-		auto handle = OPCODE_READ_PARAM_VEHICLE_HANDLE();
-
-		auto vehicle = CPools::GetVehicle(handle);
-		auto state = vehicle->bSirenOrAlarm;
-
-		OPCODE_CONDITION_RESULT(state);
-		return OR_CONTINUE;
-	}
-
-	// is_car_engine_on
-	// is_car_engine_on [Car] (logical)
-	static OpcodeResult __stdcall opcode_0ABE(CRunningScript* thread)
-	{
-		auto handle = OPCODE_READ_PARAM_VEHICLE_HANDLE();
-
-		auto vehicle = CPools::GetVehicle(handle);
-		auto state = vehicle->bEngineOn;
-
-		OPCODE_CONDITION_RESULT(state);
-		return OR_CONTINUE;
-	}
-
-	// cleo_set_car_engine_on
-	// cleo_set_car_engine_on [Car] {state} [bool]
-	static OpcodeResult __stdcall opcode_0ABF(CRunningScript* thread)
-	{
-		auto handle = OPCODE_READ_PARAM_VEHICLE_HANDLE();
-		auto state = OPCODE_READ_PARAM_BOOL();
-
-		auto vehicle = CPools::GetVehicle(handle);
-
-		vehicle->bEngineOn = (state != false);
-		return OR_CONTINUE;
-	}
-
-	// get_char_player_is_targeting
-	// [var handle: Char] = get_char_player_is_targeting [Player] (logical)
-	static OpcodeResult __stdcall opcode_0AD2(CRunningScript* thread)
-	{
-		auto playerId = OPCODE_READ_PARAM_PLAYER_ID();
-
-		auto ped = FindPlayerPed(playerId);
-
-		auto target = ped->m_pPlayerTargettedPed;
-		if (target == nullptr) target = (CPed*)ped->m_pTargetedObject;
-		
-		if (target == nullptr || target->m_nType != ENTITY_TYPE_PED)
-		{
-			OPCODE_WRITE_PARAM_INT(-1);
-			OPCODE_CONDITION_RESULT(false);
-			return OR_CONTINUE;
-		}
-
-		auto handle = CPools::GetPedRef(target);
-
-		OPCODE_WRITE_PARAM_INT(handle);
-		OPCODE_CONDITION_RESULT(true);
-		return OR_CONTINUE;
-	}
-
-	// spawn_vehicle_by_cheating
-	// spawn_vehicle_by_cheating {modelId} [model_vehicle]
-	static OpcodeResult __stdcall opcode_0ADD(CRunningScript* thread)
-	{
-		auto modelIndex = OPCODE_READ_PARAM_INT();
-
-		auto model = CModelInfo::GetModelInfo(modelIndex);
-		if (model == nullptr || model->GetModelType() != MODEL_INFO_VEHICLE)
-		{
-			return OR_CONTINUE; // modelIndex is not vehicle
-		}
-
-		auto veh = (CVehicleModelInfo*)model;
-		switch (veh->m_nVehicleType)
-		{
-			case VEHICLE_AUTOMOBILE:
-			case VEHICLE_MTRUCK:
-			case VEHICLE_QUAD:
-			case VEHICLE_HELI:
-			case VEHICLE_PLANE:
-			case VEHICLE_BOAT:
-			//case VEHICLE_TRAIN:
-			//case VEHICLE_FHELI:
-			//case VEHICLE_FPLANE:
-			case VEHICLE_BIKE:
-			case VEHICLE_BMX:
-			case VEHICLE_TRAILER:
-				break;
-
-			default:
-				return OR_CONTINUE; // unsupported vehicle type
-		}
-
-		CCheat::VehicleCheat(modelIndex);
-
-		return OR_CONTINUE;
-	}
-
-	// get_random_char_in_sphere_no_save_recursive
-	// [var handle: Char] = get_random_char_in_sphere_no_save_recursive {x} [float] {y} [float] {z} [float] {radius} [float] {findNext} [bool] {filter} [int] (logical)
-	static OpcodeResult __stdcall opcode_0AE1(CRunningScript* thread)
-	{
-		CVector center = {};
-		center.x = OPCODE_READ_PARAM_FLOAT();
-		center.y = OPCODE_READ_PARAM_FLOAT();
-		center.z = OPCODE_READ_PARAM_FLOAT();
-		auto radius = OPCODE_READ_PARAM_FLOAT();
-		auto findNext = OPCODE_READ_PARAM_BOOL();
-		auto filter = OPCODE_READ_PARAM_INT();
-
-		bool skipDead = (filter == 1);
-		bool skipPlayer = (filter != -1);
-
-		int& searchIdx = Instance.charSearchState[thread];
-		if (!findNext) searchIdx = 0;
-
-		CPed* found = nullptr;
-		for (int index = searchIdx; index < CPools::ms_pPedPool->m_nSize; index++)
-		{
-			auto ped = CPools::ms_pPedPool->GetAt(index);
-
-			if (ped == nullptr || ped->bFadeOut)
-			{
-				continue; // invalid or about to be deleted
-			}
-
-			if (skipPlayer && ped->IsPlayer())
-			{
-				continue; // player
-			}
-
-			if (skipDead)
-			{
-				if (ped->m_ePedState == PEDSTATE_DIE || ped->m_ePedState == PEDSTATE_DEAD)
-				{
-					continue; // dead
-				}
-			}
-
-			if (radius < 1000.0f)
-			{
-				if((ped->GetPosition() - center).Magnitude() > radius)
-				{
-					continue; // out of search radius
-				}
-			}
-
-			found = ped;
-			searchIdx = index + 1; // next search start index
-			break;
-		}
-
-		DWORD handle;
-		if (found != nullptr)
-		{
-			handle = CPools::ms_pPedPool->GetRef(found);
-		}
-		else
-		{
-			handle = -1;
-			searchIdx = 0;
-		}
-
-		OPCODE_WRITE_PARAM_INT(handle);
-		OPCODE_CONDITION_RESULT(handle != -1);
-		return OR_CONTINUE;
-	}
-
-	// get_random_car_in_sphere_no_save_recursive
-	// [var handle: Car] = get_random_car_in_sphere_no_save_recursive {x} [float] {y} [float] {z} [float] {radius} [float] {findNext} [bool] {skipWrecked} [bool] (logical)
-	static OpcodeResult __stdcall opcode_0AE2(CRunningScript* thread)
-	{
-		CVector center = {};
-		center.x = OPCODE_READ_PARAM_FLOAT();
-		center.y = OPCODE_READ_PARAM_FLOAT();
-		center.z = OPCODE_READ_PARAM_FLOAT();
-		auto radius = OPCODE_READ_PARAM_FLOAT();
-		auto findNext = OPCODE_READ_PARAM_BOOL();
-		auto skipWrecked = OPCODE_READ_PARAM_BOOL();
-
-		int& searchIdx = Instance.carSearchState[thread];
-		if (!findNext) searchIdx = 0;
-
-		CVehicle* found = nullptr;
-		for (int index = searchIdx; index < CPools::ms_pVehiclePool->m_nSize; index++)
-		{
-			auto car = CPools::ms_pVehiclePool->GetAt(index);
-
-			if (car == nullptr || car->bFadeOut)
-			{
-				continue; // invalid or about to be deleted
-			}
-
-			if (skipWrecked)
-			{
-				if (car->m_nStatus == STATUS_WRECKED || car->bIsDrowning)
-				{
-					continue; // wrecked
-				}
-			}
-
-			if (radius < 1000.0f)
-			{
-				if ((car->GetPosition() - center).Magnitude() > radius)
-				{
-					continue; // out of search radius
-				}
-			}
-
-			found = car;
-			searchIdx = index + 1; // next search start index
-			break;
-		}
-
-		DWORD handle;
-		if (found != nullptr)
-		{
-			handle = CPools::ms_pVehiclePool->GetRef(found);
-		}
-		else
-		{
-			handle = -1;
-			searchIdx = 0;
-		}
-
-		OPCODE_WRITE_PARAM_INT(handle);
-		OPCODE_CONDITION_RESULT(handle != -1);
-		return OR_CONTINUE;
-	}
-
-	// get_random_object_in_sphere_no_save_recursive
-	// [var handle: Object] = get_random_object_in_sphere_no_save_recursive {x} [float] {y} [float] {z} [float] {radius} [float] {findNext} [bool] (logical)
-	static OpcodeResult __stdcall opcode_0AE3(CRunningScript* thread)
-	{
-		CVector center = {};
-		center.x = OPCODE_READ_PARAM_FLOAT();
-		center.y = OPCODE_READ_PARAM_FLOAT();
-		center.z = OPCODE_READ_PARAM_FLOAT();
-		auto radius = OPCODE_READ_PARAM_FLOAT();
-		auto findNext = OPCODE_READ_PARAM_BOOL();
-
-		int& searchIdx = Instance.objectSearchState[thread];
-		if (!findNext) searchIdx = 0;
-
-		CObject* found = nullptr;
-		for (int index = searchIdx; index < CPools::ms_pObjectPool->m_nSize; index++)
-		{
-			auto object = CPools::ms_pObjectPool->GetAt(index);
-
-			if (object == nullptr || object->m_nObjectFlags.bFadingIn) // this is actually .bFadingOut
-			{
-				continue; // invalid
-			}
-
-			if (radius < 1000.0f)
-			{
-				if ((object->GetPosition() - center).Magnitude() > radius)
-				{
-					continue; // out of search radius
-				}
-			}
-
-			found = object;
-			searchIdx = index + 1; // next search start index
-			break;
-		}
-
-		DWORD handle;
-		if (found != nullptr)
-		{
-			handle = CPools::ms_pObjectPool->GetRef(found);
-		}
-		else
-		{
-			handle = -1;
-			searchIdx = 0;
-		}
-
-		OPCODE_WRITE_PARAM_INT(handle);
-		OPCODE_CONDITION_RESULT(handle != -1);
-		return OR_CONTINUE;
-	}
+    std::map<CRunningScript*, int> charSearchState; // for get_random_char_in_sphere_no_save_recursive
+    std::map<CRunningScript*, int> carSearchState; // for get_random_car_in_sphere_no_save_recursive
+    std::map<CRunningScript*, int> objectSearchState; // for get_random_object_in_sphere_no_save_recursive
+
+    GameEntities()
+    {
+        if (!PluginCheckCleoVersion()) return;
+
+        // register opcodes
+        CLEO_RegisterOpcode(0x0AB5, opcode_0AB5); // store_closest_entities
+        CLEO_RegisterOpcode(0x0AB6, opcode_0AB6); // get_target_blip_coords
+        CLEO_RegisterOpcode(0x0AB7, opcode_0AB7); // get_car_number_of_gears
+        CLEO_RegisterOpcode(0x0AB8, opcode_0AB8); // get_car_current_gear
+        CLEO_RegisterOpcode(0x0ABD, opcode_0ABD); // is_car_siren_on
+        CLEO_RegisterOpcode(0x0ABE, opcode_0ABE); // is_car_engine_on
+        CLEO_RegisterOpcode(0x0ABF, opcode_0ABF); // cleo_set_car_engine_on
+        CLEO_RegisterOpcode(0x0AD2, opcode_0AD2); // get_char_player_is_targeting
+        CLEO_RegisterOpcode(0x0ADD, opcode_0ADD); // spawn_vehicle_by_cheating
+        CLEO_RegisterOpcode(0x0AE1, opcode_0AE1); // get_random_char_in_sphere_no_save_recursive
+        CLEO_RegisterOpcode(0x0AE2, opcode_0AE2); // get_random_car_in_sphere_no_save_recursive
+        CLEO_RegisterOpcode(0x0AE3, opcode_0AE3); // get_random_object_in_sphere_no_save_recursive
+
+        // register event callbacks
+        CLEO_RegisterCallback(eCallbackId::ScriptsFinalize, OnScriptsFinalize);
+    }
+
+    ~GameEntities()
+    {
+        CLEO_UnregisterCallback(eCallbackId::ScriptsFinalize, OnScriptsFinalize);
+    }
+
+    static void __stdcall OnScriptsFinalize()
+    {
+        Instance.charSearchState.clear();
+        Instance.carSearchState.clear();
+        Instance.objectSearchState.clear();
+    }
+
+    // store_closest_entities
+    // [var carHandle: Car], [var charHandle: Char] = store_closest_entities [Char]
+    static OpcodeResult __stdcall opcode_0AB5(CRunningScript* thread)
+    {
+        auto pedHandle = OPCODE_READ_PARAM_PED_HANDLE();
+
+        auto ped = CPools::GetPed(pedHandle);
+        if (ped == nullptr || ped->m_pIntelligence == nullptr)
+        {
+            OPCODE_WRITE_PARAM_INT(-1);
+            OPCODE_WRITE_PARAM_INT(-1);
+            return OR_CONTINUE;
+        }
+
+        DWORD foundCar = -1;
+        const auto& cars = ped->m_pIntelligence->m_vehicleScanner.m_apEntities;
+        for (size_t i = 0; i < std::size(cars); i++)
+        {
+            auto car = (CVehicle*)cars[i];
+            if (car != nullptr &&
+                car->m_nCreatedBy != eVehicleCreatedBy::MISSION_VEHICLE &&
+                !car->bFadeOut)
+            {
+                foundCar = CPools::GetVehicleRef(car); // get handle
+                break;
+            }
+        }
+
+        DWORD foundPed = -1;
+        const auto& peds = ped->m_pIntelligence->m_pedScanner.m_apEntities;
+        for (size_t i = 0; i < std::size(peds); i++)
+        {
+            auto ped = (CPed*)peds[i];
+            if (ped != nullptr &&
+                ped->m_nCreatedBy == 1 && // random pedestrian
+                !ped->bFadeOut)
+            {
+                foundPed = CPools::GetPedRef(ped); // get handle
+                break;
+            }
+        }
+
+        OPCODE_WRITE_PARAM_INT(foundCar);
+        OPCODE_WRITE_PARAM_INT(foundPed);
+        return OR_CONTINUE;
+    }
+
+    // get_target_blip_coords
+    // [var x: float], [var y: float], [var z: float] = get_target_blip_coords (logical)
+    static OpcodeResult __stdcall opcode_0AB6(CRunningScript* thread)
+    {
+        auto blipIdx = CRadar::GetActualBlipArrayIndex(FrontEndMenuManager.m_nTargetBlipIndex);
+        if (blipIdx == -1)
+        {
+            OPCODE_SKIP_PARAMS(3); // x, y, z
+            OPCODE_CONDITION_RESULT(false); // no target marker placed
+            return OR_CONTINUE;
+        }
+
+        CVector pos = CRadar::ms_RadarTrace[blipIdx].m_vecPos; // TODO: support for Fastman92's Limit Adjuster
+
+        // TODO: load world collisions for the coords
+        pos.z = CWorld::FindGroundZForCoord(pos.x, pos.y);
+
+        OPCODE_WRITE_PARAM_FLOAT(pos.x);
+        OPCODE_WRITE_PARAM_FLOAT(pos.y);
+        OPCODE_WRITE_PARAM_FLOAT(pos.z);
+        OPCODE_CONDITION_RESULT(true);
+        return OR_CONTINUE;
+    }
+
+    // get_car_number_of_gears
+    // [var numGear: int] = get_car_number_of_gears [Car]
+    static OpcodeResult __stdcall opcode_0AB7(CRunningScript* thread)
+    {
+        auto handle = OPCODE_READ_PARAM_VEHICLE_HANDLE();
+
+        auto vehicle = CPools::GetVehicle(handle);
+        auto gears = vehicle->m_pHandlingData->m_transmissionData.m_nNumberOfGears;
+
+        OPCODE_WRITE_PARAM_INT(gears);
+        return OR_CONTINUE;
+    }
+
+    // get_car_current_gear
+    // [var gear: int] = get_car_current_gear [Car]
+    static OpcodeResult __stdcall opcode_0AB8(CRunningScript* thread)
+    {
+        auto handle = OPCODE_READ_PARAM_VEHICLE_HANDLE();
+
+        auto vehicle = CPools::GetVehicle(handle);
+        auto gear = vehicle->m_nCurrentGear;
+
+        OPCODE_WRITE_PARAM_INT(gear);
+        return OR_CONTINUE;
+    }
+
+    // is_car_siren_on
+    // is_car_siren_on [Car] (logical)
+    static OpcodeResult __stdcall opcode_0ABD(CRunningScript* thread)
+    {
+        auto handle = OPCODE_READ_PARAM_VEHICLE_HANDLE();
+
+        auto vehicle = CPools::GetVehicle(handle);
+        auto state = vehicle->bSirenOrAlarm;
+
+        OPCODE_CONDITION_RESULT(state);
+        return OR_CONTINUE;
+    }
+
+    // is_car_engine_on
+    // is_car_engine_on [Car] (logical)
+    static OpcodeResult __stdcall opcode_0ABE(CRunningScript* thread)
+    {
+        auto handle = OPCODE_READ_PARAM_VEHICLE_HANDLE();
+
+        auto vehicle = CPools::GetVehicle(handle);
+        auto state = vehicle->bEngineOn;
+
+        OPCODE_CONDITION_RESULT(state);
+        return OR_CONTINUE;
+    }
+
+    // cleo_set_car_engine_on
+    // cleo_set_car_engine_on [Car] {state} [bool]
+    static OpcodeResult __stdcall opcode_0ABF(CRunningScript* thread)
+    {
+        auto handle = OPCODE_READ_PARAM_VEHICLE_HANDLE();
+        auto state = OPCODE_READ_PARAM_BOOL();
+
+        auto vehicle = CPools::GetVehicle(handle);
+
+        vehicle->bEngineOn = (state != false);
+        return OR_CONTINUE;
+    }
+
+    // get_char_player_is_targeting
+    // [var handle: Char] = get_char_player_is_targeting [Player] (logical)
+    static OpcodeResult __stdcall opcode_0AD2(CRunningScript* thread)
+    {
+        auto playerId = OPCODE_READ_PARAM_PLAYER_ID();
+
+        auto ped = FindPlayerPed(playerId);
+
+        auto target = ped->m_pPlayerTargettedPed;
+        if (target == nullptr) target = (CPed*)ped->m_pTargetedObject;
+        
+        if (target == nullptr || target->m_nType != ENTITY_TYPE_PED)
+        {
+            OPCODE_WRITE_PARAM_INT(-1);
+            OPCODE_CONDITION_RESULT(false);
+            return OR_CONTINUE;
+        }
+
+        auto handle = CPools::GetPedRef(target);
+
+        OPCODE_WRITE_PARAM_INT(handle);
+        OPCODE_CONDITION_RESULT(true);
+        return OR_CONTINUE;
+    }
+
+    // spawn_vehicle_by_cheating
+    // spawn_vehicle_by_cheating {modelId} [model_vehicle]
+    static OpcodeResult __stdcall opcode_0ADD(CRunningScript* thread)
+    {
+        auto modelIndex = OPCODE_READ_PARAM_INT();
+
+        auto model = CModelInfo::GetModelInfo(modelIndex);
+        if (model == nullptr || model->GetModelType() != MODEL_INFO_VEHICLE)
+        {
+            return OR_CONTINUE; // modelIndex is not vehicle
+        }
+
+        auto veh = (CVehicleModelInfo*)model;
+        switch (veh->m_nVehicleType)
+        {
+            case VEHICLE_AUTOMOBILE:
+            case VEHICLE_MTRUCK:
+            case VEHICLE_QUAD:
+            case VEHICLE_HELI:
+            case VEHICLE_PLANE:
+            case VEHICLE_BOAT:
+            //case VEHICLE_TRAIN:
+            //case VEHICLE_FHELI:
+            //case VEHICLE_FPLANE:
+            case VEHICLE_BIKE:
+            case VEHICLE_BMX:
+            case VEHICLE_TRAILER:
+                break;
+
+            default:
+                return OR_CONTINUE; // unsupported vehicle type
+        }
+
+        CCheat::VehicleCheat(modelIndex);
+
+        return OR_CONTINUE;
+    }
+
+    // get_random_char_in_sphere_no_save_recursive
+    // [var handle: Char] = get_random_char_in_sphere_no_save_recursive {x} [float] {y} [float] {z} [float] {radius} [float] {findNext} [bool] {filter} [int] (logical)
+    static OpcodeResult __stdcall opcode_0AE1(CRunningScript* thread)
+    {
+        CVector center = {};
+        center.x = OPCODE_READ_PARAM_FLOAT();
+        center.y = OPCODE_READ_PARAM_FLOAT();
+        center.z = OPCODE_READ_PARAM_FLOAT();
+        auto radius = OPCODE_READ_PARAM_FLOAT();
+        auto findNext = OPCODE_READ_PARAM_BOOL();
+        auto filter = OPCODE_READ_PARAM_INT();
+
+        bool skipDead = (filter == 1);
+        bool skipPlayer = (filter != -1);
+
+        int& searchIdx = Instance.charSearchState[thread];
+        if (!findNext) searchIdx = 0;
+
+        CPed* found = nullptr;
+        for (int index = searchIdx; index < CPools::ms_pPedPool->m_nSize; index++)
+        {
+            auto ped = CPools::ms_pPedPool->GetAt(index);
+
+            if (ped == nullptr || ped->bFadeOut)
+            {
+                continue; // invalid or about to be deleted
+            }
+
+            if (skipPlayer && ped->IsPlayer())
+            {
+                continue; // player
+            }
+
+            if (skipDead)
+            {
+                if (ped->m_ePedState == PEDSTATE_DIE || ped->m_ePedState == PEDSTATE_DEAD)
+                {
+                    continue; // dead
+                }
+            }
+
+            if (radius < 1000.0f)
+            {
+                if((ped->GetPosition() - center).Magnitude() > radius)
+                {
+                    continue; // out of search radius
+                }
+            }
+
+            found = ped;
+            searchIdx = index + 1; // next search start index
+            break;
+        }
+
+        DWORD handle;
+        if (found != nullptr)
+        {
+            handle = CPools::ms_pPedPool->GetRef(found);
+        }
+        else
+        {
+            handle = -1;
+            searchIdx = 0;
+        }
+
+        OPCODE_WRITE_PARAM_INT(handle);
+        OPCODE_CONDITION_RESULT(handle != -1);
+        return OR_CONTINUE;
+    }
+
+    // get_random_car_in_sphere_no_save_recursive
+    // [var handle: Car] = get_random_car_in_sphere_no_save_recursive {x} [float] {y} [float] {z} [float] {radius} [float] {findNext} [bool] {skipWrecked} [bool] (logical)
+    static OpcodeResult __stdcall opcode_0AE2(CRunningScript* thread)
+    {
+        CVector center = {};
+        center.x = OPCODE_READ_PARAM_FLOAT();
+        center.y = OPCODE_READ_PARAM_FLOAT();
+        center.z = OPCODE_READ_PARAM_FLOAT();
+        auto radius = OPCODE_READ_PARAM_FLOAT();
+        auto findNext = OPCODE_READ_PARAM_BOOL();
+        auto skipWrecked = OPCODE_READ_PARAM_BOOL();
+
+        int& searchIdx = Instance.carSearchState[thread];
+        if (!findNext) searchIdx = 0;
+
+        CVehicle* found = nullptr;
+        for (int index = searchIdx; index < CPools::ms_pVehiclePool->m_nSize; index++)
+        {
+            auto car = CPools::ms_pVehiclePool->GetAt(index);
+
+            if (car == nullptr || car->bFadeOut)
+            {
+                continue; // invalid or about to be deleted
+            }
+
+            if (skipWrecked)
+            {
+                if (car->m_nStatus == STATUS_WRECKED || car->bIsDrowning)
+                {
+                    continue; // wrecked
+                }
+            }
+
+            if (radius < 1000.0f)
+            {
+                if ((car->GetPosition() - center).Magnitude() > radius)
+                {
+                    continue; // out of search radius
+                }
+            }
+
+            found = car;
+            searchIdx = index + 1; // next search start index
+            break;
+        }
+
+        DWORD handle;
+        if (found != nullptr)
+        {
+            handle = CPools::ms_pVehiclePool->GetRef(found);
+        }
+        else
+        {
+            handle = -1;
+            searchIdx = 0;
+        }
+
+        OPCODE_WRITE_PARAM_INT(handle);
+        OPCODE_CONDITION_RESULT(handle != -1);
+        return OR_CONTINUE;
+    }
+
+    // get_random_object_in_sphere_no_save_recursive
+    // [var handle: Object] = get_random_object_in_sphere_no_save_recursive {x} [float] {y} [float] {z} [float] {radius} [float] {findNext} [bool] (logical)
+    static OpcodeResult __stdcall opcode_0AE3(CRunningScript* thread)
+    {
+        CVector center = {};
+        center.x = OPCODE_READ_PARAM_FLOAT();
+        center.y = OPCODE_READ_PARAM_FLOAT();
+        center.z = OPCODE_READ_PARAM_FLOAT();
+        auto radius = OPCODE_READ_PARAM_FLOAT();
+        auto findNext = OPCODE_READ_PARAM_BOOL();
+
+        int& searchIdx = Instance.objectSearchState[thread];
+        if (!findNext) searchIdx = 0;
+
+        CObject* found = nullptr;
+        for (int index = searchIdx; index < CPools::ms_pObjectPool->m_nSize; index++)
+        {
+            auto object = CPools::ms_pObjectPool->GetAt(index);
+
+            if (object == nullptr || object->m_nObjectFlags.bFadingIn) // this is actually .bFadingOut
+            {
+                continue; // invalid
+            }
+
+            if (radius < 1000.0f)
+            {
+                if ((object->GetPosition() - center).Magnitude() > radius)
+                {
+                    continue; // out of search radius
+                }
+            }
+
+            found = object;
+            searchIdx = index + 1; // next search start index
+            break;
+        }
+
+        DWORD handle;
+        if (found != nullptr)
+        {
+            handle = CPools::ms_pObjectPool->GetRef(found);
+        }
+        else
+        {
+            handle = -1;
+            searchIdx = 0;
+        }
+
+        OPCODE_WRITE_PARAM_INT(handle);
+        OPCODE_CONDITION_RESULT(handle != -1);
+        return OR_CONTINUE;
+    }
 } Instance;

--- a/cleo_plugins/IniFiles/IniFiles.cpp
+++ b/cleo_plugins/IniFiles/IniFiles.cpp
@@ -8,12 +8,12 @@ using namespace CLEO;
 // In case of naked file names without parent path INI file APIs searchs in Windows directory. Add leading ".\" to prevent that.
 static void fixIniFilepath(char* buff)
 {
-	if (!std::filesystem::path(buff).has_parent_path())
-	{
-		std::string filename = buff;
-		strcpy_s(buff, 512, ".\\");
-		strcat_s(buff, 512, filename.c_str());
-	}
+    if (!std::filesystem::path(buff).has_parent_path())
+    {
+        std::string filename = buff;
+        strcpy_s(buff, 512, ".\\");
+        strcat_s(buff, 512, filename.c_str());
+    }
 }
 
 #define OPCODE_READ_PARAM_FILEPATH_INI(_varName) OPCODE_READ_PARAM_FILEPATH(_varName); fixIniFilepath(_buff_##_varName)
@@ -21,235 +21,235 @@ static void fixIniFilepath(char* buff)
 #define OPCODE_READ_PARAM_STRING_OR_ZERO(_varName) const char* ##_varName; \
 if (IsLegacyScript(thread) && IsImmInteger(thread->PeekDataType()) && CLEO_PeekIntOpcodeParam(thread) == 0) \
 { \
-	CLEO_SkipOpcodeParams(thread, 1); \
-	##_varName = nullptr; \
+    CLEO_SkipOpcodeParams(thread, 1); \
+    ##_varName = nullptr; \
 } \
 else \
 { \
-	char _buff_##_varName[MAX_STR_LEN + 1]; \
-	##_varName = _readParamText(thread, _buff_##_varName, MAX_STR_LEN + 1); \
-	if (!_paramWasString()) { return OpcodeResult::OR_INTERRUPT; } \
+    char _buff_##_varName[MAX_STR_LEN + 1]; \
+    ##_varName = _readParamText(thread, _buff_##_varName, MAX_STR_LEN + 1); \
+    if (!_paramWasString()) { return OpcodeResult::OR_INTERRUPT; } \
 };
 
 class IniFiles
 {
 public:
-	IniFiles()
-	{
-		if (!PluginCheckCleoVersion()) return;
+    IniFiles()
+    {
+        if (!PluginCheckCleoVersion()) return;
 
-		// register opcodes
-		CLEO_RegisterOpcode(0x0AF0, Script_InifileGetInt);
-		CLEO_RegisterOpcode(0x0AF1, Script_InifileWriteInt);
-		CLEO_RegisterOpcode(0x0AF2, Script_InifileGetFloat);
-		CLEO_RegisterOpcode(0x0AF3, Script_InifileWriteFloat);
-		CLEO_RegisterOpcode(0x0AF4, Script_InifileReadString);
-		CLEO_RegisterOpcode(0x0AF5, Script_InifileWriteString);
-		CLEO_RegisterOpcode(0x2800, Script_InifileDeleteSection);
-		CLEO_RegisterOpcode(0x2801, Script_InifileDeleteKey);
-	}
+        // register opcodes
+        CLEO_RegisterOpcode(0x0AF0, Script_InifileGetInt);
+        CLEO_RegisterOpcode(0x0AF1, Script_InifileWriteInt);
+        CLEO_RegisterOpcode(0x0AF2, Script_InifileGetFloat);
+        CLEO_RegisterOpcode(0x0AF3, Script_InifileWriteFloat);
+        CLEO_RegisterOpcode(0x0AF4, Script_InifileReadString);
+        CLEO_RegisterOpcode(0x0AF5, Script_InifileWriteString);
+        CLEO_RegisterOpcode(0x2800, Script_InifileDeleteSection);
+        CLEO_RegisterOpcode(0x2801, Script_InifileDeleteKey);
+    }
 
-	static OpcodeResult __stdcall Script_InifileGetInt(CRunningScript* thread)
-		/****************************************************************
-		Opcode Format
-		0AF0=4,%4d% = get_int_from_ini_file %1s% section %2s% key %3s%
-		****************************************************************/
-	{
-		OPCODE_READ_PARAM_FILEPATH_INI(path);
-		OPCODE_READ_PARAM_STRING(section);
-		OPCODE_READ_PARAM_STRING(key);
+    static OpcodeResult __stdcall Script_InifileGetInt(CRunningScript* thread)
+        /****************************************************************
+        Opcode Format
+        0AF0=4,%4d% = get_int_from_ini_file %1s% section %2s% key %3s%
+        ****************************************************************/
+    {
+        OPCODE_READ_PARAM_FILEPATH_INI(path);
+        OPCODE_READ_PARAM_STRING(section);
+        OPCODE_READ_PARAM_STRING(key);
 
-		char buff[32];
-		if (GetPrivateProfileString(section, key, NULL, buff, sizeof(buff), path))
-		{
-			char* str;
-			int base;
-			if (StringStartsWith(buff, "0x", false)) // hex int
-			{
-				str = buff + 2;
-				base = 16;
-			}
-			else // decimal int
-			{
-				str = buff;
-				base = 10;
-			}
+        char buff[32];
+        if (GetPrivateProfileString(section, key, NULL, buff, sizeof(buff), path))
+        {
+            char* str;
+            int base;
+            if (StringStartsWith(buff, "0x", false)) // hex int
+            {
+                str = buff + 2;
+                base = 16;
+            }
+            else // decimal int
+            {
+                str = buff;
+                base = 10;
+            }
 
-			// parse
-			char* end;
-			int value = strtol(str, &end, base);
-			if (end != str || // at least one number character consumed
-				IsLegacyScript(thread)) // old CLEO reported success anyway with value 0
-			{
-				OPCODE_WRITE_PARAM_INT(value);
-				OPCODE_CONDITION_RESULT(true);
-				return OR_CONTINUE;
-			}
-		}
+            // parse
+            char* end;
+            int value = strtol(str, &end, base);
+            if (end != str || // at least one number character consumed
+                IsLegacyScript(thread)) // old CLEO reported success anyway with value 0
+            {
+                OPCODE_WRITE_PARAM_INT(value);
+                OPCODE_CONDITION_RESULT(true);
+                return OR_CONTINUE;
+            }
+        }
 
-		// failed
-		if (IsLegacyScript(thread))
-		{
-			OPCODE_WRITE_PARAM_INT(0x80000000); // CLEO4 behavior
-		}
-		else
-		{
-			OPCODE_SKIP_PARAMS(1);
-		}
+        // failed
+        if (IsLegacyScript(thread))
+        {
+            OPCODE_WRITE_PARAM_INT(0x80000000); // CLEO4 behavior
+        }
+        else
+        {
+            OPCODE_SKIP_PARAMS(1);
+        }
 
-		OPCODE_CONDITION_RESULT(false);
-		return OR_CONTINUE;
-	}
+        OPCODE_CONDITION_RESULT(false);
+        return OR_CONTINUE;
+    }
 
-	static OpcodeResult __stdcall Script_InifileWriteInt(CRunningScript* thread)
-		/****************************************************************
-		Opcode Format
-		0AF1=4,write_int %1d% to_ini_file %2s% section %3s% key %4s%
-		****************************************************************/
-	{
-		auto value = OPCODE_READ_PARAM_INT();
-		OPCODE_READ_PARAM_FILEPATH_INI(path);
-		OPCODE_READ_PARAM_STRING(section);
-		OPCODE_READ_PARAM_STRING_OR_ZERO(key);	// 0 deletes the whole section
+    static OpcodeResult __stdcall Script_InifileWriteInt(CRunningScript* thread)
+        /****************************************************************
+        Opcode Format
+        0AF1=4,write_int %1d% to_ini_file %2s% section %3s% key %4s%
+        ****************************************************************/
+    {
+        auto value = OPCODE_READ_PARAM_INT();
+        OPCODE_READ_PARAM_FILEPATH_INI(path);
+        OPCODE_READ_PARAM_STRING(section);
+        OPCODE_READ_PARAM_STRING_OR_ZERO(key);    // 0 deletes the whole section
 
-		char strValue[32];
-		_itoa_s(value, strValue, 10);
-		auto result = WritePrivateProfileString(section, key, strValue, path);
-		
-		OPCODE_CONDITION_RESULT(result);
-		return OR_CONTINUE;
-	}
+        char strValue[32];
+        _itoa_s(value, strValue, 10);
+        auto result = WritePrivateProfileString(section, key, strValue, path);
+        
+        OPCODE_CONDITION_RESULT(result);
+        return OR_CONTINUE;
+    }
 
-	static OpcodeResult __stdcall Script_InifileGetFloat(CRunningScript* thread)
-		/****************************************************************
-		Opcode Format
-		0AF2=4,%4d% = get_float_from_ini_file %1s% section %2s% key %3s%
-		****************************************************************/
-	{
-		OPCODE_READ_PARAM_FILEPATH_INI(path);
-		OPCODE_READ_PARAM_STRING(section);
-		OPCODE_READ_PARAM_STRING(key);
+    static OpcodeResult __stdcall Script_InifileGetFloat(CRunningScript* thread)
+        /****************************************************************
+        Opcode Format
+        0AF2=4,%4d% = get_float_from_ini_file %1s% section %2s% key %3s%
+        ****************************************************************/
+    {
+        OPCODE_READ_PARAM_FILEPATH_INI(path);
+        OPCODE_READ_PARAM_STRING(section);
+        OPCODE_READ_PARAM_STRING(key);
 
-		char buff[32];
-		if (GetPrivateProfileString(section, key, NULL, buff, sizeof(buff), path))
-		{
-			char *str, *end;
-			float value;
-			if (StringStartsWith(buff, "0x", false)) // hex int
-			{
-				str = buff + 2;
-				value = (float)strtol(str, &end, 16);
-			}
-			else // float
-			{
-				str = buff;
-				value = strtof(str, &end);
-			}
+        char buff[32];
+        if (GetPrivateProfileString(section, key, NULL, buff, sizeof(buff), path))
+        {
+            char *str, *end;
+            float value;
+            if (StringStartsWith(buff, "0x", false)) // hex int
+            {
+                str = buff + 2;
+                value = (float)strtol(str, &end, 16);
+            }
+            else // float
+            {
+                str = buff;
+                value = strtof(str, &end);
+            }
 
-			if (end != str || // at least one number character consumed
-				IsLegacyScript(thread)) // old CLEO reported success anyway with value 0
-			{
-				OPCODE_WRITE_PARAM_FLOAT(value);
-				OPCODE_CONDITION_RESULT(true);
-				return OR_CONTINUE;
-			}
-		}
+            if (end != str || // at least one number character consumed
+                IsLegacyScript(thread)) // old CLEO reported success anyway with value 0
+            {
+                OPCODE_WRITE_PARAM_FLOAT(value);
+                OPCODE_CONDITION_RESULT(true);
+                return OR_CONTINUE;
+            }
+        }
 
-		// failed
-		OPCODE_SKIP_PARAMS(1);
-		OPCODE_CONDITION_RESULT(false);
-		return OR_CONTINUE;
-	}
+        // failed
+        OPCODE_SKIP_PARAMS(1);
+        OPCODE_CONDITION_RESULT(false);
+        return OR_CONTINUE;
+    }
 
-	static OpcodeResult __stdcall Script_InifileWriteFloat(CRunningScript* thread)
-		/****************************************************************
-		Opcode Format
-		0AF3=4,write_float %1d% to_ini_file %2s% section %3s% key %4s%
-		****************************************************************/
-	{
-		auto value = OPCODE_READ_PARAM_FLOAT();
-		OPCODE_READ_PARAM_FILEPATH_INI(path);
-		OPCODE_READ_PARAM_STRING(section);
-		OPCODE_READ_PARAM_STRING_OR_ZERO(key); // 0 deletes the whole section
+    static OpcodeResult __stdcall Script_InifileWriteFloat(CRunningScript* thread)
+        /****************************************************************
+        Opcode Format
+        0AF3=4,write_float %1d% to_ini_file %2s% section %3s% key %4s%
+        ****************************************************************/
+    {
+        auto value = OPCODE_READ_PARAM_FLOAT();
+        OPCODE_READ_PARAM_FILEPATH_INI(path);
+        OPCODE_READ_PARAM_STRING(section);
+        OPCODE_READ_PARAM_STRING_OR_ZERO(key); // 0 deletes the whole section
 
-		char strValue[32];
-		sprintf_s(strValue, "%g", value);
-		auto result = WritePrivateProfileString(section, key, strValue, path);
-		
-		OPCODE_CONDITION_RESULT(result);
-		return OR_CONTINUE;
-	}
+        char strValue[32];
+        sprintf_s(strValue, "%g", value);
+        auto result = WritePrivateProfileString(section, key, strValue, path);
+        
+        OPCODE_CONDITION_RESULT(result);
+        return OR_CONTINUE;
+    }
 
-	static OpcodeResult __stdcall Script_InifileReadString(CRunningScript* thread)
-		/****************************************************************
-		Opcode Format
-		0AF4=4,%4d% = read_string_from_ini_file %1s% section %2s% key %3s%
-		****************************************************************/
-	{
-		OPCODE_READ_PARAM_FILEPATH_INI(path);
-		OPCODE_READ_PARAM_STRING(section);
-		OPCODE_READ_PARAM_STRING(key);
+    static OpcodeResult __stdcall Script_InifileReadString(CRunningScript* thread)
+        /****************************************************************
+        Opcode Format
+        0AF4=4,%4d% = read_string_from_ini_file %1s% section %2s% key %3s%
+        ****************************************************************/
+    {
+        OPCODE_READ_PARAM_FILEPATH_INI(path);
+        OPCODE_READ_PARAM_STRING(section);
+        OPCODE_READ_PARAM_STRING(key);
 
-		char strValue[MAX_STR_LEN];
-		auto result = GetPrivateProfileString(section, key, NULL, strValue, sizeof(strValue), path);
-		if (result)
-		{
-			OPCODE_WRITE_PARAM_STRING(strValue);
-		}
-		else
-		{
-			OPCODE_SKIP_PARAMS(1);
-		}
-		OPCODE_CONDITION_RESULT(result);
-		return OR_CONTINUE;
-	}
+        char strValue[MAX_STR_LEN];
+        auto result = GetPrivateProfileString(section, key, NULL, strValue, sizeof(strValue), path);
+        if (result)
+        {
+            OPCODE_WRITE_PARAM_STRING(strValue);
+        }
+        else
+        {
+            OPCODE_SKIP_PARAMS(1);
+        }
+        OPCODE_CONDITION_RESULT(result);
+        return OR_CONTINUE;
+    }
 
-	static OpcodeResult __stdcall Script_InifileWriteString(CRunningScript* thread)
-		/****************************************************************
-		Opcode Format
-		0AF5=4,write_string %1s% to_ini_file %2s% section %3s% key %4s%
-		****************************************************************/
-	{
-		OPCODE_READ_PARAM_STRING_OR_ZERO(strValue); // 0 deletes the key
-		OPCODE_READ_PARAM_FILEPATH_INI(path);
-		OPCODE_READ_PARAM_STRING(section);
-		OPCODE_READ_PARAM_STRING_OR_ZERO(key);		// 0 deletes the whole section
+    static OpcodeResult __stdcall Script_InifileWriteString(CRunningScript* thread)
+        /****************************************************************
+        Opcode Format
+        0AF5=4,write_string %1s% to_ini_file %2s% section %3s% key %4s%
+        ****************************************************************/
+    {
+        OPCODE_READ_PARAM_STRING_OR_ZERO(strValue); // 0 deletes the key
+        OPCODE_READ_PARAM_FILEPATH_INI(path);
+        OPCODE_READ_PARAM_STRING(section);
+        OPCODE_READ_PARAM_STRING_OR_ZERO(key);        // 0 deletes the whole section
 
-		auto result = WritePrivateProfileString(section, key, strValue, path);
+        auto result = WritePrivateProfileString(section, key, strValue, path);
 
-		OPCODE_CONDITION_RESULT(result);
-		return OR_CONTINUE;
-	}
+        OPCODE_CONDITION_RESULT(result);
+        return OR_CONTINUE;
+    }
 
-	static OpcodeResult __stdcall Script_InifileDeleteSection(CRunningScript* thread)
-		/****************************************************************
-		Opcode Format
-		2800=2,delete_section_from_ini_file %1s% section %2s%
-		****************************************************************/
-	{
-		OPCODE_READ_PARAM_FILEPATH_INI(path);
-		OPCODE_READ_PARAM_STRING(section);
+    static OpcodeResult __stdcall Script_InifileDeleteSection(CRunningScript* thread)
+        /****************************************************************
+        Opcode Format
+        2800=2,delete_section_from_ini_file %1s% section %2s%
+        ****************************************************************/
+    {
+        OPCODE_READ_PARAM_FILEPATH_INI(path);
+        OPCODE_READ_PARAM_STRING(section);
 
-		auto result = WritePrivateProfileString(section, nullptr, nullptr, path);
+        auto result = WritePrivateProfileString(section, nullptr, nullptr, path);
 
-		OPCODE_CONDITION_RESULT(result);
-		return OR_CONTINUE;
-	}
+        OPCODE_CONDITION_RESULT(result);
+        return OR_CONTINUE;
+    }
 
-	static OpcodeResult __stdcall Script_InifileDeleteKey(CRunningScript* thread)
-		/****************************************************************
-		Opcode Format
-		2801=3,delete_key_from_ini_file %1s% section %2s%
-		****************************************************************/
-	{
-		OPCODE_READ_PARAM_FILEPATH_INI(path);
-		OPCODE_READ_PARAM_STRING(section);
-		OPCODE_READ_PARAM_STRING(key);
+    static OpcodeResult __stdcall Script_InifileDeleteKey(CRunningScript* thread)
+        /****************************************************************
+        Opcode Format
+        2801=3,delete_key_from_ini_file %1s% section %2s%
+        ****************************************************************/
+    {
+        OPCODE_READ_PARAM_FILEPATH_INI(path);
+        OPCODE_READ_PARAM_STRING(section);
+        OPCODE_READ_PARAM_STRING(key);
 
-		auto result = WritePrivateProfileString(section, key, nullptr, path);
+        auto result = WritePrivateProfileString(section, key, nullptr, path);
 
-		OPCODE_CONDITION_RESULT(result);
-		return OR_CONTINUE;
-	}
+        OPCODE_CONDITION_RESULT(result);
+        return OR_CONTINUE;
+    }
 } iniFiles;
 

--- a/cleo_plugins/Input/main.cpp
+++ b/cleo_plugins/Input/main.cpp
@@ -12,636 +12,636 @@ using namespace CLEO;
 
 class Input
 {
-	static constexpr int Key_Code_None = -1;
-	static constexpr size_t Key_Code_Max = 0xFF;
-	static constexpr BYTE Key_Flag_Down = 0x80; // top bit
+    static constexpr int Key_Code_None = -1;
+    static constexpr size_t Key_Code_Max = 0xFF;
+    static constexpr BYTE Key_Flag_Down = 0x80; // top bit
 
 public:
-	std::array<BYTE, Key_Code_Max + 1>* keyStatesCurr, *keyStatesPrev;
-
-	Input()
-	{
-		keyStatesCurr = new std::array<BYTE, Key_Code_Max + 1>();
-		keyStatesPrev = new std::array<BYTE, Key_Code_Max + 1>();
-
-		if (!PluginCheckCleoVersion()) return;
-
-		// register opcodes
-		CLEO_RegisterOpcode(0x0AB0, opcode_0AB0); // is_key_pressed
-		CLEO_RegisterOpcode(0x0ADC, opcode_0ADC); // test_cheat
-		CLEO_RegisterOpcode(0x2080, opcode_2080); // is_key_just_pressed
-		CLEO_RegisterOpcode(0x2081, opcode_2081); // get_key_pressed_in_range
-		CLEO_RegisterOpcode(0x2082, opcode_2082); // get_key_just_pressed_in_range
-		CLEO_RegisterOpcode(0x2083, opcode_2083); // emulate_key_press
-		CLEO_RegisterOpcode(0x2084, opcode_2084); // emulate_key_release
-		CLEO_RegisterOpcode(0x2085, opcode_2085); // get_controller_key
-		CLEO_RegisterOpcode(0x2086, opcode_2086); // get_key_name
-
-		// register event callbacks
-		CLEO_RegisterCallback(eCallbackId::GameProcessBefore, OnGameProcessBefore);
-		CLEO_RegisterCallback(eCallbackId::DrawingFinished, OnDrawingFinished);
-	}
-
-	~Input()
-	{
-		delete keyStatesCurr;
-		delete keyStatesPrev;
-
-		CLEO_UnregisterCallback(eCallbackId::GameProcessBefore, OnGameProcessBefore);
-		CLEO_UnregisterCallback(eCallbackId::DrawingFinished, OnDrawingFinished);
-	}
-
-	// refresh keys info
-	void CheckKeyboard()
-	{
-		std::swap(keyStatesCurr, keyStatesPrev);
-		GetKeyboardState(keyStatesCurr->data());
-	}
-
-	static void SendKeyEvent(BYTE vKey, bool down)
-	{
-		INPUT input = { 0 };
-		if (vKey >= VK_LBUTTON && vKey <= VK_XBUTTON2) // mouse keys
-		{
-			input.type = INPUT_MOUSE;
-			switch (vKey)
-			{
-				case VK_LBUTTON: input.mi.dwFlags = down ? MOUSEEVENTF_LEFTDOWN : MOUSEEVENTF_LEFTUP; break;
-				case VK_MBUTTON: input.mi.dwFlags = down ? MOUSEEVENTF_MIDDLEDOWN : MOUSEEVENTF_MIDDLEUP; break;
-				case VK_RBUTTON: input.mi.dwFlags = down ? MOUSEEVENTF_RIGHTDOWN : MOUSEEVENTF_RIGHTUP; break;
-
-				case VK_XBUTTON1:
-					input.mi.dwFlags = down ? MOUSEEVENTF_XDOWN : MOUSEEVENTF_XUP;
-					input.mi.mouseData = XBUTTON1;
-					break;
-
-				case VK_XBUTTON2:
-					input.mi.dwFlags = down ? MOUSEEVENTF_XDOWN : MOUSEEVENTF_XUP;
-					input.mi.mouseData = XBUTTON2;
-					break;
-			}
-		}
-		else // keyboard
-		{
-			input.type = INPUT_KEYBOARD;
-			input.ki.wVk = vKey;
-			input.ki.dwFlags = down ? 0 : KEYEVENTF_KEYUP;
-
-			switch(vKey)
-			{
-				case VK_RETURN: // would be mapped to numpad's enter
-				case VK_LSHIFT: // maps to VK_SHIFT
-				case VK_LCONTROL: // maps to VK_CONTROL
-				case VK_LMENU: // maps to VK_MENU
-					break; // do not use scan code
-
-				default:
-					input.ki.wScan = MapVirtualKey(vKey, MAPVK_VK_TO_VSC_EX);
-					input.ki.dwFlags |= KEYEVENTF_EXTENDEDKEY;
-			}
-		}
-
-		SendInput(1, &input, sizeof(input));
-	}
-
-	static void __stdcall OnGameProcessBefore()
-	{
-		g_instance.CheckKeyboard();
-	}
-
-	static void __stdcall OnDrawingFinished()
-	{
-		if (CTimer::m_UserPause) // main menu visible
-		{
-			g_instance.CheckKeyboard(); // update for ambient scripts running in menu
-		}
-	}
-
-	// is_key_pressed
-	// is_key_pressed {keyCode} [KeyCode] (logical)
-	static OpcodeResult __stdcall opcode_0AB0(CRunningScript* thread)
-	{
-		auto key = OPCODE_READ_PARAM_INT();
-
-		if (key == Key_Code_None)
-		{
-			OPCODE_CONDITION_RESULT(false);
-			return OR_CONTINUE;
-		}
-		if (key < 0 || key > Key_Code_Max)
-		{
-			LOG_WARNING(thread, "Invalid key code (%d) used in script %s", key, ScriptInfoStr(thread).c_str()); // legacy opcode, just warning
-			OPCODE_CONDITION_RESULT(false);
-			return OR_CONTINUE;
-		}
-
-		bool isDown = g_instance.keyStatesCurr->at(key) & Key_Flag_Down;
-
-		thread->SetConditionResult(isDown);
-		return OR_CONTINUE;
-	}
-
-	// test_cheat
-	// test_cheat {input} [string] (logical)
-	static OpcodeResult __stdcall opcode_0ADC(CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING_LEN(text, sizeof(CCheat::m_CheatString));
-
-		auto len = strlen(_buff_text);
-		if (len == 0)
-		{
-			OPCODE_CONDITION_RESULT(false);
-			return OR_CONTINUE;
-		}
-
-		_strrev(_buff_text); // reverse
-		if (_strnicmp(_buff_text, CCheat::m_CheatString, len) != 0)
-		{
-			OPCODE_CONDITION_RESULT(false);
-			return OR_CONTINUE;
-		}
-
-		CCheat::m_CheatString[0] = '\0'; // consume the cheat
-		OPCODE_CONDITION_RESULT(true);
-		return OR_CONTINUE;
-	}
-
-	// is_key_just_pressed
-	// is_key_just_pressed {keyCode} [KeyCode] (logical)
-	static OpcodeResult __stdcall opcode_2080(CRunningScript* thread)
-	{
-		auto key = OPCODE_READ_PARAM_INT();
-
-		if (key == Key_Code_None)
-		{
-			OPCODE_CONDITION_RESULT(false);
-			return OR_CONTINUE;
-		}
-		if (key < 0 || key > Key_Code_Max)
-		{
-			SHOW_ERROR("Invalid key code (%d) used in script %s\nScript suspended.", key, ScriptInfoStr(thread).c_str());
-			return thread->Suspend();
-		}
-
-		bool wasDown = g_instance.keyStatesPrev->at(key) & Key_Flag_Down;
-		bool isDown = g_instance.keyStatesCurr->at(key) & Key_Flag_Down;
-
-		OPCODE_CONDITION_RESULT(!wasDown && isDown);
-		return OR_CONTINUE;
-	}
-
-	// get_key_pressed_in_range
-	// [var keyCode: KeyCode] = get_key_pressed_in_range {minKeyCode} [KeyCode] {maxKeyCode} [KeyCode] (logical)
-	static OpcodeResult __stdcall opcode_2081(CRunningScript* thread)
-	{
-		auto keyMin = OPCODE_READ_PARAM_INT();
-		auto keyMax = OPCODE_READ_PARAM_INT();
-
-		if (keyMin < 0 || keyMin > Key_Code_Max)
-		{
-			SHOW_ERROR("Invalid value (%d) of 'minKeyCode' argument in script %s\nScript suspended.", keyMin, ScriptInfoStr(thread).c_str());
-			return thread->Suspend();
-		}
-		if (keyMax < 0 || keyMax > Key_Code_Max || keyMax < keyMin)
-		{
-			SHOW_ERROR("Invalid value (%d) of 'maxKeyCode' argument in script %s\nScript suspended.", keyMin, ScriptInfoStr(thread).c_str());
-			return thread->Suspend();
-		}
-
-		for (auto key = keyMin; key <= keyMax; key++)
-		{
-			bool isDown = g_instance.keyStatesCurr->at(key) & Key_Flag_Down;
-
-			if (isDown)
-			{
-				OPCODE_WRITE_PARAM_INT(key);
-				OPCODE_CONDITION_RESULT(true);
-				return OR_CONTINUE;
-			}
-		}
-
-		OPCODE_SKIP_PARAMS(1); // no result
-		OPCODE_CONDITION_RESULT(false);
-		return OR_CONTINUE;
-	}
-
-	// get_key_just_pressed_in_range
-	// [var keyCode: KeyCode] = get_key_just_pressed_in_range {minKeyCode} [KeyCode] {maxKeyCode} [KeyCode] (logical)
-	static OpcodeResult __stdcall opcode_2082(CRunningScript* thread)
-	{
-		auto keyMin = OPCODE_READ_PARAM_INT();
-		auto keyMax = OPCODE_READ_PARAM_INT();
-
-		if (keyMin < 0 || keyMin > Key_Code_Max)
-		{
-			SHOW_ERROR("Invalid value (%d) of 'minKeyCode' argument in script %s\nScript suspended.", keyMin, ScriptInfoStr(thread).c_str());
-			return thread->Suspend();
-		}
-		if (keyMax < 0 || keyMax > Key_Code_Max || keyMax < keyMin)
-		{
-			SHOW_ERROR("Invalid value (%d) of 'maxKeyCode' argument in script %s\nScript suspended.", keyMin, ScriptInfoStr(thread).c_str());
-			return thread->Suspend();
-		}
-
-		for (auto key = keyMin; key <= keyMax; key++)
-		{
-			bool wasDown = g_instance.keyStatesPrev->at(key) & Key_Flag_Down;
-			bool isDown = g_instance.keyStatesCurr->at(key) & Key_Flag_Down;
-
-			if (!wasDown && isDown)
-			{
-				OPCODE_WRITE_PARAM_INT(key);
-				OPCODE_CONDITION_RESULT(true);
-				return OR_CONTINUE;
-			}
-		}
-
-		OPCODE_SKIP_PARAMS(1); // no result
-		OPCODE_CONDITION_RESULT(false);
-		return OR_CONTINUE;
-	}
-
-	// emulate_key_press
-	// emulate_key_press {keyCode} [KeyCode]
-	static OpcodeResult __stdcall opcode_2083(CRunningScript* thread)
-	{
-		auto key = OPCODE_READ_PARAM_INT();
-
-		if (key == Key_Code_None)
-		{
-			return OR_CONTINUE;
-		}
-		if (key < 0 || key > Key_Code_Max)
-		{
-			SHOW_ERROR("Invalid key code (%d) used in script %s\nScript suspended.", key, ScriptInfoStr(thread).c_str());
-			return thread->Suspend();
-		}
-
-		SendKeyEvent(key, true);
-
-		return OR_CONTINUE;
-	}
-
-	// emulate_key_release
-	// emulate_key_release {keyCode} [KeyCode]
-	static OpcodeResult __stdcall opcode_2084(CRunningScript* thread)
-	{
-		auto key = OPCODE_READ_PARAM_INT();
-
-		if (key == Key_Code_None)
-		{
-			return OR_CONTINUE;
-		}
-		if (key < 0 || key > Key_Code_Max)
-		{
-			SHOW_ERROR("Invalid key code (%d) used in script %s\nScript suspended.", key, ScriptInfoStr(thread).c_str());
-			return thread->Suspend();
-		}
-
-		SendKeyEvent(key, false);
-
-		return OR_CONTINUE;
-	}
-
-	// get_controller_key
-	// [var keyCode: KeyCode] = get_controller_key {action} [ControllerAction] {altKeyIdx} [int] (logical)
-	static OpcodeResult __stdcall opcode_2085(CRunningScript* thread)
-	{
-		auto actionId = OPCODE_READ_PARAM_INT();
-		auto altKeyIdx = OPCODE_READ_PARAM_INT();
-
-		if (actionId < 0 || actionId >= _countof(ControlsManager.m_actions))
-		{
-			SHOW_ERROR("Invalid value (%d) of 'action' argument in script %s\nScript suspended.", actionId, ScriptInfoStr(thread).c_str());
-			return thread->Suspend();
-		}
-		if (altKeyIdx < 0 || altKeyIdx >= _countof(CControllerAction::keys))
-		{
-			SHOW_ERROR("Invalid value (%d) of 'altKeyIdx' argument in script %s\nScript suspended.", actionId, ScriptInfoStr(thread).c_str());
-			return thread->Suspend();
-		}
-
-		auto& action = ControlsManager.m_actions[actionId];
-
-		// sort associated keys by priority
-		std::map<unsigned int, DWORD> mapping;
-		for (size_t i = 0; i < _countof(action.keys); i++)
-		{
-			auto& k = action.keys[i];
-
-			if (k.keyCode == 0 || k.priority == 0) // key not assigned
-				continue;
-
-			if (k.keyCode == rsMOUSEWHEELUPBUTTON || k.keyCode == rsMOUSEWHEELDOWNBUTTON)
-				continue; // there is no VK codes for mouse wheel rolling
-
-			mapping[k.priority] = k.keyCode;
-		}
-
-		if (mapping.size() <= (size_t)altKeyIdx)
-		{
-			OPCODE_SKIP_PARAMS(1); // no key assigned
-			OPCODE_CONDITION_RESULT(false);
-			return OR_CONTINUE;
-		}
-
-		// get the alt key code
-		auto it = std::next(mapping.begin(), altKeyIdx);
-		auto keyCode = it->second;
-
-		// translate RsKeyCode to VirtualKey
-		switch(keyCode)
-		{
-			case rsMOUSELEFTBUTTON: keyCode = VK_LBUTTON; break;
-			case rsMOUSEMIDDLEBUTTON: keyCode = VK_MBUTTON; break;
-			case rsMOUSERIGHTBUTTON: keyCode = VK_RBUTTON; break;
-			//case rsMOUSEWHEELUPBUTTON:
-			//case rsMOUSEWHEELDOWNBUTTON:
-			case rsMOUSEX1BUTTON: keyCode = VK_XBUTTON1; break;
-			case rsMOUSEX2BUTTON: keyCode = VK_XBUTTON2; break;
-
-			case rsESC: keyCode = VK_ESCAPE; break;
-
-			case rsF1: keyCode = VK_F1; break;
-			case rsF2: keyCode = VK_F2; break;
-			case rsF3: keyCode = VK_F3; break;
-			case rsF4: keyCode = VK_F4; break;
-			case rsF5: keyCode = VK_F5; break;
-			case rsF6: keyCode = VK_F6; break;
-			case rsF7: keyCode = VK_F7; break;
-			case rsF8: keyCode = VK_F8; break;
-			case rsF9: keyCode = VK_F9; break;
-			case rsF10: keyCode = VK_F10; break;
-			case rsF11: keyCode = VK_F11; break;
-			case rsF12: keyCode = VK_F12; break;
-
-			case rsINS: keyCode = VK_INSERT; break;
-			case rsDEL: keyCode = VK_DELETE; break;
-			case rsHOME: keyCode = VK_HOME; break;
-			case rsEND: keyCode = VK_END; break;
-			case rsPGUP: keyCode = VK_PRIOR; break;
-			case rsPGDN: keyCode = VK_NEXT; break;
-
-			case rsUP: keyCode = VK_UP; break;
-			case rsDOWN: keyCode = VK_DOWN; break;
-			case rsLEFT: keyCode = VK_LEFT; break;
-			case rsRIGHT: keyCode = VK_RIGHT; break;
-
-			case rsDIVIDE: keyCode = VK_DIVIDE; break;
-			case rsTIMES: keyCode = VK_MULTIPLY; break;
-			case rsPLUS: keyCode = VK_ADD; break;
-			case rsMINUS: keyCode = VK_SUBTRACT; break;
-			case rsPADDEL: keyCode = VK_DECIMAL; break;
-			case rsPADEND: keyCode = VK_NUMPAD1; break;
-			case rsPADDOWN: keyCode = VK_NUMPAD2; break;
-			case rsPADPGDN: keyCode = VK_NUMPAD3; break;
-			case rsPADLEFT: keyCode = VK_NUMPAD4; break;
-			case rsPAD5: keyCode = VK_NUMPAD5; break;
-			case rsNUMLOCK: keyCode = VK_NUMLOCK; break;
-			case rsPADRIGHT: keyCode = VK_NUMPAD6; break;
-			case rsPADHOME: keyCode = VK_NUMPAD7; break;
-			case rsPADUP: keyCode = VK_NUMPAD8; break;
-			case rsPADPGUP: keyCode = VK_NUMPAD9; break;
-			case rsPADINS: keyCode = VK_NUMPAD0; break;
-			case rsPADENTER: keyCode = VK_RETURN; break; // not quite same
-
-			case rsSCROLL: keyCode = VK_SCROLL; break;
-			case rsPAUSE: keyCode = VK_PAUSE; break;
-
-			case rsBACKSP: keyCode = VK_BACK; break;
-			case rsTAB: keyCode = VK_TAB; break;
-			case rsCAPSLK: keyCode = VK_CAPITAL; break;
-			case rsENTER: keyCode = VK_RETURN; break;
-			case rsLSHIFT: keyCode = VK_LSHIFT; break;
-			case rsRSHIFT: keyCode = VK_RSHIFT; break;
-			case rsSHIFT: keyCode = VK_SHIFT; break;
-			case rsLCTRL: keyCode = VK_LCONTROL; break;
-			case rsRCTRL: keyCode = VK_RCONTROL; break;
-			case rsLALT: keyCode = VK_LMENU; break;
-			case rsRALT: keyCode = VK_RMENU; break;
-			case rsLWIN: keyCode = VK_LWIN; break;
-			case rsRWIN: keyCode = VK_RWIN; break;
-			case rsAPPS: keyCode = VK_APPS; break;
-		}
-		
-		OPCODE_WRITE_PARAM_INT(keyCode);
-		OPCODE_CONDITION_RESULT(true);
-		return OR_CONTINUE;
-	}
-
-	// get_key_name
-	// [var name: string] = get_key_name {keyCode} [KeyCode] (logical)
-	static OpcodeResult __stdcall opcode_2086(CRunningScript* thread)
-	{
-		auto key = OPCODE_READ_PARAM_INT();
-		
-		static char buff[32];
-		const char* name = nullptr;
-
-		if ((key >= '0' && key <= '9') ||
-			(key >= 'A' && key <= 'Z'))
-		{
-			// direct ASCII equivalent
-			buff[0] = (char)key;
-			buff[1] = '\0';
-			name = buff;
-		}
-		else if (key >= VK_F1 && key <= VK_F24)
-		{
-			CMessages::InsertNumberInString(TheText.Get("FEC_FNC"), key - VK_F1 + 1, 0, 0, 0, 0, 0, buff);
-			name = buff;
-		}
-		else if (key >= VK_NUMPAD0 && key <= VK_NUMPAD9)
-		{
-			CMessages::InsertNumberInString(TheText.Get("FEC_NMN"), key - VK_NUMPAD0, 0, 0, 0, 0, 0, buff);
-			name = buff;
-		}
-		else
-		{
-			// based on CInputEvents::getEventKeyName
-			switch(key)
-			{
-				case Key_Code_None: name = TheText.Get("FEC_UNB"); break;
-
-				case VK_LBUTTON: name = TheText.Get("FEC_MSL"); break;
-				case VK_RBUTTON: name = TheText.Get("FEC_MSR"); break; 
-				//case VK_CANCEL
-				case VK_MBUTTON: name = TheText.Get("FEC_MSM"); break;
-				case VK_XBUTTON1: name = TheText.Get("FEC_MXO"); break;
-				case VK_XBUTTON2: name = TheText.Get("FEC_MXT"); break;
-
-				case VK_BACK: name = TheText.Get("FEC_BSP"); break;
-				case VK_TAB: name = TheText.Get("FEC_TAB"); break;
-				case VK_CLEAR: name = "CLEAR"; break;
-				case VK_RETURN: name = TheText.Get("FEC_RTN"); break;
-				case VK_SHIFT: name = TheText.Get("FEC_SFT"); break;
-				case VK_CONTROL: name = "CTRL"; break;
-				case VK_MENU: name = "ALT"; break;
-				case VK_PAUSE: name = TheText.Get("FEC_PSB"); break; // FEC_PAS
-				case VK_CAPITAL: name = TheText.Get("FEC_CLK"); break;
-				//case VK_KANA
-				//case VK_IME_ON
-				//case VK_JUNJA
-				//case VK_FINAL
-				//case VK_HANJA
-				//case VK_IME_OFF
-				case VK_ESCAPE: name = "ESC"; break;
-				//case VK_CONVERT
-				//case VK_NONCONVERT
-				//case VK_ACCEPT
-				//case VK_MODECHANGE
-				case VK_SPACE: name = TheText.Get("FEC_SPC"); break;
-				case VK_PRIOR: name = TheText.Get("FEC_PGU"); break;
-				case VK_NEXT: name = TheText.Get("FEC_PGD"); break;
-				case VK_END: name = TheText.Get("FEC_END"); break;
-				case VK_HOME: name = TheText.Get("FEC_HME"); break;
-				case VK_LEFT: name = TheText.Get("FEC_LFA"); break;
-				case VK_UP: name = TheText.Get("FEC_UPA"); break;
-				case VK_RIGHT: name = TheText.Get("FEC_RFA"); break;
-				case VK_DOWN: name = TheText.Get("FEC_DWA"); break;
-				case VK_SELECT: name = "SELECT"; break;
-				case VK_PRINT: name = "PRINT"; break;
-				case VK_EXECUTE: name = "EXECUTE"; break;
-				case VK_SNAPSHOT: name = "PRTSCR"; break;
-				case VK_INSERT: name = TheText.Get("FEC_IRT"); break;
-				case VK_DELETE: name = TheText.Get("FEC_DLL"); break;
-				case VK_HELP: name = "HELP"; break;
-				case VK_LWIN: name = TheText.Get("FEC_LWD"); break;
-				case VK_RWIN: name = TheText.Get("FEC_RWD"); break;
-				case VK_APPS: name = TheText.Get("FEC_WRC"); break;
-
-				case '^': // German "double s" letter
-					buff[0] = '|';
-					buff[1] = '\0';
-					name = buff;
-				break;
-
-				case VK_SLEEP: name = "SLEEP"; break;
-				case VK_MULTIPLY: name = TheText.Get("FECSTAR"); break;
-				case VK_ADD: name = TheText.Get("FEC_PLS"); break;
-				//case VK_SEPARATOR ???
-				case VK_SUBTRACT: name = TheText.Get("FEC_MIN"); break;
-				case VK_DECIMAL: name = TheText.Get("FEC_DOT"); break;
-				case VK_DIVIDE: name = TheText.Get("FEC_FWS"); break;
-				//case VK_NAVIGATION_VIEW
-				//case VK_NAVIGATION_MENU
-				//case VK_NAVIGATION_UP
-				//case VK_NAVIGATION_DOWN
-				//case VK_NAVIGATION_LEFT
-				//case VK_NAVIGATION_RIGHT
-				//case VK_NAVIGATION_ACCEPT
-				//case VK_NAVIGATION_CANCEL
-				case VK_NUMLOCK: name = TheText.Get("FEC_NLK"); break;
-				case VK_SCROLL: name = TheText.Get("FEC_SLK"); break;
-				case VK_OEM_NEC_EQUAL: name = TheText.Get("FEC_ETR"); break;
-				//case VK_OEM_FJ_JISHO
-				//case VK_OEM_FJ_MASSHOU
-				//case VK_OEM_FJ_TOUROKU
-				//case VK_OEM_FJ_LOYA
-				//case VK_OEM_FJ_ROYA
-				case VK_LSHIFT: name = TheText.Get("FEC_LSF"); break;
-				case VK_RSHIFT: name = TheText.Get("FEC_RSF"); break;
-				case VK_LCONTROL: name = TheText.Get("FEC_LCT"); break;
-				case VK_RCONTROL: name = TheText.Get("FEC_RCT"); break;
-				case VK_LMENU:name = TheText.Get("FEC_LAL"); break;
-				case VK_RMENU:name = TheText.Get("FEC_RAL"); break;
-				//case VK_BROWSER_BACK
-				//case VK_BROWSER_FORWARD
-				//case VK_BROWSER_REFRESH
-				//case VK_BROWSER_STOP
-				//case VK_BROWSER_SEARCH
-				//case VK_BROWSER_FAVORITES
-				//case VK_BROWSER_HOME
-				//case VK_VOLUME_MUTE
-				//case VK_VOLUME_DOWN
-				//case VK_VOLUME_UP
-				//case VK_MEDIA_NEXT_TRACK
-				//case VK_MEDIA_PREV_TRACK
-				//case VK_MEDIA_STOP: in GTA some French letter?
-				//case VK_MEDIA_PLAY_PAUSE
-				//case VK_LAUNCH_MAIL
-				//case VK_LAUNCH_MEDIA_SELECT
-				//case VK_LAUNCH_APP1
-				//case VK_LAUNCH_APP2
-				case VK_OEM_1: name = ","; break;
-				case VK_OEM_PLUS: name = "="; break;
-				case VK_OEM_COMMA: name = ","; break;
-				case VK_OEM_MINUS: name = "-"; break;
-				case VK_OEM_PERIOD: name = "."; break;
-				case VK_OEM_2: name = "/"; break;
-				case VK_OEM_3: name = "`"; break;
-				//case VK_GAMEPAD_A
-				//case VK_GAMEPAD_B
-				//case VK_GAMEPAD_X
-				//case VK_GAMEPAD_Y
-				//case VK_GAMEPAD_RIGHT_SHOULDER
-				//case VK_GAMEPAD_LEFT_SHOULDER
-				//case VK_GAMEPAD_LEFT_TRIGGER
-				//case VK_GAMEPAD_RIGHT_TRIGGER
-				//case VK_GAMEPAD_DPAD_UP
-				//case VK_GAMEPAD_DPAD_DOWN
-				//case VK_GAMEPAD_DPAD_LEFT
-				//case VK_GAMEPAD_DPAD_RIGHT
-				//case VK_GAMEPAD_MENU
-				//case VK_GAMEPAD_VIEW
-				//case VK_GAMEPAD_LEFT_THUMBSTICK_BUTTON
-				//case VK_GAMEPAD_RIGHT_THUMBSTICK_BUTTON
-				//case VK_GAMEPAD_LEFT_THUMBSTICK_UP
-				//case VK_GAMEPAD_LEFT_THUMBSTICK_DOWN
-				//case VK_GAMEPAD_LEFT_THUMBSTICK_RIGHT
-				//case VK_GAMEPAD_LEFT_THUMBSTICK_LEFT
-				//case VK_GAMEPAD_RIGHT_THUMBSTICK_UP
-				//case VK_GAMEPAD_RIGHT_THUMBSTICK_DOWN
-				//case VK_GAMEPAD_RIGHT_THUMBSTICK_RIGHT
-				//case VK_GAMEPAD_RIGHT_THUMBSTICK_LEFT
-				case VK_OEM_4: name = "["; break;
-				case VK_OEM_5: name = "\\"; break;
-				case VK_OEM_6: name = "]"; break;
-				case VK_OEM_7: name = "'"; break;
-				//case VK_OEM_8
-				//case VK_OEM_AX
-				//case VK_OEM_102
-				//case VK_ICO_HELP
-				//case VK_ICO_00
-				//case VK_ICO_CLEAR
-				//case VK_PACKET
-				//case VK_OEM_RESET
-				//case VK_OEM_JUMP
-				//case VK_OEM_PA1
-				//case VK_OEM_PA2
-				//case VK_OEM_PA3
-				//case VK_OEM_WSCTRL
-				//case VK_OEM_CUSEL
-				//case VK_OEM_ATTN
-				//case VK_OEM_FINISH
-				//case VK_OEM_COPY
-				//case VK_OEM_AUTO
-				//case VK_OEM_ENLW
-				//case VK_OEM_BACKTAB
-				//case VK_OEM_BACKTAB
-				//case VK_ATTN
-				//case VK_CRSEL
-				//case VK_EXSEL
-				//case VK_EREOF
-				//case VK_PLAY
-				//case VK_ZOOM
-				//case VK_NONAME
-				//case VK_PA1
-				//case VK_OEM_CLEAR
-			}
-		}
-
-		if (name == nullptr)
-		{
-			OPCODE_SKIP_PARAMS(1);
-			OPCODE_CONDITION_RESULT(false);
-			return OR_CONTINUE;
-		}
-
-		OPCODE_WRITE_PARAM_STRING(name);
-		OPCODE_CONDITION_RESULT(true);
-		return OR_CONTINUE;
-	}
+    std::array<BYTE, Key_Code_Max + 1>* keyStatesCurr, *keyStatesPrev;
+
+    Input()
+    {
+        keyStatesCurr = new std::array<BYTE, Key_Code_Max + 1>();
+        keyStatesPrev = new std::array<BYTE, Key_Code_Max + 1>();
+
+        if (!PluginCheckCleoVersion()) return;
+
+        // register opcodes
+        CLEO_RegisterOpcode(0x0AB0, opcode_0AB0); // is_key_pressed
+        CLEO_RegisterOpcode(0x0ADC, opcode_0ADC); // test_cheat
+        CLEO_RegisterOpcode(0x2080, opcode_2080); // is_key_just_pressed
+        CLEO_RegisterOpcode(0x2081, opcode_2081); // get_key_pressed_in_range
+        CLEO_RegisterOpcode(0x2082, opcode_2082); // get_key_just_pressed_in_range
+        CLEO_RegisterOpcode(0x2083, opcode_2083); // emulate_key_press
+        CLEO_RegisterOpcode(0x2084, opcode_2084); // emulate_key_release
+        CLEO_RegisterOpcode(0x2085, opcode_2085); // get_controller_key
+        CLEO_RegisterOpcode(0x2086, opcode_2086); // get_key_name
+
+        // register event callbacks
+        CLEO_RegisterCallback(eCallbackId::GameProcessBefore, OnGameProcessBefore);
+        CLEO_RegisterCallback(eCallbackId::DrawingFinished, OnDrawingFinished);
+    }
+
+    ~Input()
+    {
+        delete keyStatesCurr;
+        delete keyStatesPrev;
+
+        CLEO_UnregisterCallback(eCallbackId::GameProcessBefore, OnGameProcessBefore);
+        CLEO_UnregisterCallback(eCallbackId::DrawingFinished, OnDrawingFinished);
+    }
+
+    // refresh keys info
+    void CheckKeyboard()
+    {
+        std::swap(keyStatesCurr, keyStatesPrev);
+        GetKeyboardState(keyStatesCurr->data());
+    }
+
+    static void SendKeyEvent(BYTE vKey, bool down)
+    {
+        INPUT input = { 0 };
+        if (vKey >= VK_LBUTTON && vKey <= VK_XBUTTON2) // mouse keys
+        {
+            input.type = INPUT_MOUSE;
+            switch (vKey)
+            {
+                case VK_LBUTTON: input.mi.dwFlags = down ? MOUSEEVENTF_LEFTDOWN : MOUSEEVENTF_LEFTUP; break;
+                case VK_MBUTTON: input.mi.dwFlags = down ? MOUSEEVENTF_MIDDLEDOWN : MOUSEEVENTF_MIDDLEUP; break;
+                case VK_RBUTTON: input.mi.dwFlags = down ? MOUSEEVENTF_RIGHTDOWN : MOUSEEVENTF_RIGHTUP; break;
+
+                case VK_XBUTTON1:
+                    input.mi.dwFlags = down ? MOUSEEVENTF_XDOWN : MOUSEEVENTF_XUP;
+                    input.mi.mouseData = XBUTTON1;
+                    break;
+
+                case VK_XBUTTON2:
+                    input.mi.dwFlags = down ? MOUSEEVENTF_XDOWN : MOUSEEVENTF_XUP;
+                    input.mi.mouseData = XBUTTON2;
+                    break;
+            }
+        }
+        else // keyboard
+        {
+            input.type = INPUT_KEYBOARD;
+            input.ki.wVk = vKey;
+            input.ki.dwFlags = down ? 0 : KEYEVENTF_KEYUP;
+
+            switch(vKey)
+            {
+                case VK_RETURN: // would be mapped to numpad's enter
+                case VK_LSHIFT: // maps to VK_SHIFT
+                case VK_LCONTROL: // maps to VK_CONTROL
+                case VK_LMENU: // maps to VK_MENU
+                    break; // do not use scan code
+
+                default:
+                    input.ki.wScan = MapVirtualKey(vKey, MAPVK_VK_TO_VSC_EX);
+                    input.ki.dwFlags |= KEYEVENTF_EXTENDEDKEY;
+            }
+        }
+
+        SendInput(1, &input, sizeof(input));
+    }
+
+    static void __stdcall OnGameProcessBefore()
+    {
+        g_instance.CheckKeyboard();
+    }
+
+    static void __stdcall OnDrawingFinished()
+    {
+        if (CTimer::m_UserPause) // main menu visible
+        {
+            g_instance.CheckKeyboard(); // update for ambient scripts running in menu
+        }
+    }
+
+    // is_key_pressed
+    // is_key_pressed {keyCode} [KeyCode] (logical)
+    static OpcodeResult __stdcall opcode_0AB0(CRunningScript* thread)
+    {
+        auto key = OPCODE_READ_PARAM_INT();
+
+        if (key == Key_Code_None)
+        {
+            OPCODE_CONDITION_RESULT(false);
+            return OR_CONTINUE;
+        }
+        if (key < 0 || key > Key_Code_Max)
+        {
+            LOG_WARNING(thread, "Invalid key code (%d) used in script %s", key, ScriptInfoStr(thread).c_str()); // legacy opcode, just warning
+            OPCODE_CONDITION_RESULT(false);
+            return OR_CONTINUE;
+        }
+
+        bool isDown = g_instance.keyStatesCurr->at(key) & Key_Flag_Down;
+
+        thread->SetConditionResult(isDown);
+        return OR_CONTINUE;
+    }
+
+    // test_cheat
+    // test_cheat {input} [string] (logical)
+    static OpcodeResult __stdcall opcode_0ADC(CRunningScript* thread)
+    {
+        OPCODE_READ_PARAM_STRING_LEN(text, sizeof(CCheat::m_CheatString));
+
+        auto len = strlen(_buff_text);
+        if (len == 0)
+        {
+            OPCODE_CONDITION_RESULT(false);
+            return OR_CONTINUE;
+        }
+
+        _strrev(_buff_text); // reverse
+        if (_strnicmp(_buff_text, CCheat::m_CheatString, len) != 0)
+        {
+            OPCODE_CONDITION_RESULT(false);
+            return OR_CONTINUE;
+        }
+
+        CCheat::m_CheatString[0] = '\0'; // consume the cheat
+        OPCODE_CONDITION_RESULT(true);
+        return OR_CONTINUE;
+    }
+
+    // is_key_just_pressed
+    // is_key_just_pressed {keyCode} [KeyCode] (logical)
+    static OpcodeResult __stdcall opcode_2080(CRunningScript* thread)
+    {
+        auto key = OPCODE_READ_PARAM_INT();
+
+        if (key == Key_Code_None)
+        {
+            OPCODE_CONDITION_RESULT(false);
+            return OR_CONTINUE;
+        }
+        if (key < 0 || key > Key_Code_Max)
+        {
+            SHOW_ERROR("Invalid key code (%d) used in script %s\nScript suspended.", key, ScriptInfoStr(thread).c_str());
+            return thread->Suspend();
+        }
+
+        bool wasDown = g_instance.keyStatesPrev->at(key) & Key_Flag_Down;
+        bool isDown = g_instance.keyStatesCurr->at(key) & Key_Flag_Down;
+
+        OPCODE_CONDITION_RESULT(!wasDown && isDown);
+        return OR_CONTINUE;
+    }
+
+    // get_key_pressed_in_range
+    // [var keyCode: KeyCode] = get_key_pressed_in_range {minKeyCode} [KeyCode] {maxKeyCode} [KeyCode] (logical)
+    static OpcodeResult __stdcall opcode_2081(CRunningScript* thread)
+    {
+        auto keyMin = OPCODE_READ_PARAM_INT();
+        auto keyMax = OPCODE_READ_PARAM_INT();
+
+        if (keyMin < 0 || keyMin > Key_Code_Max)
+        {
+            SHOW_ERROR("Invalid value (%d) of 'minKeyCode' argument in script %s\nScript suspended.", keyMin, ScriptInfoStr(thread).c_str());
+            return thread->Suspend();
+        }
+        if (keyMax < 0 || keyMax > Key_Code_Max || keyMax < keyMin)
+        {
+            SHOW_ERROR("Invalid value (%d) of 'maxKeyCode' argument in script %s\nScript suspended.", keyMin, ScriptInfoStr(thread).c_str());
+            return thread->Suspend();
+        }
+
+        for (auto key = keyMin; key <= keyMax; key++)
+        {
+            bool isDown = g_instance.keyStatesCurr->at(key) & Key_Flag_Down;
+
+            if (isDown)
+            {
+                OPCODE_WRITE_PARAM_INT(key);
+                OPCODE_CONDITION_RESULT(true);
+                return OR_CONTINUE;
+            }
+        }
+
+        OPCODE_SKIP_PARAMS(1); // no result
+        OPCODE_CONDITION_RESULT(false);
+        return OR_CONTINUE;
+    }
+
+    // get_key_just_pressed_in_range
+    // [var keyCode: KeyCode] = get_key_just_pressed_in_range {minKeyCode} [KeyCode] {maxKeyCode} [KeyCode] (logical)
+    static OpcodeResult __stdcall opcode_2082(CRunningScript* thread)
+    {
+        auto keyMin = OPCODE_READ_PARAM_INT();
+        auto keyMax = OPCODE_READ_PARAM_INT();
+
+        if (keyMin < 0 || keyMin > Key_Code_Max)
+        {
+            SHOW_ERROR("Invalid value (%d) of 'minKeyCode' argument in script %s\nScript suspended.", keyMin, ScriptInfoStr(thread).c_str());
+            return thread->Suspend();
+        }
+        if (keyMax < 0 || keyMax > Key_Code_Max || keyMax < keyMin)
+        {
+            SHOW_ERROR("Invalid value (%d) of 'maxKeyCode' argument in script %s\nScript suspended.", keyMin, ScriptInfoStr(thread).c_str());
+            return thread->Suspend();
+        }
+
+        for (auto key = keyMin; key <= keyMax; key++)
+        {
+            bool wasDown = g_instance.keyStatesPrev->at(key) & Key_Flag_Down;
+            bool isDown = g_instance.keyStatesCurr->at(key) & Key_Flag_Down;
+
+            if (!wasDown && isDown)
+            {
+                OPCODE_WRITE_PARAM_INT(key);
+                OPCODE_CONDITION_RESULT(true);
+                return OR_CONTINUE;
+            }
+        }
+
+        OPCODE_SKIP_PARAMS(1); // no result
+        OPCODE_CONDITION_RESULT(false);
+        return OR_CONTINUE;
+    }
+
+    // emulate_key_press
+    // emulate_key_press {keyCode} [KeyCode]
+    static OpcodeResult __stdcall opcode_2083(CRunningScript* thread)
+    {
+        auto key = OPCODE_READ_PARAM_INT();
+
+        if (key == Key_Code_None)
+        {
+            return OR_CONTINUE;
+        }
+        if (key < 0 || key > Key_Code_Max)
+        {
+            SHOW_ERROR("Invalid key code (%d) used in script %s\nScript suspended.", key, ScriptInfoStr(thread).c_str());
+            return thread->Suspend();
+        }
+
+        SendKeyEvent(key, true);
+
+        return OR_CONTINUE;
+    }
+
+    // emulate_key_release
+    // emulate_key_release {keyCode} [KeyCode]
+    static OpcodeResult __stdcall opcode_2084(CRunningScript* thread)
+    {
+        auto key = OPCODE_READ_PARAM_INT();
+
+        if (key == Key_Code_None)
+        {
+            return OR_CONTINUE;
+        }
+        if (key < 0 || key > Key_Code_Max)
+        {
+            SHOW_ERROR("Invalid key code (%d) used in script %s\nScript suspended.", key, ScriptInfoStr(thread).c_str());
+            return thread->Suspend();
+        }
+
+        SendKeyEvent(key, false);
+
+        return OR_CONTINUE;
+    }
+
+    // get_controller_key
+    // [var keyCode: KeyCode] = get_controller_key {action} [ControllerAction] {altKeyIdx} [int] (logical)
+    static OpcodeResult __stdcall opcode_2085(CRunningScript* thread)
+    {
+        auto actionId = OPCODE_READ_PARAM_INT();
+        auto altKeyIdx = OPCODE_READ_PARAM_INT();
+
+        if (actionId < 0 || actionId >= _countof(ControlsManager.m_actions))
+        {
+            SHOW_ERROR("Invalid value (%d) of 'action' argument in script %s\nScript suspended.", actionId, ScriptInfoStr(thread).c_str());
+            return thread->Suspend();
+        }
+        if (altKeyIdx < 0 || altKeyIdx >= _countof(CControllerAction::keys))
+        {
+            SHOW_ERROR("Invalid value (%d) of 'altKeyIdx' argument in script %s\nScript suspended.", actionId, ScriptInfoStr(thread).c_str());
+            return thread->Suspend();
+        }
+
+        auto& action = ControlsManager.m_actions[actionId];
+
+        // sort associated keys by priority
+        std::map<unsigned int, DWORD> mapping;
+        for (size_t i = 0; i < _countof(action.keys); i++)
+        {
+            auto& k = action.keys[i];
+
+            if (k.keyCode == 0 || k.priority == 0) // key not assigned
+                continue;
+
+            if (k.keyCode == rsMOUSEWHEELUPBUTTON || k.keyCode == rsMOUSEWHEELDOWNBUTTON)
+                continue; // there is no VK codes for mouse wheel rolling
+
+            mapping[k.priority] = k.keyCode;
+        }
+
+        if (mapping.size() <= (size_t)altKeyIdx)
+        {
+            OPCODE_SKIP_PARAMS(1); // no key assigned
+            OPCODE_CONDITION_RESULT(false);
+            return OR_CONTINUE;
+        }
+
+        // get the alt key code
+        auto it = std::next(mapping.begin(), altKeyIdx);
+        auto keyCode = it->second;
+
+        // translate RsKeyCode to VirtualKey
+        switch(keyCode)
+        {
+            case rsMOUSELEFTBUTTON: keyCode = VK_LBUTTON; break;
+            case rsMOUSEMIDDLEBUTTON: keyCode = VK_MBUTTON; break;
+            case rsMOUSERIGHTBUTTON: keyCode = VK_RBUTTON; break;
+            //case rsMOUSEWHEELUPBUTTON:
+            //case rsMOUSEWHEELDOWNBUTTON:
+            case rsMOUSEX1BUTTON: keyCode = VK_XBUTTON1; break;
+            case rsMOUSEX2BUTTON: keyCode = VK_XBUTTON2; break;
+
+            case rsESC: keyCode = VK_ESCAPE; break;
+
+            case rsF1: keyCode = VK_F1; break;
+            case rsF2: keyCode = VK_F2; break;
+            case rsF3: keyCode = VK_F3; break;
+            case rsF4: keyCode = VK_F4; break;
+            case rsF5: keyCode = VK_F5; break;
+            case rsF6: keyCode = VK_F6; break;
+            case rsF7: keyCode = VK_F7; break;
+            case rsF8: keyCode = VK_F8; break;
+            case rsF9: keyCode = VK_F9; break;
+            case rsF10: keyCode = VK_F10; break;
+            case rsF11: keyCode = VK_F11; break;
+            case rsF12: keyCode = VK_F12; break;
+
+            case rsINS: keyCode = VK_INSERT; break;
+            case rsDEL: keyCode = VK_DELETE; break;
+            case rsHOME: keyCode = VK_HOME; break;
+            case rsEND: keyCode = VK_END; break;
+            case rsPGUP: keyCode = VK_PRIOR; break;
+            case rsPGDN: keyCode = VK_NEXT; break;
+
+            case rsUP: keyCode = VK_UP; break;
+            case rsDOWN: keyCode = VK_DOWN; break;
+            case rsLEFT: keyCode = VK_LEFT; break;
+            case rsRIGHT: keyCode = VK_RIGHT; break;
+
+            case rsDIVIDE: keyCode = VK_DIVIDE; break;
+            case rsTIMES: keyCode = VK_MULTIPLY; break;
+            case rsPLUS: keyCode = VK_ADD; break;
+            case rsMINUS: keyCode = VK_SUBTRACT; break;
+            case rsPADDEL: keyCode = VK_DECIMAL; break;
+            case rsPADEND: keyCode = VK_NUMPAD1; break;
+            case rsPADDOWN: keyCode = VK_NUMPAD2; break;
+            case rsPADPGDN: keyCode = VK_NUMPAD3; break;
+            case rsPADLEFT: keyCode = VK_NUMPAD4; break;
+            case rsPAD5: keyCode = VK_NUMPAD5; break;
+            case rsNUMLOCK: keyCode = VK_NUMLOCK; break;
+            case rsPADRIGHT: keyCode = VK_NUMPAD6; break;
+            case rsPADHOME: keyCode = VK_NUMPAD7; break;
+            case rsPADUP: keyCode = VK_NUMPAD8; break;
+            case rsPADPGUP: keyCode = VK_NUMPAD9; break;
+            case rsPADINS: keyCode = VK_NUMPAD0; break;
+            case rsPADENTER: keyCode = VK_RETURN; break; // not quite same
+
+            case rsSCROLL: keyCode = VK_SCROLL; break;
+            case rsPAUSE: keyCode = VK_PAUSE; break;
+
+            case rsBACKSP: keyCode = VK_BACK; break;
+            case rsTAB: keyCode = VK_TAB; break;
+            case rsCAPSLK: keyCode = VK_CAPITAL; break;
+            case rsENTER: keyCode = VK_RETURN; break;
+            case rsLSHIFT: keyCode = VK_LSHIFT; break;
+            case rsRSHIFT: keyCode = VK_RSHIFT; break;
+            case rsSHIFT: keyCode = VK_SHIFT; break;
+            case rsLCTRL: keyCode = VK_LCONTROL; break;
+            case rsRCTRL: keyCode = VK_RCONTROL; break;
+            case rsLALT: keyCode = VK_LMENU; break;
+            case rsRALT: keyCode = VK_RMENU; break;
+            case rsLWIN: keyCode = VK_LWIN; break;
+            case rsRWIN: keyCode = VK_RWIN; break;
+            case rsAPPS: keyCode = VK_APPS; break;
+        }
+        
+        OPCODE_WRITE_PARAM_INT(keyCode);
+        OPCODE_CONDITION_RESULT(true);
+        return OR_CONTINUE;
+    }
+
+    // get_key_name
+    // [var name: string] = get_key_name {keyCode} [KeyCode] (logical)
+    static OpcodeResult __stdcall opcode_2086(CRunningScript* thread)
+    {
+        auto key = OPCODE_READ_PARAM_INT();
+        
+        static char buff[32];
+        const char* name = nullptr;
+
+        if ((key >= '0' && key <= '9') ||
+            (key >= 'A' && key <= 'Z'))
+        {
+            // direct ASCII equivalent
+            buff[0] = (char)key;
+            buff[1] = '\0';
+            name = buff;
+        }
+        else if (key >= VK_F1 && key <= VK_F24)
+        {
+            CMessages::InsertNumberInString(TheText.Get("FEC_FNC"), key - VK_F1 + 1, 0, 0, 0, 0, 0, buff);
+            name = buff;
+        }
+        else if (key >= VK_NUMPAD0 && key <= VK_NUMPAD9)
+        {
+            CMessages::InsertNumberInString(TheText.Get("FEC_NMN"), key - VK_NUMPAD0, 0, 0, 0, 0, 0, buff);
+            name = buff;
+        }
+        else
+        {
+            // based on CInputEvents::getEventKeyName
+            switch(key)
+            {
+                case Key_Code_None: name = TheText.Get("FEC_UNB"); break;
+
+                case VK_LBUTTON: name = TheText.Get("FEC_MSL"); break;
+                case VK_RBUTTON: name = TheText.Get("FEC_MSR"); break; 
+                //case VK_CANCEL
+                case VK_MBUTTON: name = TheText.Get("FEC_MSM"); break;
+                case VK_XBUTTON1: name = TheText.Get("FEC_MXO"); break;
+                case VK_XBUTTON2: name = TheText.Get("FEC_MXT"); break;
+
+                case VK_BACK: name = TheText.Get("FEC_BSP"); break;
+                case VK_TAB: name = TheText.Get("FEC_TAB"); break;
+                case VK_CLEAR: name = "CLEAR"; break;
+                case VK_RETURN: name = TheText.Get("FEC_RTN"); break;
+                case VK_SHIFT: name = TheText.Get("FEC_SFT"); break;
+                case VK_CONTROL: name = "CTRL"; break;
+                case VK_MENU: name = "ALT"; break;
+                case VK_PAUSE: name = TheText.Get("FEC_PSB"); break; // FEC_PAS
+                case VK_CAPITAL: name = TheText.Get("FEC_CLK"); break;
+                //case VK_KANA
+                //case VK_IME_ON
+                //case VK_JUNJA
+                //case VK_FINAL
+                //case VK_HANJA
+                //case VK_IME_OFF
+                case VK_ESCAPE: name = "ESC"; break;
+                //case VK_CONVERT
+                //case VK_NONCONVERT
+                //case VK_ACCEPT
+                //case VK_MODECHANGE
+                case VK_SPACE: name = TheText.Get("FEC_SPC"); break;
+                case VK_PRIOR: name = TheText.Get("FEC_PGU"); break;
+                case VK_NEXT: name = TheText.Get("FEC_PGD"); break;
+                case VK_END: name = TheText.Get("FEC_END"); break;
+                case VK_HOME: name = TheText.Get("FEC_HME"); break;
+                case VK_LEFT: name = TheText.Get("FEC_LFA"); break;
+                case VK_UP: name = TheText.Get("FEC_UPA"); break;
+                case VK_RIGHT: name = TheText.Get("FEC_RFA"); break;
+                case VK_DOWN: name = TheText.Get("FEC_DWA"); break;
+                case VK_SELECT: name = "SELECT"; break;
+                case VK_PRINT: name = "PRINT"; break;
+                case VK_EXECUTE: name = "EXECUTE"; break;
+                case VK_SNAPSHOT: name = "PRTSCR"; break;
+                case VK_INSERT: name = TheText.Get("FEC_IRT"); break;
+                case VK_DELETE: name = TheText.Get("FEC_DLL"); break;
+                case VK_HELP: name = "HELP"; break;
+                case VK_LWIN: name = TheText.Get("FEC_LWD"); break;
+                case VK_RWIN: name = TheText.Get("FEC_RWD"); break;
+                case VK_APPS: name = TheText.Get("FEC_WRC"); break;
+
+                case '^': // German "double s" letter
+                    buff[0] = '|';
+                    buff[1] = '\0';
+                    name = buff;
+                break;
+
+                case VK_SLEEP: name = "SLEEP"; break;
+                case VK_MULTIPLY: name = TheText.Get("FECSTAR"); break;
+                case VK_ADD: name = TheText.Get("FEC_PLS"); break;
+                //case VK_SEPARATOR ???
+                case VK_SUBTRACT: name = TheText.Get("FEC_MIN"); break;
+                case VK_DECIMAL: name = TheText.Get("FEC_DOT"); break;
+                case VK_DIVIDE: name = TheText.Get("FEC_FWS"); break;
+                //case VK_NAVIGATION_VIEW
+                //case VK_NAVIGATION_MENU
+                //case VK_NAVIGATION_UP
+                //case VK_NAVIGATION_DOWN
+                //case VK_NAVIGATION_LEFT
+                //case VK_NAVIGATION_RIGHT
+                //case VK_NAVIGATION_ACCEPT
+                //case VK_NAVIGATION_CANCEL
+                case VK_NUMLOCK: name = TheText.Get("FEC_NLK"); break;
+                case VK_SCROLL: name = TheText.Get("FEC_SLK"); break;
+                case VK_OEM_NEC_EQUAL: name = TheText.Get("FEC_ETR"); break;
+                //case VK_OEM_FJ_JISHO
+                //case VK_OEM_FJ_MASSHOU
+                //case VK_OEM_FJ_TOUROKU
+                //case VK_OEM_FJ_LOYA
+                //case VK_OEM_FJ_ROYA
+                case VK_LSHIFT: name = TheText.Get("FEC_LSF"); break;
+                case VK_RSHIFT: name = TheText.Get("FEC_RSF"); break;
+                case VK_LCONTROL: name = TheText.Get("FEC_LCT"); break;
+                case VK_RCONTROL: name = TheText.Get("FEC_RCT"); break;
+                case VK_LMENU:name = TheText.Get("FEC_LAL"); break;
+                case VK_RMENU:name = TheText.Get("FEC_RAL"); break;
+                //case VK_BROWSER_BACK
+                //case VK_BROWSER_FORWARD
+                //case VK_BROWSER_REFRESH
+                //case VK_BROWSER_STOP
+                //case VK_BROWSER_SEARCH
+                //case VK_BROWSER_FAVORITES
+                //case VK_BROWSER_HOME
+                //case VK_VOLUME_MUTE
+                //case VK_VOLUME_DOWN
+                //case VK_VOLUME_UP
+                //case VK_MEDIA_NEXT_TRACK
+                //case VK_MEDIA_PREV_TRACK
+                //case VK_MEDIA_STOP: in GTA some French letter?
+                //case VK_MEDIA_PLAY_PAUSE
+                //case VK_LAUNCH_MAIL
+                //case VK_LAUNCH_MEDIA_SELECT
+                //case VK_LAUNCH_APP1
+                //case VK_LAUNCH_APP2
+                case VK_OEM_1: name = ","; break;
+                case VK_OEM_PLUS: name = "="; break;
+                case VK_OEM_COMMA: name = ","; break;
+                case VK_OEM_MINUS: name = "-"; break;
+                case VK_OEM_PERIOD: name = "."; break;
+                case VK_OEM_2: name = "/"; break;
+                case VK_OEM_3: name = "`"; break;
+                //case VK_GAMEPAD_A
+                //case VK_GAMEPAD_B
+                //case VK_GAMEPAD_X
+                //case VK_GAMEPAD_Y
+                //case VK_GAMEPAD_RIGHT_SHOULDER
+                //case VK_GAMEPAD_LEFT_SHOULDER
+                //case VK_GAMEPAD_LEFT_TRIGGER
+                //case VK_GAMEPAD_RIGHT_TRIGGER
+                //case VK_GAMEPAD_DPAD_UP
+                //case VK_GAMEPAD_DPAD_DOWN
+                //case VK_GAMEPAD_DPAD_LEFT
+                //case VK_GAMEPAD_DPAD_RIGHT
+                //case VK_GAMEPAD_MENU
+                //case VK_GAMEPAD_VIEW
+                //case VK_GAMEPAD_LEFT_THUMBSTICK_BUTTON
+                //case VK_GAMEPAD_RIGHT_THUMBSTICK_BUTTON
+                //case VK_GAMEPAD_LEFT_THUMBSTICK_UP
+                //case VK_GAMEPAD_LEFT_THUMBSTICK_DOWN
+                //case VK_GAMEPAD_LEFT_THUMBSTICK_RIGHT
+                //case VK_GAMEPAD_LEFT_THUMBSTICK_LEFT
+                //case VK_GAMEPAD_RIGHT_THUMBSTICK_UP
+                //case VK_GAMEPAD_RIGHT_THUMBSTICK_DOWN
+                //case VK_GAMEPAD_RIGHT_THUMBSTICK_RIGHT
+                //case VK_GAMEPAD_RIGHT_THUMBSTICK_LEFT
+                case VK_OEM_4: name = "["; break;
+                case VK_OEM_5: name = "\\"; break;
+                case VK_OEM_6: name = "]"; break;
+                case VK_OEM_7: name = "'"; break;
+                //case VK_OEM_8
+                //case VK_OEM_AX
+                //case VK_OEM_102
+                //case VK_ICO_HELP
+                //case VK_ICO_00
+                //case VK_ICO_CLEAR
+                //case VK_PACKET
+                //case VK_OEM_RESET
+                //case VK_OEM_JUMP
+                //case VK_OEM_PA1
+                //case VK_OEM_PA2
+                //case VK_OEM_PA3
+                //case VK_OEM_WSCTRL
+                //case VK_OEM_CUSEL
+                //case VK_OEM_ATTN
+                //case VK_OEM_FINISH
+                //case VK_OEM_COPY
+                //case VK_OEM_AUTO
+                //case VK_OEM_ENLW
+                //case VK_OEM_BACKTAB
+                //case VK_OEM_BACKTAB
+                //case VK_ATTN
+                //case VK_CRSEL
+                //case VK_EXSEL
+                //case VK_EREOF
+                //case VK_PLAY
+                //case VK_ZOOM
+                //case VK_NONAME
+                //case VK_PA1
+                //case VK_OEM_CLEAR
+            }
+        }
+
+        if (name == nullptr)
+        {
+            OPCODE_SKIP_PARAMS(1);
+            OPCODE_CONDITION_RESULT(false);
+            return OR_CONTINUE;
+        }
+
+        OPCODE_WRITE_PARAM_STRING(name);
+        OPCODE_CONDITION_RESULT(true);
+        return OR_CONTINUE;
+    }
 
 } g_instance;
 

--- a/cleo_plugins/Text/CTextManager.cpp
+++ b/cleo_plugins/Text/CTextManager.cpp
@@ -142,11 +142,11 @@ namespace CLEO
             stream.getline(buf, sizeof(buf));
             if (stream.fail()) break;
 
-            // parse extracted line	
+            // parse extracted line
             key_start = key_iterator = buf;
             while (*key_iterator)
             {
-                if (*key_iterator == '#')	// start of comment
+                if (*key_iterator == '#') // start of comment
                     break;
                 if (*key_iterator == '/' && key_iterator[1] == '/') // comment
                     break;

--- a/cleo_plugins/Text/Text.cpp
+++ b/cleo_plugins/Text/Text.cpp
@@ -18,621 +18,621 @@ using namespace plugin;
 class Text
 {
 public:
-	static ScriptDrawing scriptDrawing;
-	static CTextManager textManager;
-	
-	static char msgBuffLow[MAX_STR_LEN + 1];
-	static char msgBuffHigh[MAX_STR_LEN + 1];
-	static const size_t MsgBigStyleCount = 7;
-	static char msgBuffBig[MsgBigStyleCount][MAX_STR_LEN + 1];
-
-	static WORD genericLabelCounter;
-
-	bool m_initialized = false;
-	MemPatch m_patchCTextGet;
-
-	Text()
-	{
-		if (!PluginCheckCleoVersion()) return;
-
-		//register opcodes
-		CLEO_RegisterOpcode(0x0ACA, opcode_0ACA); // print_help_string
-		CLEO_RegisterOpcode(0x0ACB, opcode_0ACB); // print_big_string
-		CLEO_RegisterOpcode(0x0ACC, opcode_0ACC); // print_string
-		CLEO_RegisterOpcode(0x0ACD, opcode_0ACD); // print_string_now
-		CLEO_RegisterOpcode(0x0ACE, opcode_0ACE); // print_help_formatted
-		CLEO_RegisterOpcode(0x0ACF, opcode_0ACF); // print_big_formatted
-		CLEO_RegisterOpcode(0x0AD0, opcode_0AD0); // print_formatted
-		CLEO_RegisterOpcode(0x0AD1, opcode_0AD1); // print_formatted_now
-
-		CLEO_RegisterOpcode(0x0AD3, opcode_0AD3); // string_format
-		CLEO_RegisterOpcode(0x0AD4, opcode_0AD4); // scan_string
-		CLEO_RegisterOpcode(0x0ADB, opcode_0ADB); // get_name_of_vehicle_model
-							    
-		CLEO_RegisterOpcode(0x0ADE, opcode_0ADE); // get_text_label_string
-		CLEO_RegisterOpcode(0x0ADF, opcode_0ADF); // add_text_label
-		CLEO_RegisterOpcode(0x0AE0, opcode_0AE0); // remove_text_label
-							    
-		CLEO_RegisterOpcode(0x0AED, opcode_0AED); // string_float_format
-
-		CLEO_RegisterOpcode(0x2600, opcode_2600); // is_text_empty
-		CLEO_RegisterOpcode(0x2601, opcode_2601); // is_text_equal
-		CLEO_RegisterOpcode(0x2602, opcode_2602); // is_text_in_text
-		CLEO_RegisterOpcode(0x2603, opcode_2603); // is_text_prefix
-		CLEO_RegisterOpcode(0x2604, opcode_2604); // is_text_sufix
-		CLEO_RegisterOpcode(0x2605, opcode_2605); // display_text_formatted
-		CLEO_RegisterOpcode(0x2606, opcode_2606); // load_fxt
-		CLEO_RegisterOpcode(0x2607, opcode_2607); // unload_fxt
-		CLEO_RegisterOpcode(0x2608, opcode_2608); // get_text_length
-		CLEO_RegisterOpcode(0x2609, opcode_2609); // add_text_label_formatted
-
-		// register event callbacks
-		CLEO_RegisterCallback(eCallbackId::GameBegin, OnGameBegin);
-		CLEO_RegisterCallback(eCallbackId::GameProcessBefore, OnGameProcessBefore);
-		CLEO_RegisterCallback(eCallbackId::GameEnd, OnGameEnd);
-
-		CLEO_RegisterCallback(eCallbackId::ScriptProcessBefore, OnScriptBeforeProcess);
-		CLEO_RegisterCallback(eCallbackId::ScriptProcessAfter, OnScriptAfterProcess);
-		CLEO_RegisterCallback(eCallbackId::ScriptUnregister, OnScriptUnregister);
-		CLEO_RegisterCallback(eCallbackId::ScriptDraw, OnScriptDraw);
-		CLEO_RegisterCallback(eCallbackId::DrawingFinished, OnDrawingFinished);
-	}
-
-	~Text()
-	{
-		CLEO_UnregisterCallback(eCallbackId::GameBegin, OnGameBegin);
-		CLEO_UnregisterCallback(eCallbackId::GameProcessBefore, OnGameProcessBefore);
-		CLEO_UnregisterCallback(eCallbackId::GameEnd, OnGameEnd);
-
-		CLEO_UnregisterCallback(eCallbackId::ScriptProcessBefore, OnScriptBeforeProcess);
-		CLEO_UnregisterCallback(eCallbackId::ScriptProcessAfter, OnScriptAfterProcess);
-		CLEO_UnregisterCallback(eCallbackId::ScriptUnregister, OnScriptUnregister);
-		CLEO_UnregisterCallback(eCallbackId::ScriptDraw, OnScriptDraw);
-		CLEO_UnregisterCallback(eCallbackId::DrawingFinished, OnDrawingFinished);
-		
-		m_patchCTextGet.Apply(); // undo hook
-	}
-
-	static void __stdcall OnGameBegin(DWORD saveSlot)
-	{
-		textManager.LoadFxts();
-	}
-
-	static void __stdcall OnGameProcessBefore()
-	{
-		genericLabelCounter = 0;
-	}
-
-	static void __stdcall OnGameEnd()
-	{
-		textManager.Clear();
-	}
-
-	static bool __stdcall OnScriptBeforeProcess(CLEO::CRunningScript* pScript)
-	{
-		scriptDrawing.ScriptProcessingBegin(pScript);
-		return true;
-	}
-
-	static void __stdcall OnScriptAfterProcess(CLEO::CRunningScript* pScript)
-	{
-		scriptDrawing.ScriptProcessingEnd(pScript);
-	}
-
-	static void __stdcall OnScriptUnregister(CLEO::CRunningScript* pScript)
-	{
-		scriptDrawing.ScriptUnregister(pScript);
-	}
-
-	static void __stdcall OnScriptDraw(bool beforeFade)
-	{
-		scriptDrawing.Draw(beforeFade);
-	}
-
-	static void WINAPI OnDrawingFinished()
-	{
-		// late initialization
-		if (!instance.m_initialized)
-		{
-			instance.m_patchCTextGet = MemPatchJump(gaddrof(CText::Get), &HOOK_CTextGet);
-
-			instance.m_initialized = true;
-		}
-	}
-
-	// hook of game's CText::Get
-	static const char* __fastcall HOOK_CTextGet(CText* text, int dummy, const char* gxt)
-	{
-		if ((gxt[0] == '\0') || (gxt[0] == ' ')) return "";
-
-		// check CLEO's texts
-		auto result = Text::textManager.LocateFxt(gxt);
-		if (result != nullptr) return result;
-
-		// call original function
-		instance.m_patchCTextGet.Apply(); // restore original function code
-		result = text->Get(gxt);
-		MemPatchJump(gaddrof(CText::Get), &HOOK_CTextGet); // reinstall our hook
-
-		return result;
-	}
-
-	//0ACA=1,show_text_box %1d%
-	static OpcodeResult __stdcall opcode_0ACA(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING(text);
-
-		CHud::SetHelpMessage(text, true, false, false);
-		return OR_CONTINUE;
-	}
-
-	//0ACB=3,show_styled_text %1d% time %2d% style %3d%
-	static OpcodeResult __stdcall opcode_0ACB(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING(text);
-		auto time = OPCODE_READ_PARAM_INT();
-		auto style = OPCODE_READ_PARAM_INT();
-
-		auto styleIdx = std::clamp(style, 0, (int)MsgBigStyleCount - 1);
-		strncpy_s(msgBuffBig[styleIdx], text, sizeof(msgBuffBig[styleIdx]));
-		CMessages::AddBigMessage(msgBuffBig[styleIdx], time, style - 1);
-		return OR_CONTINUE;
-	}
-
-	//0ACC=2,show_text_lowpriority %1d% time %2d%
-	static OpcodeResult __stdcall opcode_0ACC(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING(text);
-		auto time = OPCODE_READ_PARAM_INT();
-
-		strncpy_s(msgBuffLow, text, sizeof(msgBuffLow));
-		CMessages::AddMessage(msgBuffLow, time, false, false);
-		return OR_CONTINUE;
-	}
-
-	//0ACD=2,show_text_highpriority %1d% time %2d%
-	static OpcodeResult __stdcall opcode_0ACD(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING(text);
-		auto time = OPCODE_READ_PARAM_INT();
-
-		strncpy_s(msgBuffHigh, text, sizeof(msgBuffHigh));
-		CMessages::AddMessageJumpQ(msgBuffHigh, time, false, false);
-		return OR_CONTINUE;
-	}
-
-	//0ACE=-1,show_formatted_text_box %1d%
-	static OpcodeResult __stdcall opcode_0ACE(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING_FORMATTED(text);
-
-		CHud::SetHelpMessage(text, true, false, false);
-		return OR_CONTINUE;
-	}
-
-	//0ACF=-1,show_formatted_styled_text %1d% time %2d% style %3d%
-	static OpcodeResult __stdcall opcode_0ACF(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING(format);
-		auto time = OPCODE_READ_PARAM_INT();
-		auto style = OPCODE_READ_PARAM_INT();
-		OPCODE_READ_PARAMS_FORMATTED(format, text);
-
-		auto styleIdx = std::clamp(style, 0, (int)MsgBigStyleCount - 1);
-		strncpy_s(msgBuffBig[styleIdx], text, sizeof(msgBuffBig[styleIdx]));
-		CMessages::AddBigMessage(msgBuffBig[styleIdx], time, style - 1);
-		return OR_CONTINUE;
-	}
-
-	//0AD0=-1,show_formatted_text_lowpriority %1d% time %2d%
-	static OpcodeResult __stdcall opcode_0AD0(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING(format);
-		auto time = OPCODE_READ_PARAM_INT();
-		OPCODE_READ_PARAMS_FORMATTED(format, text);
-
-		strncpy_s(msgBuffLow, text, sizeof(msgBuffLow));
-		CMessages::AddMessage(msgBuffLow, time, false, false);
-		return OR_CONTINUE;
-	}
-
-	//0AD1=-1,show_formatted_text_highpriority %1d% time %2d%
-	static OpcodeResult __stdcall opcode_0AD1(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING(format);
-		auto time = OPCODE_READ_PARAM_INT();
-		OPCODE_READ_PARAMS_FORMATTED(format, text);
-
-		strncpy_s(msgBuffHigh, text, sizeof(msgBuffHigh));
-		CMessages::AddMessageJumpQ(msgBuffHigh, time, false, false);
-		return OR_CONTINUE;
-	}
-
-	//0AD3=-1,string %1d% format %2d% ...
-	static OpcodeResult __stdcall opcode_0AD3(CLEO::CRunningScript* thread)
-	{
-		auto result = OPCODE_READ_PARAM_OUTPUT_VAR_STRING();
-		OPCODE_READ_PARAM_STRING_FORMATTED(text);
-
-		OPCODE_WRITE_PARAM_VAR_STRING(result, text);
-		return OR_CONTINUE;
-	}
-
-	//0AD4=-1,%3d% = scan_string %1d% format %2d%  //IF and SET
-	static OpcodeResult __stdcall opcode_0AD4(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING(src);
-		OPCODE_READ_PARAM_STRING(format);
-
-		auto readCount = OPCODE_READ_PARAM_OUTPUT_VAR_INT(); // store_to
-
-		// format string tokens processing helper
-		const char* formatPos = format;
-		auto GetNextTokenType = [&]()
-		{
-			while (true)
-			{
-				if (*formatPos == '\0') return DT_END;
-
-				if (*formatPos == '%') // formatting sequence start
-				{
-					if (formatPos[1] == '%' || // escaped % character
-						formatPos[1] == '*') // sscanf non-capturing token
-					{
-						formatPos += 2;
-						continue;
-					}
-
-					while (true)
-					{
-						formatPos++; // next char
-						if (*formatPos == '\0')
-						{
-							SHOW_ERROR("Invalid string format sequence ('%s') in script %s\nScript suspended.", format, ScriptInfoStr(thread).c_str());
-							return DT_INVALID;
-						}
-
-						// width specification
-						if (*formatPos >= '0' && *formatPos <= '9')
-						{
-							formatPos++;
-							continue;
-						}
-
-						switch(*formatPos)
-						{
-							case 's': return DT_STRING;
-							default: return DT_VAR; // any32. TODO: actually parse and verify other types?
-						}
-					}
-				}
-
-				formatPos++;
-			}
-		};
-
-		// collect provided by caller store_to variables
-		size_t outputParamCount = 0;
-		SCRIPT_VAR* outputParams[35];
-		struct StringParamDesc
-		{
-			bool used = false;
-			StringParamBufferInfo target;
-			std::string str;
-		} stringParams[35];
-
-		for (int i = 0; i < 35; i++)
-		{
-			auto paramType = thread->PeekDataType();
-
-			auto formatTokenType = GetNextTokenType();
-			if (formatTokenType == DT_INVALID) return thread->Suspend(); // error message already displayed
-
-			if (paramType == DT_END)
-			{
-				if (formatTokenType != DT_END && !IsLegacyScript(thread))
-				{
-					SHOW_ERROR("More tokens in format string than return variables in script %s\nScript suspended.", format, ScriptInfoStr(thread).c_str());
-					return thread->Suspend();
-				}
-				break;
-			}
-
-			if (formatTokenType == DT_END && !IsLegacyScript(thread))
-			{
-				SHOW_ERROR("More return variables than tokens in format string in script %s\nScript suspended.", format, ScriptInfoStr(thread).c_str());
-				return thread->Suspend();
-			}
-
-			if (IsVarString(paramType))
-			{
-				if (IsLegacyScript(thread))
-				{
-					// older CLEOs did not carred about string variable size limitations
-					// just give pointer to the variable's data and allow overflow depending on input data
-					outputParams[i] = CLEO_GetPointerToScriptVariable(thread);
-				}
-				else
-				{
-					stringParams[i].used = true;
-					stringParams[i].target = OPCODE_READ_PARAM_OUTPUT_VAR_STRING();
-
-					stringParams[i].str.resize(MAX_STR_LEN); // temp storage
-					outputParams[i] = (SCRIPT_VAR*)stringParams[i].str.data();
-				}
-			}
-			else if (formatTokenType == DT_STRING) // `%s`
-			{
-				auto ptr = OPCODE_READ_PARAM_PTR();
-				outputParams[i] = (SCRIPT_VAR*)ptr;
-			}
-			else
-			{
-				outputParams[i] = OPCODE_READ_PARAM_OUTPUT_VAR_ANY32();
-			}
-
-			outputParamCount++;
-		}
-		CLEO_SkipUnusedVarArgs(thread); // and var args terminator
-
-		#pragma warning(suppress: 4996) // sscanf_s would expect additional arg after each %s arg
-		*readCount = sscanf(src, format,
-			outputParams[0], outputParams[1], outputParams[2], outputParams[3], outputParams[4], outputParams[5],
-			outputParams[6], outputParams[7], outputParams[8], outputParams[9], outputParams[10], outputParams[11],
-			outputParams[12], outputParams[13], outputParams[14], outputParams[15], outputParams[16], outputParams[17],
-			outputParams[18], outputParams[19], outputParams[20], outputParams[21], outputParams[22], outputParams[23],
-			outputParams[24], outputParams[25], outputParams[26], outputParams[27], outputParams[28], outputParams[29],
-			outputParams[30], outputParams[31], outputParams[32], outputParams[33], outputParams[34]);
-
-		// transfer string params to target variables
-		for (auto& p : stringParams)
-		{
-			if (p.used) OPCODE_WRITE_PARAM_VAR_STRING(p.target, p.str.c_str());
-		}
-
-		OPCODE_CONDITION_RESULT(outputParamCount == *readCount);
-		return OR_CONTINUE;
-	}
-
-	//0ADB=2,%2d% = car_model %1d% name
-	static OpcodeResult __stdcall opcode_0ADB(CLEO::CRunningScript* thread)
-	{
-		auto modelIndex = OPCODE_READ_PARAM_UINT();
-
-		CVehicleModelInfo* model;
-		// if 1.0 US, prefer GetModelInfo function  makes it compatible with fastman92's limit adjuster
-		if (CLEO_GetGameVersion() == CLEO::GV_US10)
-			model = plugin::CallAndReturn<CVehicleModelInfo*, 0x403DA0, int>(modelIndex);
-		else
-			model = reinterpret_cast<CVehicleModelInfo*>(CModelInfo::ms_modelInfoPtrs[modelIndex]);
-
-		auto str = std::string(std::string_view(model->m_szGameName, sizeof(model->m_szGameName))); // to proper cstr
-
-		OPCODE_WRITE_PARAM_STRING(str.c_str());
-		return OR_CONTINUE;
-	}
-
-	//0ADE=2,%2d% = text_by_GXT_entry %1d%
-	static OpcodeResult __stdcall opcode_0ADE(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING_LEN(gxt, 7); // GXT labels can be max 7 character long
-
-		auto txt = textManager.Get(gxt);
-
-		if (IsVarString(thread->PeekDataType()))
-		{
-			OPCODE_WRITE_PARAM_STRING(txt);
-		}
-		else
-		{
-			OPCODE_WRITE_PARAM_PTR(txt); // address of the text
-		}
-		return OR_CONTINUE;
-	}
-
-	//0ADF=2,add_dynamic_GXT_entry %1d% text %2d%
-	static OpcodeResult __stdcall opcode_0ADF(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING_LEN(gxt, 7); // GXT labels can be max 7 character long
-		OPCODE_READ_PARAM_STRING(txt);
-
-		textManager.AddFxt(gxt, txt);
-		return OR_CONTINUE;
-	}
-
-	//0AE0=1,remove_dynamic_GXT_entry %1d%
-	static OpcodeResult __stdcall opcode_0AE0(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING_LEN(gxt, 7); // GXT labels can be max 7 character long
-
-		textManager.RemoveFxt(gxt);
-		return OR_CONTINUE;
-	}
-
-	//0AED=3,%3d% = float %1d% to_string_format %2d%
-	static OpcodeResult __stdcall opcode_0AED(CLEO::CRunningScript* thread)
-	{
-		// this opcode is useless now
-		auto val = OPCODE_READ_PARAM_FLOAT();
-		OPCODE_READ_PARAM_STRING(format);
-
-		char result[32];
-		sprintf_s(result, sizeof(result), format, val);
-
-		OPCODE_WRITE_PARAM_STRING(result);
-		return OR_CONTINUE;
-	}
-
-	//2600=1,  is_text_empty %1s%
-	static OpcodeResult __stdcall opcode_2600(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING(str);
-
-		OPCODE_CONDITION_RESULT(str[0] == '\0');
-		return OR_CONTINUE;
-	}
-
-	//2601=3,  is_text_equal %1s% another %2s% ignore_case %3d%
-	static OpcodeResult __stdcall opcode_2601(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING(a);
-		OPCODE_READ_PARAM_STRING(b);
-		auto ignoreCase = OPCODE_READ_PARAM_BOOL();
-
-		auto result = ignoreCase ? _stricmp(a, b) : strcmp(a, b);
-
-		OPCODE_CONDITION_RESULT(result == 0);
-		return OR_CONTINUE;
-	}
-
-	//2602=3,  is_text_in_text %1s% sub_text %2s% ignore_case %3d%
-	static OpcodeResult __stdcall opcode_2602(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING(str);
-		OPCODE_READ_PARAM_STRING(substr);
-		auto ignoreCase = OPCODE_READ_PARAM_BOOL();
-
-		if (substr[0] == '\0')
-		{
-			OPCODE_CONDITION_RESULT(true);
-			return OR_CONTINUE;
-		}
-
-		auto result = ignoreCase ? StrStrIA(str, substr) : strstr(str, substr);
-
-		OPCODE_CONDITION_RESULT(result != nullptr);
-		return OR_CONTINUE;
-	}
-
-	//2603=3,  is_text_prefix %1s% prefix %2s% ignore_case %3d%
-	static OpcodeResult __stdcall opcode_2603(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING(str);
-		OPCODE_READ_PARAM_STRING(prefix);
-		auto ignoreCase = OPCODE_READ_PARAM_BOOL();
-
-		auto prefixLen = strlen(prefix);
-		auto result = ignoreCase ? _strnicmp(str, prefix, prefixLen) : strncmp(str, prefix, prefixLen);
-
-		OPCODE_CONDITION_RESULT(result == 0);
-		return OR_CONTINUE;
-	}
-
-	//2604=3,  is_text_sufix %1s% sufix %2s% ignore_case %3d%
-	static OpcodeResult __stdcall opcode_2604(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING(str);
-		OPCODE_READ_PARAM_STRING(sufix);
-		auto ignoreCase = OPCODE_READ_PARAM_BOOL();
-
-		auto strLen = strlen(str);
-		auto sufixLen = strlen(sufix);
-
-		if (sufixLen > strLen)
-		{
-			OPCODE_CONDITION_RESULT(false);
-			return OR_CONTINUE;
-		}
-
-		auto offset = strLen - sufixLen;
-		auto result = ignoreCase ? _stricmp(str + offset, sufix) : strcmp(str + offset, sufix);
-
-		OPCODE_CONDITION_RESULT(result == 0);
-		return OR_CONTINUE;
-	}
-
-	//2605=-1,display_text_formatted offset_left %1d% offset_top %2d% format %3d% args
-	static OpcodeResult __stdcall opcode_2605(CLEO::CRunningScript* thread)
-	{
-		auto posX = OPCODE_READ_PARAM_FLOAT();
-		auto posY = OPCODE_READ_PARAM_FLOAT();
-		OPCODE_READ_PARAM_STRING_FORMATTED(text);
-
-		if (CTheScripts::NumberOfIntroTextLinesThisFrame >= 0x60) // GTA SA CTheScripts::IntroTextLines capacity
-		{
-			LOG_WARNING(thread, "Display text limit (%d) exceeded in script %s", 0x60, ScriptInfoStr(thread).c_str());
-			return OR_CONTINUE;
-		}
-
-		// new generic GXT label
-		// includes unprintable character, to ensure there will be no collision with user GXT labels
-		char gxt[9] = { 0x01, 'C', 'L', 'E', 0x00, 0x00, 0x00, 0x00, 0x00 }; // enough space for even worst case scenario
-		_itoa_s(genericLabelCounter, gxt + 4, sizeof(gxt) - 4, 36); // 0xFFFF -> "1ekf"
-		genericLabelCounter++;
-
-		textManager.AddFxt(gxt, text);
-
-		auto& draw = CTheScripts::IntroTextLines[CTheScripts::NumberOfIntroTextLinesThisFrame];
-		memcpy(&draw.xPosition, &posX, sizeof(draw.xPosition)); // invalid type in Plugin SDK. Just copy memory
-		memcpy(&draw.yPosition, &posY, sizeof(draw.yPosition));
-		strcpy_s(draw.text, gxt);
-
-		CTheScripts::NumberOfIntroTextLinesThisFrame++;
-
-		return OR_CONTINUE;
-	}
-
-	//2606=1,  load_fxt %1d%
-	static OpcodeResult __stdcall opcode_2606(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_FILEPATH(filename);
-
-		size_t added = 0;
-		try
-		{
-			std::ifstream stream(filename);
-			added = textManager.ParseFxtFile(stream, true, false);
-		}
-		catch (std::exception& ex)
-		{
-			LOG_WARNING(0, "Loading of FXT file '%s' failed: \n%s", filename, ex.what());
-		}
-
-		OPCODE_CONDITION_RESULT(added != 0);
-		return OR_CONTINUE;
-	}
-
-	//2607=1,  unload_fxt %1d%
-	static OpcodeResult __stdcall opcode_2607(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_FILEPATH(filename);
-
-		size_t removed = 0;
-		try
-		{
-			std::ifstream stream(filename);
-			removed = textManager.ParseFxtFile(stream, true, true);
-		}
-		catch (std::exception& ex)
-		{
-			LOG_WARNING(0, "Unloading of FXT file '%s' failed: \n%s", filename, ex.what());
-		}
-
-		OPCODE_CONDITION_RESULT(removed != 0);
-		return OR_CONTINUE;
-	}
-
-	//2608=3,get_text_length %1d% store_to %2d%
-	static OpcodeResult __stdcall opcode_2608(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING(str);
-
-		auto result = strlen(str);
-
-		OPCODE_WRITE_PARAM_INT(result);
-		return OR_CONTINUE;
-	}
-
-	//2609=-1,add_text_label_formatted %1d% args %2d% 
-	static OpcodeResult __stdcall opcode_2609(CLEO::CRunningScript* thread)
-	{
-		OPCODE_READ_PARAM_STRING_LEN(gxt, 7); // GXT labels can be max 7 character long
-		OPCODE_READ_PARAM_STRING_FORMATTED(str);
-
-		textManager.AddFxt(gxt, str);
-
-		return OR_CONTINUE;
-	}
+    static ScriptDrawing scriptDrawing;
+    static CTextManager textManager;
+    
+    static char msgBuffLow[MAX_STR_LEN + 1];
+    static char msgBuffHigh[MAX_STR_LEN + 1];
+    static const size_t MsgBigStyleCount = 7;
+    static char msgBuffBig[MsgBigStyleCount][MAX_STR_LEN + 1];
+
+    static WORD genericLabelCounter;
+
+    bool m_initialized = false;
+    MemPatch m_patchCTextGet;
+
+    Text()
+    {
+        if (!PluginCheckCleoVersion()) return;
+
+        //register opcodes
+        CLEO_RegisterOpcode(0x0ACA, opcode_0ACA); // print_help_string
+        CLEO_RegisterOpcode(0x0ACB, opcode_0ACB); // print_big_string
+        CLEO_RegisterOpcode(0x0ACC, opcode_0ACC); // print_string
+        CLEO_RegisterOpcode(0x0ACD, opcode_0ACD); // print_string_now
+        CLEO_RegisterOpcode(0x0ACE, opcode_0ACE); // print_help_formatted
+        CLEO_RegisterOpcode(0x0ACF, opcode_0ACF); // print_big_formatted
+        CLEO_RegisterOpcode(0x0AD0, opcode_0AD0); // print_formatted
+        CLEO_RegisterOpcode(0x0AD1, opcode_0AD1); // print_formatted_now
+
+        CLEO_RegisterOpcode(0x0AD3, opcode_0AD3); // string_format
+        CLEO_RegisterOpcode(0x0AD4, opcode_0AD4); // scan_string
+        CLEO_RegisterOpcode(0x0ADB, opcode_0ADB); // get_name_of_vehicle_model
+                                
+        CLEO_RegisterOpcode(0x0ADE, opcode_0ADE); // get_text_label_string
+        CLEO_RegisterOpcode(0x0ADF, opcode_0ADF); // add_text_label
+        CLEO_RegisterOpcode(0x0AE0, opcode_0AE0); // remove_text_label
+                                
+        CLEO_RegisterOpcode(0x0AED, opcode_0AED); // string_float_format
+
+        CLEO_RegisterOpcode(0x2600, opcode_2600); // is_text_empty
+        CLEO_RegisterOpcode(0x2601, opcode_2601); // is_text_equal
+        CLEO_RegisterOpcode(0x2602, opcode_2602); // is_text_in_text
+        CLEO_RegisterOpcode(0x2603, opcode_2603); // is_text_prefix
+        CLEO_RegisterOpcode(0x2604, opcode_2604); // is_text_sufix
+        CLEO_RegisterOpcode(0x2605, opcode_2605); // display_text_formatted
+        CLEO_RegisterOpcode(0x2606, opcode_2606); // load_fxt
+        CLEO_RegisterOpcode(0x2607, opcode_2607); // unload_fxt
+        CLEO_RegisterOpcode(0x2608, opcode_2608); // get_text_length
+        CLEO_RegisterOpcode(0x2609, opcode_2609); // add_text_label_formatted
+
+        // register event callbacks
+        CLEO_RegisterCallback(eCallbackId::GameBegin, OnGameBegin);
+        CLEO_RegisterCallback(eCallbackId::GameProcessBefore, OnGameProcessBefore);
+        CLEO_RegisterCallback(eCallbackId::GameEnd, OnGameEnd);
+
+        CLEO_RegisterCallback(eCallbackId::ScriptProcessBefore, OnScriptBeforeProcess);
+        CLEO_RegisterCallback(eCallbackId::ScriptProcessAfter, OnScriptAfterProcess);
+        CLEO_RegisterCallback(eCallbackId::ScriptUnregister, OnScriptUnregister);
+        CLEO_RegisterCallback(eCallbackId::ScriptDraw, OnScriptDraw);
+        CLEO_RegisterCallback(eCallbackId::DrawingFinished, OnDrawingFinished);
+    }
+
+    ~Text()
+    {
+        CLEO_UnregisterCallback(eCallbackId::GameBegin, OnGameBegin);
+        CLEO_UnregisterCallback(eCallbackId::GameProcessBefore, OnGameProcessBefore);
+        CLEO_UnregisterCallback(eCallbackId::GameEnd, OnGameEnd);
+
+        CLEO_UnregisterCallback(eCallbackId::ScriptProcessBefore, OnScriptBeforeProcess);
+        CLEO_UnregisterCallback(eCallbackId::ScriptProcessAfter, OnScriptAfterProcess);
+        CLEO_UnregisterCallback(eCallbackId::ScriptUnregister, OnScriptUnregister);
+        CLEO_UnregisterCallback(eCallbackId::ScriptDraw, OnScriptDraw);
+        CLEO_UnregisterCallback(eCallbackId::DrawingFinished, OnDrawingFinished);
+        
+        m_patchCTextGet.Apply(); // undo hook
+    }
+
+    static void __stdcall OnGameBegin(DWORD saveSlot)
+    {
+        textManager.LoadFxts();
+    }
+
+    static void __stdcall OnGameProcessBefore()
+    {
+        genericLabelCounter = 0;
+    }
+
+    static void __stdcall OnGameEnd()
+    {
+        textManager.Clear();
+    }
+
+    static bool __stdcall OnScriptBeforeProcess(CLEO::CRunningScript* pScript)
+    {
+        scriptDrawing.ScriptProcessingBegin(pScript);
+        return true;
+    }
+
+    static void __stdcall OnScriptAfterProcess(CLEO::CRunningScript* pScript)
+    {
+        scriptDrawing.ScriptProcessingEnd(pScript);
+    }
+
+    static void __stdcall OnScriptUnregister(CLEO::CRunningScript* pScript)
+    {
+        scriptDrawing.ScriptUnregister(pScript);
+    }
+
+    static void __stdcall OnScriptDraw(bool beforeFade)
+    {
+        scriptDrawing.Draw(beforeFade);
+    }
+
+    static void WINAPI OnDrawingFinished()
+    {
+        // late initialization
+        if (!instance.m_initialized)
+        {
+            instance.m_patchCTextGet = MemPatchJump(gaddrof(CText::Get), &HOOK_CTextGet);
+
+            instance.m_initialized = true;
+        }
+    }
+
+    // hook of game's CText::Get
+    static const char* __fastcall HOOK_CTextGet(CText* text, int dummy, const char* gxt)
+    {
+        if ((gxt[0] == '\0') || (gxt[0] == ' ')) return "";
+
+        // check CLEO's texts
+        auto result = Text::textManager.LocateFxt(gxt);
+        if (result != nullptr) return result;
+
+        // call original function
+        instance.m_patchCTextGet.Apply(); // restore original function code
+        result = text->Get(gxt);
+        MemPatchJump(gaddrof(CText::Get), &HOOK_CTextGet); // reinstall our hook
+
+        return result;
+    }
+
+    //0ACA=1,show_text_box %1d%
+    static OpcodeResult __stdcall opcode_0ACA(CLEO::CRunningScript* thread)
+    {
+        OPCODE_READ_PARAM_STRING(text);
+
+        CHud::SetHelpMessage(text, true, false, false);
+        return OR_CONTINUE;
+    }
+
+    //0ACB=3,show_styled_text %1d% time %2d% style %3d%
+    static OpcodeResult __stdcall opcode_0ACB(CLEO::CRunningScript* thread)
+    {
+        OPCODE_READ_PARAM_STRING(text);
+        auto time = OPCODE_READ_PARAM_INT();
+        auto style = OPCODE_READ_PARAM_INT();
+
+        auto styleIdx = std::clamp(style, 0, (int)MsgBigStyleCount - 1);
+        strncpy_s(msgBuffBig[styleIdx], text, sizeof(msgBuffBig[styleIdx]));
+        CMessages::AddBigMessage(msgBuffBig[styleIdx], time, style - 1);
+        return OR_CONTINUE;
+    }
+
+    //0ACC=2,show_text_lowpriority %1d% time %2d%
+    static OpcodeResult __stdcall opcode_0ACC(CLEO::CRunningScript* thread)
+    {
+        OPCODE_READ_PARAM_STRING(text);
+        auto time = OPCODE_READ_PARAM_INT();
+
+        strncpy_s(msgBuffLow, text, sizeof(msgBuffLow));
+        CMessages::AddMessage(msgBuffLow, time, false, false);
+        return OR_CONTINUE;
+    }
+
+    //0ACD=2,show_text_highpriority %1d% time %2d%
+    static OpcodeResult __stdcall opcode_0ACD(CLEO::CRunningScript* thread)
+    {
+        OPCODE_READ_PARAM_STRING(text);
+        auto time = OPCODE_READ_PARAM_INT();
+
+        strncpy_s(msgBuffHigh, text, sizeof(msgBuffHigh));
+        CMessages::AddMessageJumpQ(msgBuffHigh, time, false, false);
+        return OR_CONTINUE;
+    }
+
+    //0ACE=-1,show_formatted_text_box %1d%
+    static OpcodeResult __stdcall opcode_0ACE(CLEO::CRunningScript* thread)
+    {
+        OPCODE_READ_PARAM_STRING_FORMATTED(text);
+
+        CHud::SetHelpMessage(text, true, false, false);
+        return OR_CONTINUE;
+    }
+
+    //0ACF=-1,show_formatted_styled_text %1d% time %2d% style %3d%
+    static OpcodeResult __stdcall opcode_0ACF(CLEO::CRunningScript* thread)
+    {
+        OPCODE_READ_PARAM_STRING(format);
+        auto time = OPCODE_READ_PARAM_INT();
+        auto style = OPCODE_READ_PARAM_INT();
+        OPCODE_READ_PARAMS_FORMATTED(format, text);
+
+        auto styleIdx = std::clamp(style, 0, (int)MsgBigStyleCount - 1);
+        strncpy_s(msgBuffBig[styleIdx], text, sizeof(msgBuffBig[styleIdx]));
+        CMessages::AddBigMessage(msgBuffBig[styleIdx], time, style - 1);
+        return OR_CONTINUE;
+    }
+
+    //0AD0=-1,show_formatted_text_lowpriority %1d% time %2d%
+    static OpcodeResult __stdcall opcode_0AD0(CLEO::CRunningScript* thread)
+    {
+        OPCODE_READ_PARAM_STRING(format);
+        auto time = OPCODE_READ_PARAM_INT();
+        OPCODE_READ_PARAMS_FORMATTED(format, text);
+
+        strncpy_s(msgBuffLow, text, sizeof(msgBuffLow));
+        CMessages::AddMessage(msgBuffLow, time, false, false);
+        return OR_CONTINUE;
+    }
+
+    //0AD1=-1,show_formatted_text_highpriority %1d% time %2d%
+    static OpcodeResult __stdcall opcode_0AD1(CLEO::CRunningScript* thread)
+    {
+        OPCODE_READ_PARAM_STRING(format);
+        auto time = OPCODE_READ_PARAM_INT();
+        OPCODE_READ_PARAMS_FORMATTED(format, text);
+
+        strncpy_s(msgBuffHigh, text, sizeof(msgBuffHigh));
+        CMessages::AddMessageJumpQ(msgBuffHigh, time, false, false);
+        return OR_CONTINUE;
+    }
+
+    //0AD3=-1,string %1d% format %2d% ...
+    static OpcodeResult __stdcall opcode_0AD3(CLEO::CRunningScript* thread)
+    {
+        auto result = OPCODE_READ_PARAM_OUTPUT_VAR_STRING();
+        OPCODE_READ_PARAM_STRING_FORMATTED(text);
+
+        OPCODE_WRITE_PARAM_VAR_STRING(result, text);
+        return OR_CONTINUE;
+    }
+
+    //0AD4=-1,%3d% = scan_string %1d% format %2d%  //IF and SET
+    static OpcodeResult __stdcall opcode_0AD4(CLEO::CRunningScript* thread)
+    {
+        OPCODE_READ_PARAM_STRING(src);
+        OPCODE_READ_PARAM_STRING(format);
+
+        auto readCount = OPCODE_READ_PARAM_OUTPUT_VAR_INT(); // store_to
+
+        // format string tokens processing helper
+        const char* formatPos = format;
+        auto GetNextTokenType = [&]()
+        {
+            while (true)
+            {
+                if (*formatPos == '\0') return DT_END;
+
+                if (*formatPos == '%') // formatting sequence start
+                {
+                    if (formatPos[1] == '%' || // escaped % character
+                        formatPos[1] == '*') // sscanf non-capturing token
+                    {
+                        formatPos += 2;
+                        continue;
+                    }
+
+                    while (true)
+                    {
+                        formatPos++; // next char
+                        if (*formatPos == '\0')
+                        {
+                            SHOW_ERROR("Invalid string format sequence ('%s') in script %s\nScript suspended.", format, ScriptInfoStr(thread).c_str());
+                            return DT_INVALID;
+                        }
+
+                        // width specification
+                        if (*formatPos >= '0' && *formatPos <= '9')
+                        {
+                            formatPos++;
+                            continue;
+                        }
+
+                        switch(*formatPos)
+                        {
+                            case 's': return DT_STRING;
+                            default: return DT_VAR; // any32. TODO: actually parse and verify other types?
+                        }
+                    }
+                }
+
+                formatPos++;
+            }
+        };
+
+        // collect provided by caller store_to variables
+        size_t outputParamCount = 0;
+        SCRIPT_VAR* outputParams[35];
+        struct StringParamDesc
+        {
+            bool used = false;
+            StringParamBufferInfo target;
+            std::string str;
+        } stringParams[35];
+
+        for (int i = 0; i < 35; i++)
+        {
+            auto paramType = thread->PeekDataType();
+
+            auto formatTokenType = GetNextTokenType();
+            if (formatTokenType == DT_INVALID) return thread->Suspend(); // error message already displayed
+
+            if (paramType == DT_END)
+            {
+                if (formatTokenType != DT_END && !IsLegacyScript(thread))
+                {
+                    SHOW_ERROR("More tokens in format string than return variables in script %s\nScript suspended.", format, ScriptInfoStr(thread).c_str());
+                    return thread->Suspend();
+                }
+                break;
+            }
+
+            if (formatTokenType == DT_END && !IsLegacyScript(thread))
+            {
+                SHOW_ERROR("More return variables than tokens in format string in script %s\nScript suspended.", format, ScriptInfoStr(thread).c_str());
+                return thread->Suspend();
+            }
+
+            if (IsVarString(paramType))
+            {
+                if (IsLegacyScript(thread))
+                {
+                    // older CLEOs did not carred about string variable size limitations
+                    // just give pointer to the variable's data and allow overflow depending on input data
+                    outputParams[i] = CLEO_GetPointerToScriptVariable(thread);
+                }
+                else
+                {
+                    stringParams[i].used = true;
+                    stringParams[i].target = OPCODE_READ_PARAM_OUTPUT_VAR_STRING();
+
+                    stringParams[i].str.resize(MAX_STR_LEN); // temp storage
+                    outputParams[i] = (SCRIPT_VAR*)stringParams[i].str.data();
+                }
+            }
+            else if (formatTokenType == DT_STRING) // `%s`
+            {
+                auto ptr = OPCODE_READ_PARAM_PTR();
+                outputParams[i] = (SCRIPT_VAR*)ptr;
+            }
+            else
+            {
+                outputParams[i] = OPCODE_READ_PARAM_OUTPUT_VAR_ANY32();
+            }
+
+            outputParamCount++;
+        }
+        CLEO_SkipUnusedVarArgs(thread); // and var args terminator
+
+        #pragma warning(suppress: 4996) // sscanf_s would expect additional arg after each %s arg
+        *readCount = sscanf(src, format,
+            outputParams[0], outputParams[1], outputParams[2], outputParams[3], outputParams[4], outputParams[5],
+            outputParams[6], outputParams[7], outputParams[8], outputParams[9], outputParams[10], outputParams[11],
+            outputParams[12], outputParams[13], outputParams[14], outputParams[15], outputParams[16], outputParams[17],
+            outputParams[18], outputParams[19], outputParams[20], outputParams[21], outputParams[22], outputParams[23],
+            outputParams[24], outputParams[25], outputParams[26], outputParams[27], outputParams[28], outputParams[29],
+            outputParams[30], outputParams[31], outputParams[32], outputParams[33], outputParams[34]);
+
+        // transfer string params to target variables
+        for (auto& p : stringParams)
+        {
+            if (p.used) OPCODE_WRITE_PARAM_VAR_STRING(p.target, p.str.c_str());
+        }
+
+        OPCODE_CONDITION_RESULT(outputParamCount == *readCount);
+        return OR_CONTINUE;
+    }
+
+    //0ADB=2,%2d% = car_model %1d% name
+    static OpcodeResult __stdcall opcode_0ADB(CLEO::CRunningScript* thread)
+    {
+        auto modelIndex = OPCODE_READ_PARAM_UINT();
+
+        CVehicleModelInfo* model;
+        // if 1.0 US, prefer GetModelInfo function  makes it compatible with fastman92's limit adjuster
+        if (CLEO_GetGameVersion() == CLEO::GV_US10)
+            model = plugin::CallAndReturn<CVehicleModelInfo*, 0x403DA0, int>(modelIndex);
+        else
+            model = reinterpret_cast<CVehicleModelInfo*>(CModelInfo::ms_modelInfoPtrs[modelIndex]);
+
+        auto str = std::string(std::string_view(model->m_szGameName, sizeof(model->m_szGameName))); // to proper cstr
+
+        OPCODE_WRITE_PARAM_STRING(str.c_str());
+        return OR_CONTINUE;
+    }
+
+    //0ADE=2,%2d% = text_by_GXT_entry %1d%
+    static OpcodeResult __stdcall opcode_0ADE(CLEO::CRunningScript* thread)
+    {
+        OPCODE_READ_PARAM_STRING_LEN(gxt, 7); // GXT labels can be max 7 character long
+
+        auto txt = textManager.Get(gxt);
+
+        if (IsVarString(thread->PeekDataType()))
+        {
+            OPCODE_WRITE_PARAM_STRING(txt);
+        }
+        else
+        {
+            OPCODE_WRITE_PARAM_PTR(txt); // address of the text
+        }
+        return OR_CONTINUE;
+    }
+
+    //0ADF=2,add_dynamic_GXT_entry %1d% text %2d%
+    static OpcodeResult __stdcall opcode_0ADF(CLEO::CRunningScript* thread)
+    {
+        OPCODE_READ_PARAM_STRING_LEN(gxt, 7); // GXT labels can be max 7 character long
+        OPCODE_READ_PARAM_STRING(txt);
+
+        textManager.AddFxt(gxt, txt);
+        return OR_CONTINUE;
+    }
+
+    //0AE0=1,remove_dynamic_GXT_entry %1d%
+    static OpcodeResult __stdcall opcode_0AE0(CLEO::CRunningScript* thread)
+    {
+        OPCODE_READ_PARAM_STRING_LEN(gxt, 7); // GXT labels can be max 7 character long
+
+        textManager.RemoveFxt(gxt);
+        return OR_CONTINUE;
+    }
+
+    //0AED=3,%3d% = float %1d% to_string_format %2d%
+    static OpcodeResult __stdcall opcode_0AED(CLEO::CRunningScript* thread)
+    {
+        // this opcode is useless now
+        auto val = OPCODE_READ_PARAM_FLOAT();
+        OPCODE_READ_PARAM_STRING(format);
+
+        char result[32];
+        sprintf_s(result, sizeof(result), format, val);
+
+        OPCODE_WRITE_PARAM_STRING(result);
+        return OR_CONTINUE;
+    }
+
+    //2600=1,  is_text_empty %1s%
+    static OpcodeResult __stdcall opcode_2600(CLEO::CRunningScript* thread)
+    {
+        OPCODE_READ_PARAM_STRING(str);
+
+        OPCODE_CONDITION_RESULT(str[0] == '\0');
+        return OR_CONTINUE;
+    }
+
+    //2601=3,  is_text_equal %1s% another %2s% ignore_case %3d%
+    static OpcodeResult __stdcall opcode_2601(CLEO::CRunningScript* thread)
+    {
+        OPCODE_READ_PARAM_STRING(a);
+        OPCODE_READ_PARAM_STRING(b);
+        auto ignoreCase = OPCODE_READ_PARAM_BOOL();
+
+        auto result = ignoreCase ? _stricmp(a, b) : strcmp(a, b);
+
+        OPCODE_CONDITION_RESULT(result == 0);
+        return OR_CONTINUE;
+    }
+
+    //2602=3,  is_text_in_text %1s% sub_text %2s% ignore_case %3d%
+    static OpcodeResult __stdcall opcode_2602(CLEO::CRunningScript* thread)
+    {
+        OPCODE_READ_PARAM_STRING(str);
+        OPCODE_READ_PARAM_STRING(substr);
+        auto ignoreCase = OPCODE_READ_PARAM_BOOL();
+
+        if (substr[0] == '\0')
+        {
+            OPCODE_CONDITION_RESULT(true);
+            return OR_CONTINUE;
+        }
+
+        auto result = ignoreCase ? StrStrIA(str, substr) : strstr(str, substr);
+
+        OPCODE_CONDITION_RESULT(result != nullptr);
+        return OR_CONTINUE;
+    }
+
+    //2603=3,  is_text_prefix %1s% prefix %2s% ignore_case %3d%
+    static OpcodeResult __stdcall opcode_2603(CLEO::CRunningScript* thread)
+    {
+        OPCODE_READ_PARAM_STRING(str);
+        OPCODE_READ_PARAM_STRING(prefix);
+        auto ignoreCase = OPCODE_READ_PARAM_BOOL();
+
+        auto prefixLen = strlen(prefix);
+        auto result = ignoreCase ? _strnicmp(str, prefix, prefixLen) : strncmp(str, prefix, prefixLen);
+
+        OPCODE_CONDITION_RESULT(result == 0);
+        return OR_CONTINUE;
+    }
+
+    //2604=3,  is_text_sufix %1s% sufix %2s% ignore_case %3d%
+    static OpcodeResult __stdcall opcode_2604(CLEO::CRunningScript* thread)
+    {
+        OPCODE_READ_PARAM_STRING(str);
+        OPCODE_READ_PARAM_STRING(sufix);
+        auto ignoreCase = OPCODE_READ_PARAM_BOOL();
+
+        auto strLen = strlen(str);
+        auto sufixLen = strlen(sufix);
+
+        if (sufixLen > strLen)
+        {
+            OPCODE_CONDITION_RESULT(false);
+            return OR_CONTINUE;
+        }
+
+        auto offset = strLen - sufixLen;
+        auto result = ignoreCase ? _stricmp(str + offset, sufix) : strcmp(str + offset, sufix);
+
+        OPCODE_CONDITION_RESULT(result == 0);
+        return OR_CONTINUE;
+    }
+
+    //2605=-1,display_text_formatted offset_left %1d% offset_top %2d% format %3d% args
+    static OpcodeResult __stdcall opcode_2605(CLEO::CRunningScript* thread)
+    {
+        auto posX = OPCODE_READ_PARAM_FLOAT();
+        auto posY = OPCODE_READ_PARAM_FLOAT();
+        OPCODE_READ_PARAM_STRING_FORMATTED(text);
+
+        if (CTheScripts::NumberOfIntroTextLinesThisFrame >= 0x60) // GTA SA CTheScripts::IntroTextLines capacity
+        {
+            LOG_WARNING(thread, "Display text limit (%d) exceeded in script %s", 0x60, ScriptInfoStr(thread).c_str());
+            return OR_CONTINUE;
+        }
+
+        // new generic GXT label
+        // includes unprintable character, to ensure there will be no collision with user GXT labels
+        char gxt[9] = { 0x01, 'C', 'L', 'E', 0x00, 0x00, 0x00, 0x00, 0x00 }; // enough space for even worst case scenario
+        _itoa_s(genericLabelCounter, gxt + 4, sizeof(gxt) - 4, 36); // 0xFFFF -> "1ekf"
+        genericLabelCounter++;
+
+        textManager.AddFxt(gxt, text);
+
+        auto& draw = CTheScripts::IntroTextLines[CTheScripts::NumberOfIntroTextLinesThisFrame];
+        memcpy(&draw.xPosition, &posX, sizeof(draw.xPosition)); // invalid type in Plugin SDK. Just copy memory
+        memcpy(&draw.yPosition, &posY, sizeof(draw.yPosition));
+        strcpy_s(draw.text, gxt);
+
+        CTheScripts::NumberOfIntroTextLinesThisFrame++;
+
+        return OR_CONTINUE;
+    }
+
+    //2606=1,  load_fxt %1d%
+    static OpcodeResult __stdcall opcode_2606(CLEO::CRunningScript* thread)
+    {
+        OPCODE_READ_PARAM_FILEPATH(filename);
+
+        size_t added = 0;
+        try
+        {
+            std::ifstream stream(filename);
+            added = textManager.ParseFxtFile(stream, true, false);
+        }
+        catch (std::exception& ex)
+        {
+            LOG_WARNING(0, "Loading of FXT file '%s' failed: \n%s", filename, ex.what());
+        }
+
+        OPCODE_CONDITION_RESULT(added != 0);
+        return OR_CONTINUE;
+    }
+
+    //2607=1,  unload_fxt %1d%
+    static OpcodeResult __stdcall opcode_2607(CLEO::CRunningScript* thread)
+    {
+        OPCODE_READ_PARAM_FILEPATH(filename);
+
+        size_t removed = 0;
+        try
+        {
+            std::ifstream stream(filename);
+            removed = textManager.ParseFxtFile(stream, true, true);
+        }
+        catch (std::exception& ex)
+        {
+            LOG_WARNING(0, "Unloading of FXT file '%s' failed: \n%s", filename, ex.what());
+        }
+
+        OPCODE_CONDITION_RESULT(removed != 0);
+        return OR_CONTINUE;
+    }
+
+    //2608=3,get_text_length %1d% store_to %2d%
+    static OpcodeResult __stdcall opcode_2608(CLEO::CRunningScript* thread)
+    {
+        OPCODE_READ_PARAM_STRING(str);
+
+        auto result = strlen(str);
+
+        OPCODE_WRITE_PARAM_INT(result);
+        return OR_CONTINUE;
+    }
+
+    //2609=-1,add_text_label_formatted %1d% args %2d% 
+    static OpcodeResult __stdcall opcode_2609(CLEO::CRunningScript* thread)
+    {
+        OPCODE_READ_PARAM_STRING_LEN(gxt, 7); // GXT labels can be max 7 character long
+        OPCODE_READ_PARAM_STRING_FORMATTED(str);
+
+        textManager.AddFxt(gxt, str);
+
+        return OR_CONTINUE;
+    }
 } instance;
 
 ScriptDrawing Text::scriptDrawing;
@@ -646,5 +646,5 @@ WORD Text::genericLabelCounter;
 
 extern "C" __declspec(dllexport) RwTexture * GetScriptTexture(CLEO::CRunningScript* script, DWORD slot)
 {
-	return instance.scriptDrawing.GetScriptTexture(script, slot);
+    return instance.scriptDrawing.GetScriptTexture(script, slot);
 }

--- a/cleo_sdk/CLEO.h
+++ b/cleo_sdk/CLEO.h
@@ -1,15 +1,15 @@
 /*
-	CLEO 5 header file
-	Copyright (c) 2025 Alien, Deji, Junior_Djjr, Miran, Seemann
+    CLEO 5 header file
+    Copyright (c) 2025 Alien, Deji, Junior_Djjr, Miran, Seemann
 */
 #pragma once
 
 #include <string>
 #include <wtypes.h>
 
-#define CLEO_VERSION_MAIN	5
-#define CLEO_VERSION_MAJOR	1
-#define CLEO_VERSION_MINOR	0
+#define CLEO_VERSION_MAIN  5
+#define CLEO_VERSION_MAJOR 1
+#define CLEO_VERSION_MINOR 0
 
 #define CLEO_VERSION ((CLEO_VERSION_MAIN << 24)|(CLEO_VERSION_MAJOR << 16)|(CLEO_VERSION_MINOR << 8)) // 0x0v0v0v00
 
@@ -22,261 +22,261 @@ namespace CLEO
 // result of CLEO_GetScriptVersion
 enum eCLEO_Version : DWORD
 {
-	CLEO_VER_3 = 0x03000000,
-	CLEO_VER_4_MIN = 0x04000000,
-	CLEO_VER_4_2 = 0x04020000,
-	CLEO_VER_4_3 = 0x04030000,
-	CLEO_VER_4_4 = 0x04040000,
-	CLEO_VER_4 = CLEO_VER_4_4,
-	CLEO_VER_5 = 0x05000000,
-	CLEO_VER_CUR = CLEO_VERSION
+    CLEO_VER_3 =     0x03000000,
+    CLEO_VER_4_MIN = 0x04000000,
+    CLEO_VER_4_2 =   0x04020000,
+    CLEO_VER_4_3 =   0x04030000,
+    CLEO_VER_4_4 =   0x04040000,
+    CLEO_VER_4 =     CLEO_VER_4_4,
+    CLEO_VER_5 =     0x05000000,
+    CLEO_VER_CUR =   CLEO_VERSION
 };
 
 // result of CLEO_GetGameVersion
 enum eGameVersion : int
 {
-	GV_US10 = 0, // 1.0 us
-	GV_US11 = 1, // 1.01 us - not supported
-	GV_EU10 = 2, // 1.0 eu
-	GV_EU11 = 3, // 1.01 eu
-	GV_STEAM,
-	GV_TOTAL,
-	GV_UNK = -1 // any other
+    GV_US10 = 0, // 1.0 us
+    GV_US11 = 1, // 1.01 us - not supported
+    GV_EU10 = 2, // 1.0 eu
+    GV_EU11 = 3, // 1.01 eu
+    GV_STEAM,
+    GV_TOTAL,
+    GV_UNK = -1 // any other
 };
 
 // operand types
 enum eDataType : BYTE
 {
-	DT_END, // variable args end marker
-	DT_DWORD, // literal int 32
-	DT_VAR, // globalVar $
-	DT_LVAR, // localVar @
-	DT_BYTE, // literal int 8
-	DT_WORD, // literal int 16
-	DT_FLOAT, // literal float 32
-	DT_VAR_ARRAY, // globalArr $(,)
-	DT_LVAR_ARRAY, // localArr @(,)
-	DT_TEXTLABEL, // literal string up to 7 chars
-	DT_VAR_TEXTLABEL, // globalVarSString s$
-	DT_LVAR_TEXTLABEL, // localVarSString @s
-	DT_VAR_TEXTLABEL_ARRAY, // globalVarSStringArr s$(,)
-	DT_LVAR_TEXTLABEL_ARRAY, // localVarSStringArr @s(,)
-	DT_VARLEN_STRING, // literal vstring ""
-	DT_STRING, // literal string up to 15 chars
-	DT_VAR_STRING, // globalVarVString v$
-	DT_LVAR_STRING, // localVarVString @v
-	DT_VAR_STRING_ARRAY, // globalVarStringArr v$(,)
-	DT_LVAR_STRING_ARRAY, // localVarStringArr @v(,)
-	DT_INVALID = 0xFF // CLEO internal
+    DT_END, // variable args end marker
+    DT_DWORD, // literal int 32
+    DT_VAR, // globalVar $
+    DT_LVAR, // localVar @
+    DT_BYTE, // literal int 8
+    DT_WORD, // literal int 16
+    DT_FLOAT, // literal float 32
+    DT_VAR_ARRAY, // globalArr $(,)
+    DT_LVAR_ARRAY, // localArr @(,)
+    DT_TEXTLABEL, // literal string up to 7 chars
+    DT_VAR_TEXTLABEL, // globalVarSString s$
+    DT_LVAR_TEXTLABEL, // localVarSString @s
+    DT_VAR_TEXTLABEL_ARRAY, // globalVarSStringArr s$(,)
+    DT_LVAR_TEXTLABEL_ARRAY, // localVarSStringArr @s(,)
+    DT_VARLEN_STRING, // literal vstring ""
+    DT_STRING, // literal string up to 15 chars
+    DT_VAR_STRING, // globalVarVString v$
+    DT_LVAR_STRING, // localVarVString @v
+    DT_VAR_STRING_ARRAY, // globalVarStringArr v$(,)
+    DT_LVAR_STRING_ARRAY, // localVarStringArr @v(,)
+    DT_INVALID = 0xFF // CLEO internal
 };
 
 enum eArrayDataType : BYTE
 {
-	ADT_INT, // variable with integer
-	ADT_FLOAT, // variable with integer
-	ADT_TEXTLABEL, // variable with short string (8 char)
-	ADT_STRING, // variable with long string (16 char)
-	ADT_NONE = 0xFF // CLEO internal
+    ADT_INT, // variable with integer
+    ADT_FLOAT, // variable with integer
+    ADT_TEXTLABEL, // variable with short string (8 char)
+    ADT_STRING, // variable with long string (16 char)
+    ADT_NONE = 0xFF // CLEO internal
 };
 static const BYTE ArrayTypeMask = ADT_INT | ADT_FLOAT | ADT_TEXTLABEL | ADT_STRING; // array flags byte contains other info too. Type needs to be masked when read
 
 static const char* ToStr(eDataType type)
 {
-	switch (type)
-	{
-	case DT_END: return "VArgEnd"; break;
-	case DT_DWORD: return "Int32"; break;
-	case DT_VAR: return "GlobVar"; break;
-	case DT_LVAR: return "LocVar"; break;
-	case DT_BYTE: return "Int8"; break;
-	case DT_WORD: return "Int16"; break;
-	case DT_FLOAT: return "Float32"; break;
-	case DT_VAR_ARRAY: return "GlobVarArr"; break;
-	case DT_LVAR_ARRAY: return "LocVarArr"; break;
-	case DT_TEXTLABEL: return "STxt"; break;
-	case DT_VAR_TEXTLABEL: return "GlobVarSTxt"; break;
-	case DT_LVAR_TEXTLABEL: return "LocVarSTxt"; break;
-	case DT_VAR_TEXTLABEL_ARRAY: return "GlobVarSTxtArr"; break;
-	case DT_LVAR_TEXTLABEL_ARRAY: return "LocVarSTxtArr"; break;
-	case DT_VARLEN_STRING: return "Txt"; break;
-	case DT_STRING: return "LTxt"; break;
-	case DT_VAR_STRING: return "GlobVarLTxt"; break;
-	case DT_LVAR_STRING: return "LocVarLTxt"; break;
-	case DT_VAR_STRING_ARRAY: return "GlobVarLTxtArr"; break;
-	case DT_LVAR_STRING_ARRAY: return "LocVarLTxtArr"; break;
-	default: return "corrupted";
-	}
+    switch (type)
+    {
+    case DT_END: return "VArgEnd"; break;
+    case DT_DWORD: return "Int32"; break;
+    case DT_VAR: return "GlobVar"; break;
+    case DT_LVAR: return "LocVar"; break;
+    case DT_BYTE: return "Int8"; break;
+    case DT_WORD: return "Int16"; break;
+    case DT_FLOAT: return "Float32"; break;
+    case DT_VAR_ARRAY: return "GlobVarArr"; break;
+    case DT_LVAR_ARRAY: return "LocVarArr"; break;
+    case DT_TEXTLABEL: return "STxt"; break;
+    case DT_VAR_TEXTLABEL: return "GlobVarSTxt"; break;
+    case DT_LVAR_TEXTLABEL: return "LocVarSTxt"; break;
+    case DT_VAR_TEXTLABEL_ARRAY: return "GlobVarSTxtArr"; break;
+    case DT_LVAR_TEXTLABEL_ARRAY: return "LocVarSTxtArr"; break;
+    case DT_VARLEN_STRING: return "Txt"; break;
+    case DT_STRING: return "LTxt"; break;
+    case DT_VAR_STRING: return "GlobVarLTxt"; break;
+    case DT_LVAR_STRING: return "LocVarLTxt"; break;
+    case DT_VAR_STRING_ARRAY: return "GlobVarLTxtArr"; break;
+    case DT_LVAR_STRING_ARRAY: return "LocVarLTxtArr"; break;
+    default: return "corrupted";
+    }
 }
 static bool IsImmInteger(eDataType type) // immediate/literal integer in code like 42
 {
-	switch (type)
-	{
-		case DT_BYTE:
-		case DT_WORD:
-		case DT_DWORD:
-			return true;
-	}
-	return false;
+    switch (type)
+    {
+        case DT_BYTE:
+        case DT_WORD:
+        case DT_DWORD:
+            return true;
+    }
+    return false;
 }
 static bool IsImmFloat(eDataType type) // immediate/literal float in code like 42.0
 {
-	return type == DT_FLOAT;
+    return type == DT_FLOAT;
 }
 static bool IsImmString(eDataType type) // immediate/literal string in code like "text"
 {
-	switch (type)
-	{
-		case DT_STRING:
-		case DT_TEXTLABEL:
-		case DT_VARLEN_STRING:
-			return true;
-	}
-	return false;
+    switch (type)
+    {
+        case DT_STRING:
+        case DT_TEXTLABEL:
+        case DT_VARLEN_STRING:
+            return true;
+    }
+    return false;
 }
 static bool IsVarString(eDataType type) // string variable
 {
-	switch (type)
-	{
-		case DT_LVAR_TEXTLABEL:
-		case DT_LVAR_TEXTLABEL_ARRAY:
-		case DT_LVAR_STRING:
-		case DT_LVAR_STRING_ARRAY:
-		case DT_VAR_TEXTLABEL:
-		case DT_VAR_TEXTLABEL_ARRAY:
-		case DT_VAR_STRING:
-		case DT_VAR_STRING_ARRAY:
-			return true;
-	}
-	return false;
+    switch (type)
+    {
+        case DT_LVAR_TEXTLABEL:
+        case DT_LVAR_TEXTLABEL_ARRAY:
+        case DT_LVAR_STRING:
+        case DT_LVAR_STRING_ARRAY:
+        case DT_VAR_TEXTLABEL:
+        case DT_VAR_TEXTLABEL_ARRAY:
+        case DT_VAR_STRING:
+        case DT_VAR_STRING_ARRAY:
+            return true;
+    }
+    return false;
 }
 static bool IsVariable(eDataType type) // can carry int, float, pointer to text
 {
-	switch (type)
-	{
-		case DT_VAR:
-		case DT_VAR_ARRAY:
-		case DT_LVAR:
-		case DT_LVAR_ARRAY:
-			return true;
-	}
-	return false;
+    switch (type)
+    {
+        case DT_VAR:
+        case DT_VAR_ARRAY:
+        case DT_LVAR:
+        case DT_LVAR_ARRAY:
+            return true;
+    }
+    return false;
 }
 static bool IsArray(eDataType type)
 {
-	switch (type)
-	{
-		case DT_LVAR_TEXTLABEL_ARRAY:
-		case DT_LVAR_STRING_ARRAY:
-		case DT_VAR_TEXTLABEL_ARRAY:
-		case DT_VAR_STRING_ARRAY:
-		case DT_VAR_ARRAY:
-		case DT_LVAR_ARRAY:
-			return true;
-	}
-	return false;
+    switch (type)
+    {
+        case DT_LVAR_TEXTLABEL_ARRAY:
+        case DT_LVAR_STRING_ARRAY:
+        case DT_VAR_TEXTLABEL_ARRAY:
+        case DT_VAR_STRING_ARRAY:
+        case DT_VAR_ARRAY:
+        case DT_LVAR_ARRAY:
+            return true;
+    }
+    return false;
 }
 static const char* ToKindStr(eDataType type, eArrayDataType arrType = ADT_NONE)
 {
-	switch (type)
-	{
-		case DT_BYTE:
-		case DT_WORD:
-		case DT_DWORD:
-			return "int"; break;
+    switch (type)
+    {
+        case DT_BYTE:
+        case DT_WORD:
+        case DT_DWORD:
+            return "int"; break;
 
-		case DT_FLOAT:
-			return "float"; break;
+        case DT_FLOAT:
+            return "float"; break;
 
-		case DT_STRING:
-		case DT_TEXTLABEL:
-		case DT_LVAR_TEXTLABEL:
-		case DT_LVAR_TEXTLABEL_ARRAY:
-		case DT_LVAR_STRING:
-		case DT_LVAR_STRING_ARRAY:
-		case DT_VAR_TEXTLABEL:
-		case DT_VAR_TEXTLABEL_ARRAY:
-		case DT_VAR_STRING:
-		case DT_VAR_STRING_ARRAY:
-		case DT_VARLEN_STRING:
-			return "string"; break;
+        case DT_STRING:
+        case DT_TEXTLABEL:
+        case DT_LVAR_TEXTLABEL:
+        case DT_LVAR_TEXTLABEL_ARRAY:
+        case DT_LVAR_STRING:
+        case DT_LVAR_STRING_ARRAY:
+        case DT_VAR_TEXTLABEL:
+        case DT_VAR_TEXTLABEL_ARRAY:
+        case DT_VAR_STRING:
+        case DT_VAR_STRING_ARRAY:
+        case DT_VARLEN_STRING:
+            return "string"; break;
 
-		case DT_VAR:
-		case DT_LVAR:
-			return "variable"; break;
+        case DT_VAR:
+        case DT_LVAR:
+            return "variable"; break;
 
-		case DT_VAR_ARRAY:
-		case DT_LVAR_ARRAY:
-			switch(arrType)
-			{
-				case ADT_INT:
-					return "int"; break;
+        case DT_VAR_ARRAY:
+        case DT_LVAR_ARRAY:
+            switch(arrType)
+            {
+                case ADT_INT:
+                    return "int"; break;
 
-				case ADT_FLOAT:
-					return "float"; break;
+                case ADT_FLOAT:
+                    return "float"; break;
 
-				case ADT_TEXTLABEL:
-				case ADT_STRING:
-					return "string"; break;
+                case ADT_TEXTLABEL:
+                case ADT_STRING:
+                    return "string"; break;
 
-				default: return "variable";
-			}
+                default: return "variable";
+            }
 
-		case DT_END:
-			return "varArgEnd"; break;
+        case DT_END:
+            return "varArgEnd"; break;
 
-		default:
-			return "corrupted"; break;
-	}
+        default:
+            return "corrupted"; break;
+    }
 }
 
 const size_t MAX_STR_LEN = 0xff; // max length of string type parameter
 
 union SCRIPT_VAR
 {
-	DWORD dwParam;
-	short wParam;
-	WORD usParam;
-	BYTE ucParam;
-	char cParam;
-	bool bParam;
-	int nParam;
-	float fParam;
-	void* pParam;
-	char* pcParam;
+    DWORD dwParam;
+    short wParam;
+    WORD usParam;
+    BYTE ucParam;
+    char cParam;
+    bool bParam;
+    int nParam;
+    float fParam;
+    void* pParam;
+    char* pcParam;
 };
 
 enum eLogicalOperation : WORD
 {
-	NONE = 0, // just replace
+    NONE = 0, // just replace
 
-	ANDS_1 = 1, // count of 'and' keywords in the expression
-	ANDS_2,
-	ANDS_3,
-	ANDS_4,
-	ANDS_5,
-	ANDS_6,
-	ANDS_7,
-	ANDS_8,
-	AND_END,
-	
-	ORS_1 = 21, // count of 'or' keywords in the expression
-	ORS_2,
-	ORS_3,
-	ORS_4,
-	ORS_5,
-	ORS_6,
-	ORS_7,
-	ORS_8,
-	OR_END,
+    ANDS_1 = 1, // count of 'and' keywords in the expression
+    ANDS_2,
+    ANDS_3,
+    ANDS_4,
+    ANDS_5,
+    ANDS_6,
+    ANDS_7,
+    ANDS_8,
+    AND_END,
+    
+    ORS_1 = 21, // count of 'or' keywords in the expression
+    ORS_2,
+    ORS_3,
+    ORS_4,
+    ORS_5,
+    ORS_6,
+    ORS_7,
+    ORS_8,
+    OR_END,
 };
 static eLogicalOperation& operator--(eLogicalOperation& o)
 {
-	if (o == eLogicalOperation::NONE) return o; // can not be decremented anymore
-	if (o == eLogicalOperation::ORS_1) return o = eLogicalOperation::NONE;
-	
-	auto val = static_cast<WORD>(o); // to number
-	val--;
-	return o = static_cast<eLogicalOperation>(val);
+    if (o == eLogicalOperation::NONE) return o; // can not be decremented anymore
+    if (o == eLogicalOperation::ORS_1) return o = eLogicalOperation::NONE;
+    
+    auto val = static_cast<WORD>(o); // to number
+    val--;
+    return o = static_cast<eLogicalOperation>(val);
 }
 
 // CLEO virtual path prefixes. Expandable with CLEO_ResolvePath
@@ -289,39 +289,39 @@ const char DIR_MODULES[] = "modules:"; // game\cleo\modules directory
 // argument of CLEO_RegisterCallback
 enum class eCallbackId : DWORD
 {
-	GameBegin = 0, // void WINAPI OnGameBegin(DWORD saveSlot); // game session started. -1 if not started from save
-	GameProcessBefore = 1, // void WINAPI OnGameProcessBefore(); // called once every frame before game logic processing
-	GameProcessAfter = 14, // void WINAPI OnGameProcessAfter(); // called once every frame after game logic processing
-	GameEnd = 2, // void WINAPI OnGameEnd(); // game session ended
-	ScriptsLoaded = 3, // void WINAPI OnScriptsLoaded();
-	ScriptsFinalize = 4, // void WINAPI OnScriptsFinalize(); // called after all scripts has been deleted. Pointers to scripts are no longer valid!
-	ScriptRegister = 5, // void WINAPI OnScriptRegister(CRunningScript* pScript); // called after script creation
-	ScriptUnregister = 6, // void WINAPI OnScriptUnregister(CRunningScript* pScript); // called before script deletion
-	ScriptProcessBefore = 7, // bool WINAPI OnScriptProcessBefore(CRunningScript* pScript); // return false to skip this script processing
-	ScriptProcessAfter = 15, // void WINAPI OnScriptProcessAfter(CRunningScript* pScript);
-	ScriptOpcodeProcessBefore = 8, // OpcodeResult WINAPI OnScriptOpcodeProcessBefore(CRunningScript* pScript, DWORD opcode); // return other than OR_NONE to signal that opcode was handled in the callback
-	ScriptOpcodeProcessAfter = 9, // OpcodeResult WINAPI OnScriptOpcodeProcessAfter(CRunningScript* pScript, DWORD opcode, OpcodeResult result); // return other than OR_NONE to overwrite original result
-	ScriptDraw = 10, // void WINAPI OnScriptDraw(bool beforeFade);
-	DrawingFinished = 11, // void WINAPI OnDrawingFinished(); // called after game rendered everything and before presenting screen buffer
-	Log = 12, // void OnLog(eLogLevel level, const char* msg);
-	MainWindowFocus = 13, // void WINAPI OnMainWindowFocus(bool active); // called when game main window focus changes
+    GameBegin = 0, // void WINAPI OnGameBegin(DWORD saveSlot); // game session started. -1 if not started from save
+    GameProcessBefore = 1, // void WINAPI OnGameProcessBefore(); // called once every frame before game logic processing
+    GameProcessAfter = 14, // void WINAPI OnGameProcessAfter(); // called once every frame after game logic processing
+    GameEnd = 2, // void WINAPI OnGameEnd(); // game session ended
+    ScriptsLoaded = 3, // void WINAPI OnScriptsLoaded();
+    ScriptsFinalize = 4, // void WINAPI OnScriptsFinalize(); // called after all scripts has been deleted. Pointers to scripts are no longer valid!
+    ScriptRegister = 5, // void WINAPI OnScriptRegister(CRunningScript* pScript); // called after script creation
+    ScriptUnregister = 6, // void WINAPI OnScriptUnregister(CRunningScript* pScript); // called before script deletion
+    ScriptProcessBefore = 7, // bool WINAPI OnScriptProcessBefore(CRunningScript* pScript); // return false to skip this script processing
+    ScriptProcessAfter = 15, // void WINAPI OnScriptProcessAfter(CRunningScript* pScript);
+    ScriptOpcodeProcessBefore = 8, // OpcodeResult WINAPI OnScriptOpcodeProcessBefore(CRunningScript* pScript, DWORD opcode); // return other than OR_NONE to signal that opcode was handled in the callback
+    ScriptOpcodeProcessAfter = 9, // OpcodeResult WINAPI OnScriptOpcodeProcessAfter(CRunningScript* pScript, DWORD opcode, OpcodeResult result); // return other than OR_NONE to overwrite original result
+    ScriptDraw = 10, // void WINAPI OnScriptDraw(bool beforeFade);
+    DrawingFinished = 11, // void WINAPI OnDrawingFinished(); // called after game rendered everything and before presenting screen buffer
+    Log = 12, // void OnLog(eLogLevel level, const char* msg);
+    MainWindowFocus = 13, // void WINAPI OnMainWindowFocus(bool active); // called when game main window focus changes
 };
 
 // used by CLEO_Log and Log callback
 enum class eLogLevel : DWORD
 {
-	None,
-	Error, // errors and warnings
-	Debug, // debug mode / user traces
-	Default // all log messages
+    None,
+    Error, // errors and warnings
+    Debug, // debug mode / user traces
+    Default // all log messages
 };
 
 enum OpcodeResult : char
 {
-	OR_NONE = -2,
-	OR_ERROR = -1,
-	OR_CONTINUE = 0,
-	OR_INTERRUPT = 1,
+    OR_NONE = -2,
+    OR_ERROR = -1,
+    OR_CONTINUE = 0,
+    OR_INTERRUPT = 1,
 };
 
 class CRunningScript;
@@ -330,208 +330,208 @@ typedef OpcodeResult(__stdcall* CustomOpcodeHandler)(CRunningScript*);
 // exports
 extern "C"
 {
-	DWORD WINAPI CLEO_GetVersion();
-	LPCSTR WINAPI CLEO_GetVersionStr(); // for example "5.0.0-alpha.1"
-	eGameVersion WINAPI CLEO_GetGameVersion();
+    DWORD WINAPI CLEO_GetVersion();
+    LPCSTR WINAPI CLEO_GetVersionStr(); // for example "5.0.0-alpha.1"
+    eGameVersion WINAPI CLEO_GetGameVersion();
 
-	BOOL WINAPI CLEO_RegisterOpcode(WORD opcode, CustomOpcodeHandler callback);
-	BOOL WINAPI CLEO_RegisterCommand(const char* commandName, CustomOpcodeHandler callback); // uses cleo\.CONFIG\sa.json to obtain opcode number from name
-	OpcodeResult WINAPI CLEO_CallNativeOpcode(CRunningScript* script, WORD opcode); // call original unhooked opcode handler
+    BOOL WINAPI CLEO_RegisterOpcode(WORD opcode, CustomOpcodeHandler callback);
+    BOOL WINAPI CLEO_RegisterCommand(const char* commandName, CustomOpcodeHandler callback); // uses cleo\.CONFIG\sa.json to obtain opcode number from name
+    OpcodeResult WINAPI CLEO_CallNativeOpcode(CRunningScript* script, WORD opcode); // call original unhooked opcode handler
 
-	void WINAPI CLEO_RegisterCallback(eCallbackId id, void* func);
-	void WINAPI CLEO_UnregisterCallback(eCallbackId id, void* func);
+    void WINAPI CLEO_RegisterCallback(eCallbackId id, void* func);
+    void WINAPI CLEO_UnregisterCallback(eCallbackId id, void* func);
 
-	// scripts deletion callback
-	typedef void(*FuncScriptDeleteDelegateT) (CRunningScript* script);
-	void WINAPI CLEO_AddScriptDeleteDelegate(FuncScriptDeleteDelegateT func);
-	void WINAPI CLEO_RemoveScriptDeleteDelegate(FuncScriptDeleteDelegateT func);
-
-
-	// script utils
-	BOOL WINAPI CLEO_IsScriptRunning(const CRunningScript* thread); // check if script is active
-	void WINAPI CLEO_GetScriptInfoStr(CRunningScript* thread, bool currLineInfo, char* buf, DWORD bufSize); // short text for displaying in error\log messages
-	void WINAPI CLEO_GetScriptParamInfoStr(int idexOffset, char* buf, DWORD bufSize); // short text with last processed + idexOffset opcode's parameter info (index and name if available)
-	DWORD WINAPI CLEO_GetScriptBaseRelativeOffset(const CRunningScript* script, const BYTE* codePos); // get offset within script source file
-	eCLEO_Version WINAPI CLEO_GetScriptVersion(const CRunningScript* thread); // get compatible version
-	void WINAPI CLEO_SetScriptVersion(CRunningScript* thread, eCLEO_Version version); // set compatible version
-	LPCSTR WINAPI CLEO_GetScriptFilename(const CRunningScript* thread); // returns nullptr if provided script ptr is not valid
-
-	LPCSTR WINAPI CLEO_GetScriptWorkDir(const CRunningScript* thread);
-	void WINAPI CLEO_SetScriptWorkDir(CRunningScript* thread, const char* path);
-
-	void WINAPI CLEO_SetThreadCondResult(CRunningScript* thread, BOOL result);
-	void WINAPI CLEO_ThreadJumpAtLabelPtr(CRunningScript* thread, int offset);
-	void WINAPI CLEO_TerminateScript(CRunningScript* thread);
-
-	int WINAPI CLEO_GetOperandType(const CRunningScript* thread); // peek parameter data type. Returns int for legacy reason, should be eDataType.
-	DWORD WINAPI CLEO_GetVarArgCount(CRunningScript* thread); // peek remaining var-args count
-
-	extern SCRIPT_VAR* opcodeParams;
-	extern SCRIPT_VAR* missionLocals;
-	extern CRunningScript* staticThreads;
-
-	BYTE* WINAPI CLEO_GetScmMainData(); // get pointer to main script block. Supports limit adjusters
-	SCRIPT_VAR* WINAPI CLEO_GetOpcodeParamsArray(); // get pointer to 'SCRIPT_VAR[32] opcodeParams'. Used by Retrieve/Record opcode params functions
-	BYTE WINAPI CLEO_GetParamsHandledCount(); // number of already read/written opcode parameters since current opcode handler was called
-
-	// param read
-	SCRIPT_VAR* WINAPI CLEO_GetPointerToScriptVariable(CRunningScript* thread); // get pointer to the variable's data, nullptr if parameter is not variable. Advances script to next param
-	void WINAPI CLEO_RetrieveOpcodeParams(CRunningScript* thread, int count); // read multiple params. Stored in opcodeParams array
-	DWORD WINAPI CLEO_GetIntOpcodeParam(CRunningScript* thread);
-	float WINAPI CLEO_GetFloatOpcodeParam(CRunningScript* thread);
-	LPCSTR WINAPI CLEO_ReadStringOpcodeParam(CRunningScript* thread, char* buff = nullptr, int buffSize = 0); // read always null-terminated string into buffer, clamped to its size. If no buffer provided then internal, globally shared by all CLEO_ReadStringOpcodeParam calls, is used. Returns pointer to the result buffer or nullptr on fail
-	LPCSTR WINAPI CLEO_ReadStringPointerOpcodeParam(CRunningScript* thread, char* buff = nullptr, int buffSize = 0); // read always null-terminated string into buffer, clamped to its size. If no buffer provided then internal, globally shared by all CLEO_ReadStringPointerOpcodeParam calls, is used. WARNING: returned pointer may differ from buff and contain string longer than buffSize (ptr to original data source) 
-	void WINAPI CLEO_ReadStringParamWriteBuffer(CRunningScript* thread, char** outBuf, int* outBufSize, BOOL* outNeedsTerminator); // get info about the string opcode param, so it can be written latter. If outNeedsTerminator is not 0 then whole bufSize can be used as text characters. Advances script to next param
-	char* WINAPI CLEO_ReadParamsFormatted(CRunningScript* thread, const char* format, char* buf = nullptr, int bufSize = 0); // consumes all var-arg params and terminator
-	// get param value without advancing the script
-	DWORD WINAPI CLEO_PeekIntOpcodeParam(CRunningScript* thread);
-	float WINAPI CLEO_PeekFloatOpcodeParam(CRunningScript* thread);
-	SCRIPT_VAR* WINAPI CLEO_PeekPointerToScriptVariable(CRunningScript* thread); // get pointer to the variable's data, nullptr if parameter is not variable
-
-	// param skip without reading
-	void WINAPI CLEO_SkipOpcodeParams(CRunningScript* thread, int count);
-	void WINAPI CLEO_SkipUnusedVarArgs(CRunningScript* thread); // for var-args opcodes. Should be called even when all params were read (to skip var-arg terminator)
-
-	// param write
-	void WINAPI CLEO_RecordOpcodeParams(CRunningScript* thread, int count); // write multiple params from opcodeParams array
-	void WINAPI CLEO_SetIntOpcodeParam(CRunningScript* thread, DWORD value);
-	void WINAPI CLEO_SetFloatOpcodeParam(CRunningScript* thread, float value);
-	void WINAPI CLEO_WriteStringOpcodeParam(CRunningScript* thread, const char* str);
+    // scripts deletion callback
+    typedef void(*FuncScriptDeleteDelegateT) (CRunningScript* script);
+    void WINAPI CLEO_AddScriptDeleteDelegate(FuncScriptDeleteDelegateT func);
+    void WINAPI CLEO_RemoveScriptDeleteDelegate(FuncScriptDeleteDelegateT func);
 
 
-	BOOL WINAPI CLEO_GetScriptDebugMode(const CRunningScript* thread); // debug mode features enabled for this script?
-	void WINAPI CLEO_SetScriptDebugMode(CRunningScript* thread, BOOL enabled);
+    // script utils
+    BOOL WINAPI CLEO_IsScriptRunning(const CRunningScript* thread); // check if script is active
+    void WINAPI CLEO_GetScriptInfoStr(CRunningScript* thread, bool currLineInfo, char* buf, DWORD bufSize); // short text for displaying in error\log messages
+    void WINAPI CLEO_GetScriptParamInfoStr(int idexOffset, char* buf, DWORD bufSize); // short text with last processed + idexOffset opcode's parameter info (index and name if available)
+    DWORD WINAPI CLEO_GetScriptBaseRelativeOffset(const CRunningScript* script, const BYTE* codePos); // get offset within script source file
+    eCLEO_Version WINAPI CLEO_GetScriptVersion(const CRunningScript* thread); // get compatible version
+    void WINAPI CLEO_SetScriptVersion(CRunningScript* thread, eCLEO_Version version); // set compatible version
+    LPCSTR WINAPI CLEO_GetScriptFilename(const CRunningScript* thread); // returns nullptr if provided script ptr is not valid
 
-	CRunningScript* WINAPI CLEO_CreateCustomScript(CRunningScript* fromThread, const char* filePath, int label);
-	CRunningScript* WINAPI CLEO_GetLastCreatedCustomScript();
-	CRunningScript* WINAPI CLEO_GetScriptByName(const char* threadName, BOOL standardScripts, BOOL customScripts, DWORD resultIndex = 0); // can be called multiple times to find more scripts named threadName. resultIndex should be incremented until the method returns nullptr
-	CRunningScript* WINAPI CLEO_GetScriptByFilename(const char* path, DWORD resultIndex = 0); // can be absolute, partial path or just filename
+    LPCSTR WINAPI CLEO_GetScriptWorkDir(const CRunningScript* thread);
+    void WINAPI CLEO_SetScriptWorkDir(CRunningScript* thread, const char* path);
 
-	DWORD WINAPI CLEO_GetScriptTextureById(CRunningScript* thread, int id); // returns RwTexture*
+    void WINAPI CLEO_SetThreadCondResult(CRunningScript* thread, BOOL result);
+    void WINAPI CLEO_ThreadJumpAtLabelPtr(CRunningScript* thread, int offset);
+    void WINAPI CLEO_TerminateScript(CRunningScript* thread);
 
-	DWORD WINAPI CLEO_GetInternalAudioStream(CRunningScript* unused, DWORD scriptAudioStreamHandle); // returns BASS' HSTREAM
+    int WINAPI CLEO_GetOperandType(const CRunningScript* thread); // peek parameter data type. Returns int for legacy reason, should be eDataType.
+    DWORD WINAPI CLEO_GetVarArgCount(CRunningScript* thread); // peek remaining var-args count
 
-	struct StringList { DWORD count; char** strings; };
-	void WINAPI CLEO_StringListFree(StringList list); // releases resources used by StringList container
+    extern SCRIPT_VAR* opcodeParams;
+    extern SCRIPT_VAR* missionLocals;
+    extern CRunningScript* staticThreads;
 
-	// Should be always used when working with files. Provides ModLoader compatibility
-	void WINAPI CLEO_ResolvePath(CRunningScript* thread, char* inOutPath, DWORD pathMaxLen); // convert to absolute (file system) path
-	StringList WINAPI CLEO_ListDirectory(CRunningScript* thread, const char* searchPath, BOOL listDirs, BOOL listFiles); // thread can be null, searchPath can contain wildcards. After use CLEO_StringListFree must be called on returned StringList to free its resources
-	LPCSTR WINAPI CLEO_GetGameDirectory(); // absolute game directory filepath without trailling path separator
-	LPCSTR WINAPI CLEO_GetUserDirectory(); // absolute game user files directory filepath without trailling path separator
+    BYTE* WINAPI CLEO_GetScmMainData(); // get pointer to main script block. Supports limit adjusters
+    SCRIPT_VAR* WINAPI CLEO_GetOpcodeParamsArray(); // get pointer to 'SCRIPT_VAR[32] opcodeParams'. Used by Retrieve/Record opcode params functions
+    BYTE WINAPI CLEO_GetParamsHandledCount(); // number of already read/written opcode parameters since current opcode handler was called
 
-	void WINAPI CLEO_Log(eLogLevel level, const char* msg); // add message to log
+    // param read
+    SCRIPT_VAR* WINAPI CLEO_GetPointerToScriptVariable(CRunningScript* thread); // get pointer to the variable's data, nullptr if parameter is not variable. Advances script to next param
+    void WINAPI CLEO_RetrieveOpcodeParams(CRunningScript* thread, int count); // read multiple params. Stored in opcodeParams array
+    DWORD WINAPI CLEO_GetIntOpcodeParam(CRunningScript* thread);
+    float WINAPI CLEO_GetFloatOpcodeParam(CRunningScript* thread);
+    LPCSTR WINAPI CLEO_ReadStringOpcodeParam(CRunningScript* thread, char* buff = nullptr, int buffSize = 0); // read always null-terminated string into buffer, clamped to its size. If no buffer provided then internal, globally shared by all CLEO_ReadStringOpcodeParam calls, is used. Returns pointer to the result buffer or nullptr on fail
+    LPCSTR WINAPI CLEO_ReadStringPointerOpcodeParam(CRunningScript* thread, char* buff = nullptr, int buffSize = 0); // read always null-terminated string into buffer, clamped to its size. If no buffer provided then internal, globally shared by all CLEO_ReadStringPointerOpcodeParam calls, is used. WARNING: returned pointer may differ from buff and contain string longer than buffSize (ptr to original data source) 
+    void WINAPI CLEO_ReadStringParamWriteBuffer(CRunningScript* thread, char** outBuf, int* outBufSize, BOOL* outNeedsTerminator); // get info about the string opcode param, so it can be written latter. If outNeedsTerminator is not 0 then whole bufSize can be used as text characters. Advances script to next param
+    char* WINAPI CLEO_ReadParamsFormatted(CRunningScript* thread, const char* format, char* buf = nullptr, int bufSize = 0); // consumes all var-arg params and terminator
+    // get param value without advancing the script
+    DWORD WINAPI CLEO_PeekIntOpcodeParam(CRunningScript* thread);
+    float WINAPI CLEO_PeekFloatOpcodeParam(CRunningScript* thread);
+    SCRIPT_VAR* WINAPI CLEO_PeekPointerToScriptVariable(CRunningScript* thread); // get pointer to the variable's data, nullptr if parameter is not variable
+
+    // param skip without reading
+    void WINAPI CLEO_SkipOpcodeParams(CRunningScript* thread, int count);
+    void WINAPI CLEO_SkipUnusedVarArgs(CRunningScript* thread); // for var-args opcodes. Should be called even when all params were read (to skip var-arg terminator)
+
+    // param write
+    void WINAPI CLEO_RecordOpcodeParams(CRunningScript* thread, int count); // write multiple params from opcodeParams array
+    void WINAPI CLEO_SetIntOpcodeParam(CRunningScript* thread, DWORD value);
+    void WINAPI CLEO_SetFloatOpcodeParam(CRunningScript* thread, float value);
+    void WINAPI CLEO_WriteStringOpcodeParam(CRunningScript* thread, const char* str);
+
+
+    BOOL WINAPI CLEO_GetScriptDebugMode(const CRunningScript* thread); // debug mode features enabled for this script?
+    void WINAPI CLEO_SetScriptDebugMode(CRunningScript* thread, BOOL enabled);
+
+    CRunningScript* WINAPI CLEO_CreateCustomScript(CRunningScript* fromThread, const char* filePath, int label);
+    CRunningScript* WINAPI CLEO_GetLastCreatedCustomScript();
+    CRunningScript* WINAPI CLEO_GetScriptByName(const char* threadName, BOOL standardScripts, BOOL customScripts, DWORD resultIndex = 0); // can be called multiple times to find more scripts named threadName. resultIndex should be incremented until the method returns nullptr
+    CRunningScript* WINAPI CLEO_GetScriptByFilename(const char* path, DWORD resultIndex = 0); // can be absolute, partial path or just filename
+
+    DWORD WINAPI CLEO_GetScriptTextureById(CRunningScript* thread, int id); // returns RwTexture*
+
+    DWORD WINAPI CLEO_GetInternalAudioStream(CRunningScript* unused, DWORD scriptAudioStreamHandle); // returns BASS' HSTREAM
+
+    struct StringList { DWORD count; char** strings; };
+    void WINAPI CLEO_StringListFree(StringList list); // releases resources used by StringList container
+
+    // Should be always used when working with files. Provides ModLoader compatibility
+    void WINAPI CLEO_ResolvePath(CRunningScript* thread, char* inOutPath, DWORD pathMaxLen); // convert to absolute (file system) path
+    StringList WINAPI CLEO_ListDirectory(CRunningScript* thread, const char* searchPath, BOOL listDirs, BOOL listFiles); // thread can be null, searchPath can contain wildcards. After use CLEO_StringListFree must be called on returned StringList to free its resources
+    LPCSTR WINAPI CLEO_GetGameDirectory(); // absolute game directory filepath without trailling path separator
+    LPCSTR WINAPI CLEO_GetUserDirectory(); // absolute game user files directory filepath without trailling path separator
+
+    void WINAPI CLEO_Log(eLogLevel level, const char* msg); // add message to log
 }
 
 #pragma pack(push,1)
 class CRunningScript
 {
 public:
-	CRunningScript* Next;		// 0x00 next script in queue
-	CRunningScript* Previous;	// 0x04 previous script in queue
-	char Name[8];				// 0x08 name of script, given by 03A4 opcode
-	void* BaseIP;				// 0x10 pointer to begin of script in memory
-	BYTE* CurrentIP;			// 0x14 current instruction pointer
-	BYTE* Stack[8];				// 0x18 return stack for 0050, 0051
-	WORD SP;					// 0x38 current item in stack
-	BYTE _pad3A[2];				// 0x3A padding
-	SCRIPT_VAR LocalVar[32];	// 0x3C script's local variables
-	DWORD Timers[2];			// 0xBC script's timers
-	bool bIsActive;				// 0xC4 is script active
-	bool bCondResult;			// 0xC5 condition result. Use SetConditionResult to modify!
-	bool bUseMissionCleanup;	// 0xC6 clean mission
-	bool bIsExternal;			// 0xC7 is thread external (from script.img)
-	bool bTextBlockOverride;	// 0xC8
-	BYTE bExternalType;			// 0xC9
-	BYTE _padCA[2];				// 0xCA padding
-	DWORD WakeTime;				// 0xCC time, when script starts again after 0001 opcode
-	eLogicalOperation LogicalOp;// 0xD0 opcode 00D6 parameter
-	bool NotFlag;				// 0xD2 opcode & 0x8000 != 0
-	bool bWastedBustedCheck;	// 0xD3 wasted_or_busted check flag
-	bool bWastedOrBusted;		// 0xD4 is player wasted or busted
-	char _padD5[3];				// 0xD5 padding
-	void* SceneSkipIP;			// 0xD8 scene skip label ptr
-	bool bIsMission;			// 0xDC is this script mission
-	WORD ScmFunction;			// 0xDD CLEO's previous scmFunction id
-	bool bIsCustom;				// 0xDF is this CLEO script
+    CRunningScript* Next;        // 0x00 next script in queue
+    CRunningScript* Previous;    // 0x04 previous script in queue
+    char Name[8];                // 0x08 name of script, given by 03A4 opcode
+    void* BaseIP;                // 0x10 pointer to begin of script in memory
+    BYTE* CurrentIP;             // 0x14 current instruction pointer
+    BYTE* Stack[8];              // 0x18 return stack for 0050, 0051
+    WORD SP;                     // 0x38 current item in stack
+    BYTE _pad3A[2];              // 0x3A padding
+    SCRIPT_VAR LocalVar[32];     // 0x3C script's local variables
+    DWORD Timers[2];             // 0xBC script's timers
+    bool bIsActive;              // 0xC4 is script active
+    bool bCondResult;            // 0xC5 condition result. Use SetConditionResult to modify!
+    bool bUseMissionCleanup;     // 0xC6 clean mission
+    bool bIsExternal;            // 0xC7 is thread external (from script.img)
+    bool bTextBlockOverride;     // 0xC8
+    BYTE bExternalType;          // 0xC9
+    BYTE _padCA[2];              // 0xCA padding
+    DWORD WakeTime;              // 0xCC time, when script starts again after 0001 opcode
+    eLogicalOperation LogicalOp; // 0xD0 opcode 00D6 parameter
+    bool NotFlag;                // 0xD2 opcode & 0x8000 != 0
+    bool bWastedBustedCheck;     // 0xD3 wasted_or_busted check flag
+    bool bWastedOrBusted;        // 0xD4 is player wasted or busted
+    char _padD5[3];              // 0xD5 padding
+    void* SceneSkipIP;           // 0xD8 scene skip label ptr
+    bool bIsMission;             // 0xDC is this script mission
+    WORD ScmFunction;            // 0xDD CLEO's previous scmFunction id
+    bool bIsCustom;              // 0xDF is this CLEO script
 
 public:
-	CRunningScript()
-	{
-		strcpy_s(Name, "noname");
-		BaseIP = 0;
-		Previous = 0;
-		Next = 0;
-		CurrentIP = 0;
-		memset(Stack, 0, sizeof(Stack));
-		SP = 0;
-		WakeTime = 0;
-		bIsActive = false;
-		bCondResult = false;
-		bUseMissionCleanup = false;
-		bIsExternal = false;
-		bTextBlockOverride = false;
-		bExternalType = -1;
-		memset(LocalVar, 0, sizeof(LocalVar));
-		LogicalOp = eLogicalOperation::NONE;
-		NotFlag = false;
-		bWastedBustedCheck = true;
-		bWastedOrBusted = false;
-		SceneSkipIP = 0;
-		bIsMission = false;
-		ScmFunction = 0;
-		bIsCustom = false;
-	}
+    CRunningScript()
+    {
+        strcpy_s(Name, "noname");
+        BaseIP = 0;
+        Previous = 0;
+        Next = 0;
+        CurrentIP = 0;
+        memset(Stack, 0, sizeof(Stack));
+        SP = 0;
+        WakeTime = 0;
+        bIsActive = false;
+        bCondResult = false;
+        bUseMissionCleanup = false;
+        bIsExternal = false;
+        bTextBlockOverride = false;
+        bExternalType = -1;
+        memset(LocalVar, 0, sizeof(LocalVar));
+        LogicalOp = eLogicalOperation::NONE;
+        NotFlag = false;
+        bWastedBustedCheck = true;
+        bWastedOrBusted = false;
+        SceneSkipIP = 0;
+        bIsMission = false;
+        ScmFunction = 0;
+        bIsCustom = false;
+    }
 
-	bool IsActive() const { return bIsActive; }
-	bool IsExternal() const { return bIsExternal; }
-	bool IsMission() const { return bIsMission; }
-	bool IsCustom() const { return bIsCustom; } // is this CLEO Script?
-	std::string GetName() const { auto str = std::string(Name, Name + 8); str.resize(strlen(str.c_str())); return str; } // make sure it is always null terminated
-	BYTE* GetBasePointer() const { return (BYTE*)BaseIP; }
-	BYTE* GetBytePointer() const { return CurrentIP; }
-	void SetIp(void* ip) { CurrentIP = (BYTE*)ip; }
-	void SetBaseIp(void* ip) { BaseIP = ip; }
-	void Jump(int offset) { CLEO_ThreadJumpAtLabelPtr(this, offset); }
-	CRunningScript* GetNext() const { return Next; }
-	CRunningScript* GetPrev() const { return Previous; }
-	void SetIsExternal(bool b) { bIsExternal = b; }
-	void SetActive(bool b) { bIsActive = b; }
-	OpcodeResult Suspend() { WakeTime = 0xFFFFFFFF; return OpcodeResult::OR_INTERRUPT; } // suspend script execution forever
-	void SetNext(CRunningScript* v) { Next = v; }
-	void SetPrev(CRunningScript* v) { Previous = v; }
-	SCRIPT_VAR* GetVarPtr() { return LocalVar; }
-	SCRIPT_VAR* GetVarPtr(int i) { return &LocalVar[i]; }
-	int* GetIntVarPtr(int i) { return (int*)&LocalVar[i].dwParam; }
-	int GetIntVar(int i) const { return LocalVar[i].dwParam; }
-	void SetIntVar(int i, int v) { LocalVar[i].dwParam = v; }
-	void SetFloatVar(int i, float v) { LocalVar[i].fParam = v; }
-	char GetByteVar(int i) const { return LocalVar[i].bParam; }
-	bool GetConditionResult() const { return bCondResult != false; }
-	void SetConditionResult(bool result) { CLEO_SetThreadCondResult(this, result); }
-	bool GetNotFlag() const { return NotFlag; }
-	void SetNotFlag(bool state) { NotFlag = state; }
+    bool IsActive() const { return bIsActive; }
+    bool IsExternal() const { return bIsExternal; }
+    bool IsMission() const { return bIsMission; }
+    bool IsCustom() const { return bIsCustom; } // is this CLEO Script?
+    std::string GetName() const { auto str = std::string(Name, Name + 8); str.resize(strlen(str.c_str())); return str; } // make sure it is always null terminated
+    BYTE* GetBasePointer() const { return (BYTE*)BaseIP; }
+    BYTE* GetBytePointer() const { return CurrentIP; }
+    void SetIp(void* ip) { CurrentIP = (BYTE*)ip; }
+    void SetBaseIp(void* ip) { BaseIP = ip; }
+    void Jump(int offset) { CLEO_ThreadJumpAtLabelPtr(this, offset); }
+    CRunningScript* GetNext() const { return Next; }
+    CRunningScript* GetPrev() const { return Previous; }
+    void SetIsExternal(bool b) { bIsExternal = b; }
+    void SetActive(bool b) { bIsActive = b; }
+    OpcodeResult Suspend() { WakeTime = 0xFFFFFFFF; return OpcodeResult::OR_INTERRUPT; } // suspend script execution forever
+    void SetNext(CRunningScript* v) { Next = v; }
+    void SetPrev(CRunningScript* v) { Previous = v; }
+    SCRIPT_VAR* GetVarPtr() { return LocalVar; }
+    SCRIPT_VAR* GetVarPtr(int i) { return &LocalVar[i]; }
+    int* GetIntVarPtr(int i) { return (int*)&LocalVar[i].dwParam; }
+    int GetIntVar(int i) const { return LocalVar[i].dwParam; }
+    void SetIntVar(int i, int v) { LocalVar[i].dwParam = v; }
+    void SetFloatVar(int i, float v) { LocalVar[i].fParam = v; }
+    char GetByteVar(int i) const { return LocalVar[i].bParam; }
+    bool GetConditionResult() const { return bCondResult != false; }
+    void SetConditionResult(bool result) { CLEO_SetThreadCondResult(this, result); }
+    bool GetNotFlag() const { return NotFlag; }
+    void SetNotFlag(bool state) { NotFlag = state; }
 
-	eDataType PeekDataType() const { return *(eDataType*)CurrentIP; }
-	eDataType ReadDataType() { return (eDataType)ReadByte(); }
+    eDataType PeekDataType() const { return *(eDataType*)CurrentIP; }
+    eDataType ReadDataType() { return (eDataType)ReadByte(); }
 
-	eArrayDataType PeekArrayType() const { return (eArrayDataType)(!IsArray(PeekDataType()) ? ADT_NONE : *(CurrentIP + 1 + 2 + 2 + 1) & ArrayTypeMask); }
-	WORD ReadVarIndex() { return ReadWord(); }
-	WORD ReadArrayOffset() { return ReadWord(); }
-	WORD ReadArrayIndexVarIndex() { return ReadWord(); } // index of variable sotring array element index
-	BYTE ReadArraySize() { return ReadByte(); }
-	BYTE ReadArrayFlags() { return ReadByte(); }
+    eArrayDataType PeekArrayType() const { return (eArrayDataType)(!IsArray(PeekDataType()) ? ADT_NONE : *(CurrentIP + 1 + 2 + 2 + 1) & ArrayTypeMask); }
+    WORD ReadVarIndex() { return ReadWord(); }
+    WORD ReadArrayOffset() { return ReadWord(); }
+    WORD ReadArrayIndexVarIndex() { return ReadWord(); } // index of variable sotring array element index
+    BYTE ReadArraySize() { return ReadByte(); }
+    BYTE ReadArrayFlags() { return ReadByte(); }
 
-	void IncPtr(int n = 1) { CurrentIP += n; }
-	BYTE ReadByte() { BYTE b = *CurrentIP; CurrentIP += sizeof(BYTE); return b; }
-	WORD ReadWord() { WORD v = *(WORD*)CurrentIP; CurrentIP += sizeof(WORD); return v; }
-	DWORD ReadDword() { DWORD i = *(DWORD*)CurrentIP; CurrentIP += sizeof(DWORD); return i; }
+    void IncPtr(int n = 1) { CurrentIP += n; }
+    BYTE ReadByte() { BYTE b = *CurrentIP; CurrentIP += sizeof(BYTE); return b; }
+    WORD ReadWord() { WORD v = *(WORD*)CurrentIP; CurrentIP += sizeof(WORD); return v; }
+    DWORD ReadDword() { DWORD i = *(DWORD*)CurrentIP; CurrentIP += sizeof(DWORD); return i; }
 
-	void PushStack(BYTE* ptr) { Stack[SP++] = ptr; }
-	BYTE* PopStack() { return Stack[--SP]; }
+    void PushStack(BYTE* ptr) { Stack[SP++] = ptr; }
+    BYTE* PopStack() { return Stack[--SP]; }
 
-	WORD GetScmFunction() const { return ScmFunction; }
-	void SetScmFunction(WORD id) { ScmFunction = id; }
+    WORD GetScmFunction() const { return ScmFunction; }
+    void SetScmFunction(WORD id) { ScmFunction = id; }
 };
 #pragma pack(pop)
 static_assert(sizeof(CRunningScript) == 0xE0, "Invalid size of CRunningScript!");

--- a/source/CCustomOpcodeSystem.cpp
+++ b/source/CCustomOpcodeSystem.cpp
@@ -7,1088 +7,1088 @@
 
 namespace CLEO
 {
-	CRunningScript* CCustomOpcodeSystem::lastScript = nullptr;
-	WORD CCustomOpcodeSystem::lastOpcode = 0xFFFF;
-	WORD* CCustomOpcodeSystem::lastOpcodePtr = nullptr;
-	WORD CCustomOpcodeSystem::lastCustomOpcode = 0;
-	std::string CCustomOpcodeSystem::lastErrorMsg = {};
-	WORD CCustomOpcodeSystem::prevOpcode = 0xFFFF;
-	BYTE CCustomOpcodeSystem::handledParamCount = 0;
-
-	// opcode handler for custom opcodes
-	OpcodeResult __fastcall CCustomOpcodeSystem::customOpcodeHandler(CRunningScript *thread, int dummy, WORD opcode)
-	{
-		OpcodeResult result = OR_NONE;
-
-		auto AfterOpcodeExecuted = [&]()
-		{
-			// execute registered callbacks
-			OpcodeResult callbackResult = OR_NONE;
-			for (void* func : CleoInstance.GetCallbacks(eCallbackId::ScriptOpcodeProcessAfter))
-			{
-				typedef OpcodeResult WINAPI callback(CRunningScript*, DWORD, OpcodeResult);
-				auto res = ((callback*)func)(thread, opcode, result);
-
-				callbackResult = std::max(res, callbackResult); // store result with highest value from all callbacks
-			}
-
-			return (callbackResult != OR_NONE) ? callbackResult : result;
-		};
-
-		prevOpcode = (thread != lastScript) ? 0xFFFF : lastOpcode;
-		lastScript = thread;
-		lastOpcode = opcode;
-		lastOpcodePtr = (WORD*)thread->GetBytePointer() - 1; // rewind to the opcode start
-		handledParamCount = 0;
-
-		// prevent past code execution
-		if (thread->IsCustom() && !IsLegacyScript(thread))
-		{
-			auto cs = (CCustomScript*)thread;
-			auto endPos = cs->GetBasePointer() + cs->GetCodeSize();
-			if ((BYTE*)lastOpcodePtr == endPos || (BYTE*)lastOpcodePtr == (endPos - 1)) // consider script can end with incomplete opcode
-			{
-				SHOW_ERROR_COMPAT("Code execution past script end in script %s\nThis usually happens when [004E] command is missing.\nScript suspended.", ScriptInfoStr(thread).c_str());
-				result = thread->Suspend();
-				return AfterOpcodeExecuted();
-			}
-		}
-
-		// execute registered callbacks
-		for (void* func : CleoInstance.GetCallbacks(eCallbackId::ScriptOpcodeProcessBefore))
-		{
-			typedef OpcodeResult WINAPI callback(CRunningScript*, DWORD);
-			result = ((callback*)func)(thread, opcode);
-
-			if(result != OR_NONE)
-				break; // processed
-		}
-
-		if (result == OR_NONE) // opcode not proccessed yet
-		{
-			if(opcode > Opcode_Max)
-			{
-				SHOW_ERROR("Opcode [%04X] out of supported range! \nCalled in script %s\nScript suspended.", opcode, ScriptInfoStr(thread).c_str());
-				result = thread->Suspend();
-				return AfterOpcodeExecuted();
-			}
-
-			CustomOpcodeHandler handler = customOpcodeProc[opcode];
-			if (handler != nullptr)
-			{
-				lastCustomOpcode = opcode;
-				result = handler(thread);
-				return AfterOpcodeExecuted();
-			}
-
-			// Not registered as custom opcode. Call game's original handler
-			result = CallNativeOpcode(thread, opcode);
-			if(result == OR_ERROR)
-			{
-				auto extensionMsg = CleoInstance.OpcodeInfoDb.GetExtensionMissingMessage(opcode);
-				if (!extensionMsg.empty()) extensionMsg = " " + extensionMsg;
-
-				SHOW_ERROR("Opcode [%04X] not found!%s\nCalled in script %s\nScript suspended.",
-					opcode,
-					extensionMsg.c_str(),
-					ScriptInfoStr(thread).c_str());
-
-				result = thread->Suspend();
-				return AfterOpcodeExecuted();
-			}
-		}
-
-		return AfterOpcodeExecuted();
-	}
-
-	void CCustomOpcodeSystem::FinalizeScriptObjects()
-	{
-		TRACE("Cleaning up script data...");
-
-		CleoInstance.CallCallbacks(eCallbackId::ScriptsFinalize);
-
-		// clean up after opcode_0AB1
-		ScmFunction::Clear();
-	}
-
-	void CCustomOpcodeSystem::Inject(CCodeInjector& inj)
-	{
-		TRACE("Injecting CustomOpcodeSystem...");
-		CGameVersionManager& gvm = CleoInstance.VersionManager;
-
-		// replace all handlers in original table
-		// store original opcode handlers for later use
-		auto handlersTable = (OpcodeHandler*)::CRunningScript::CommandHandlerTable;
-		for(size_t i = 0; i < OriginalOpcodeHandlersCount; i++)
-		{
-			originalOpcodeHandlers[i] = handlersTable[i];
-			handlersTable[i] = (OpcodeHandler)customOpcodeHandler;
-		}
-
-		// initialize and apply new handlers table
-		for (size_t i = 0; i < CustomOpcodeHandlersCount; i++)
-		{
-			customOpcodeHandlers[i] = (OpcodeHandler)customOpcodeHandler;
-		}
-
-		inj.MemoryWrite(gvm.TranslateMemoryAddress(MA_OPCODE_HANDLER_REF_1), &customOpcodeHandlers);
-		inj.MemoryWrite(gvm.TranslateMemoryAddress(MA_OPCODE_HANDLER_REF_2), &customOpcodeHandlers);
-	}
-
-	void CCustomOpcodeSystem::Init()
-	{
-		if (initialized) return;
-
-		TRACE(""); // separator
-		TRACE("Initializing CLEO core opcodes...");
-
-		CLEO_RegisterOpcode(0x004E, opcode_004E);
-		CLEO_RegisterOpcode(0x0051, opcode_0051);
-		CLEO_RegisterOpcode(0x0417, opcode_0417);
-		CLEO_RegisterOpcode(0x0A92, opcode_0A92);
-		CLEO_RegisterOpcode(0x0A93, opcode_0A93);
-		CLEO_RegisterOpcode(0x0A94, opcode_0A94);
-		CLEO_RegisterOpcode(0x0A95, opcode_0A95);
-		CLEO_RegisterOpcode(0x0AA0, opcode_0AA0);
-		CLEO_RegisterOpcode(0x0AA1, opcode_0AA1);
-		CLEO_RegisterOpcode(0x0AA9, opcode_0AA9);
-		CLEO_RegisterOpcode(0x0AB1, opcode_0AB1);
-		CLEO_RegisterOpcode(0x0AB2, opcode_0AB2);
-		CLEO_RegisterOpcode(0x0AB3, opcode_0AB3);
-		CLEO_RegisterOpcode(0x0AB4, opcode_0AB4);
-
-		CLEO_RegisterOpcode(0x0DD5, opcode_0DD5); // get_platform
-
-		CLEO_RegisterOpcode(0x2000, opcode_2000); // get_cleo_arg_count
-		// 2001 free
-		CLEO_RegisterOpcode(0x2002, opcode_2002); // cleo_return_with
-		CLEO_RegisterOpcode(0x2003, opcode_2003); // cleo_return_fail
-
-		initialized = true;
-	}
-
-	CCustomOpcodeSystem::~CCustomOpcodeSystem()
-	{
-		TRACE(""); // separator
-		TRACE("Custom Opcode System finalized:");
-		TRACE(" Last opcode executed: %04X", lastOpcode);
-		TRACE(" Previous opcode executed: %04X", prevOpcode);
-	}
-
-	CCustomOpcodeSystem::OpcodeHandler CCustomOpcodeSystem::originalOpcodeHandlers[OriginalOpcodeHandlersCount];
-	CCustomOpcodeSystem::OpcodeHandler CCustomOpcodeSystem::customOpcodeHandlers[CustomOpcodeHandlersCount];
-	CustomOpcodeHandler CCustomOpcodeSystem::customOpcodeProc[Opcode_Max + 1];
-
-	bool CCustomOpcodeSystem::RegisterOpcode(WORD opcode, CustomOpcodeHandler callback)
-	{
-		if (opcode > Opcode_Max)
-		{
-			SHOW_ERROR("Can not register [%04X] opcode! Out of supported range.", opcode);
-			return false;
-		}
-
-		CustomOpcodeHandler& dst = customOpcodeProc[opcode];
-		if (*dst != nullptr)
-		{
-			LOG_WARNING(0, "Opcode [%04X] already registered! Replacing...", opcode);
-		}
-
-		dst = callback;
-		TRACE("Opcode [%04X] registered", opcode);
-		return true;
-	}
-
-	OpcodeResult _CallNativeOpcode(CRunningScript* thread, void* handler, DWORD opcode)
-	{
-		// wrapped in separate function as otherwise some problems occur in debug builds
-		OpcodeResult result;
-		_asm
-		{
-			push opcode
-			mov ecx, thread
-			call handler
-			mov result, al
-		}
-		return result;
-	}
-
-	OpcodeResult CCustomOpcodeSystem::CallNativeOpcode(CRunningScript* thread, WORD opcode)
-	{
-		if (opcode > Opcode_Max_Native)
-		{
-			return OR_ERROR;
-		}
-
-		size_t tableIdx = opcode / Opcode_Table_Size;
-		return _CallNativeOpcode(thread, originalOpcodeHandlers[tableIdx], opcode);
-	}
-
-	const char* ReadStringParam(CRunningScript *thread, char* buff, int buffSize)
-	{
-		if (buffSize > 0) buff[buffSize - 1] = '\0'; // buffer always terminated
-		return GetScriptStringParam(thread, 0, buff, buffSize - 1); // minus terminator
-	}
-
-	// write output\result string parameter
-	bool WriteStringParam(CRunningScript* thread, const char* str)
-	{
-		auto target = GetStringParamWriteBuffer(thread);
-		return WriteStringParam(target, str);
-	}
-
-	bool WriteStringParam(const StringParamBufferInfo& target, const char* str)
-	{
-		CCustomOpcodeSystem::lastErrorMsg.clear();
-
-		if (str != nullptr && (size_t)str <= MinValidAddress)
-		{
-			CCustomOpcodeSystem::lastErrorMsg = StringPrintf("Writing string from invalid '0x%X' pointer", target.data);
-			return false;
-		}
-
-		if ((size_t)target.data <= MinValidAddress)
-		{
-			CCustomOpcodeSystem::lastErrorMsg = StringPrintf("Writing string into invalid '0x%X' pointer argument", target.data);
-			return false;
-		}
-
-		if (target.size == 0)
-		{
-			return false;
-		}
-
-		bool addTerminator = target.needTerminator;
-		size_t buffLen = target.size - addTerminator;
-		size_t length = str == nullptr ? 0 : strlen(str);
-
-		if (buffLen > length) addTerminator = true; // there is space left for terminator
-
-		length = std::min(length, buffLen);
-		if (length > 0) std::memcpy(target.data, str, length);
-		if (addTerminator) target.data[length] = '\0';
-
-		return true;
-	}
-
-	StringParamBufferInfo GetStringParamWriteBuffer(CRunningScript* thread)
-	{
-		StringParamBufferInfo result;
-		CCustomOpcodeSystem::lastErrorMsg.clear();
-
-		auto paramType = thread->PeekDataType();
-		if (IsImmInteger(paramType) || IsVariable(paramType))
-		{
-			// address to output buffer
-			CScriptEngine::GetScriptParams(thread, 1);
-
-			if (opcodeParams[0].dwParam <= MinValidAddress)
-			{
-				CCustomOpcodeSystem::lastErrorMsg = StringPrintf("Writing string into invalid '0x%X' pointer argument", opcodeParams[0].dwParam);
-				return result; // error
-			}
-
-			result.data = opcodeParams[0].pcParam;
-			result.size = 0x7FFFFFFF; // user allocated memory block can be any size
-			result.needTerminator = true;
-
-			return result;
-		}
-		else
-		if (IsVarString(paramType))
-		{
-			switch(paramType)
-			{
-				// short string variable
-				case DT_VAR_TEXTLABEL:
-				case DT_LVAR_TEXTLABEL:
-				case DT_VAR_TEXTLABEL_ARRAY:
-				case DT_LVAR_TEXTLABEL_ARRAY:
-					result.data = (char*)CScriptEngine::GetScriptParamPointer(thread);
-					result.size = 8;
-					result.needTerminator = false;
-					return result;
-
-				// long string variable
-				case DT_VAR_STRING:
-				case DT_LVAR_STRING:
-				case DT_VAR_STRING_ARRAY:
-				case DT_LVAR_STRING_ARRAY:
-					result.data = (char*)CScriptEngine::GetScriptParamPointer(thread);
-					result.size = 16;
-					result.needTerminator = false;
-					return result;
-			}
-		}
-
-		CCustomOpcodeSystem::lastErrorMsg = StringPrintf("Writing string, got argument %s", ToKindStr(paramType));
-		CLEO_SkipOpcodeParams(thread, 1); // skip unhandled param
-		return result; // error
-	}
-
-	// perform 'sprintf'-operation for parameters, passed through SCM
-	int ReadFormattedString(CRunningScript *thread, char *outputStr, DWORD len, const char *format)
-	{
-		unsigned int written = 0;
-		const char *iter = format;
-		char* outIter = outputStr;
-		char bufa[MAX_STR_LEN + 1], fmtbufa[64], *fmta;
-
-		// invalid input arguments
-		if(outputStr == nullptr || len == 0)
-		{
-			LOG_WARNING(thread, "ReadFormattedString invalid input arg(s) in script %s", ScriptInfoStr(thread).c_str());
-			SkipUnusedVarArgs(thread);
-			return -1; // error
-		}
-
-		if(len > 1 && format != nullptr)
-		{
-			while (*iter)
-			{
-				while (*iter && *iter != '%')
-				{
-					if (written++ >= len) goto _ReadFormattedString_OutOfMemory;
-					*outIter++ = *iter++;
-				}
-
-				if (*iter == '%')
-				{
-					// end of format string
-					if (iter[1] == '\0')
-					{
-						LOG_WARNING(thread, "ReadFormattedString encountered incomplete format specifier in script %s", ScriptInfoStr(thread).c_str());
-						SkipUnusedVarArgs(thread);
-						return -1; // error
-					}
-
-					// escaped % character
-					if (iter[1] == '%')
-					{
-						if (written++ >= len) goto _ReadFormattedString_OutOfMemory;
-						*outIter++ = '%';
-						iter += 2;
-						continue;
-					}
-
-					//get flags and width specifier
-					fmta = fmtbufa;
-					*fmta++ = *iter++;
-					while (*iter == '0' ||
-						   *iter == '+' ||
-						   *iter == '-' ||
-						   *iter == ' ' ||
-						   *iter == '*' ||
-						   *iter == '#')
-					{
-						if (*iter == '*')
-						{
-							//get width
-							if (thread->PeekDataType() == DT_END) goto _ReadFormattedString_ArgMissing;
-							CScriptEngine::GetScriptParams(thread, 1);
-							_itoa_s(opcodeParams[0].dwParam, bufa, 10);
-
-							char* buffiter = bufa;
-							while (*buffiter)
-								*fmta++ = *buffiter++;
-						}
-						else
-							*fmta++ = *iter;
-						iter++;
-					}
-
-					//get immidiate width value
-					while (isdigit(*iter))
-						*fmta++ = *iter++;
-
-					//get precision
-					if (*iter == '.')
-					{
-						*fmta++ = *iter++;
-						if (*iter == '*')
-						{
-							if (thread->PeekDataType() == DT_END) goto _ReadFormattedString_ArgMissing;
-							CScriptEngine::GetScriptParams(thread, 1);
-							_itoa_s(opcodeParams[0].dwParam, bufa, 10);
-
-							char* buffiter = bufa;
-							while (*buffiter)
-								*fmta++ = *buffiter++;
-						}
-						else
-							while (isdigit(*iter))
-								*fmta++ = *iter++;
-					}
-					//get size
-					if (*iter == 'h' || *iter == 'l')
-						*fmta++ = *iter++;
-
-					switch (*iter)
-					{
-					case 's':
-					{
-						if (thread->PeekDataType() == DT_END) goto _ReadFormattedString_ArgMissing;
-
-						const char* str = ReadStringParam(thread, bufa, sizeof(bufa));
-						if(str == nullptr) // read error
-						{
-							static const char none[] = "(INVALID_STR)";
-							str = none;
-						}
-						
-						while (*str)
-						{
-							if (written++ >= len) goto _ReadFormattedString_OutOfMemory;
-							*outIter++ = *str++;
-						}
-						iter++;
-						break;
-					}
-
-					case 'c':
-						if (written++ >= len) goto _ReadFormattedString_OutOfMemory;
-						if (thread->PeekDataType() == DT_END) goto _ReadFormattedString_ArgMissing;
-						CScriptEngine::GetScriptParams(thread, 1);
-						*outIter++ = (char)opcodeParams[0].nParam;
-						iter++;
-						break;
-
-					default:
-					{
-						/* For non wc types, use system sprintf and append to wide char output */
-						/* FIXME: for unrecognised types, should ignore % when printing */
-						if (*iter == 'p' || *iter == 'P')
-						{
-							if (thread->PeekDataType() == DT_END) goto _ReadFormattedString_ArgMissing;
-							CScriptEngine::GetScriptParams(thread, 1);
-							sprintf_s(bufa, "%08X", opcodeParams[0].dwParam);
-						}
-						else
-						{
-							*fmta++ = *iter;
-							*fmta = '\0';
-							if (*iter == 'a' || *iter == 'A' ||
-								*iter == 'e' || *iter == 'E' ||
-								*iter == 'f' || *iter == 'F' ||
-								*iter == 'g' || *iter == 'G')
-							{
-								if (thread->PeekDataType() == DT_END) goto _ReadFormattedString_ArgMissing;
-								CScriptEngine::GetScriptParams(thread, 1);
-								sprintf_s(bufa, fmtbufa, opcodeParams[0].fParam);
-							}
-							else
-							{
-								if (thread->PeekDataType() == DT_END) goto _ReadFormattedString_ArgMissing;
-								CScriptEngine::GetScriptParams(thread, 1);
-								sprintf_s(bufa, fmtbufa, opcodeParams[0].pParam);
-							}
-						}
-						char* bufaiter = bufa;
-						while (*bufaiter)
-						{
-							if (written++ >= len) goto _ReadFormattedString_OutOfMemory;
-							*outIter++ = *bufaiter++;
-						}
-						iter++;
-						break;
-					}
-					}
-				}
-			}
-		}
-
-		if (written >= len)
-		{
-		_ReadFormattedString_OutOfMemory: // jump here on error
-
-			LOG_WARNING(thread, "Target buffer too small (%d) to read whole formatted string in script %s", len, ScriptInfoStr(thread).c_str());
-			SkipUnusedVarArgs(thread);
-			outputStr[len - 1] = '\0';
-			return -1; // error
-		}
-
-		// still more var-args available
-		if (thread->PeekDataType() != DT_END)
-		{
-			LOG_WARNING(thread, "More arguments than tokens in format string in script %s", ScriptInfoStr(thread).c_str());
-		}
-		SkipUnusedVarArgs(thread); // skip terminator too
-
-		outputStr[written] = '\0';
-		return (int)written;
-
-	_ReadFormattedString_ArgMissing: // jump here on error
-		LOG_WARNING(thread, "More tokens in format string than arguments in script %s", ScriptInfoStr(thread).c_str());
-		thread->IncPtr(); // skip vararg terminator
-		outputStr[written] = '\0';
-		return -1; // error
-	}
-
-	OpcodeResult CCustomOpcodeSystem::CleoReturnGeneric(WORD opcode, CRunningScript* thread, bool returnArgs, DWORD returnArgCount, bool strictArgCount)
-	{
-		auto cs = reinterpret_cast<CCustomScript*>(thread);
-
-		ScmFunction* scmFunc = ScmFunction::Get(cs->GetScmFunction());
-		if (scmFunc == nullptr)
-		{
-			SHOW_ERROR("Invalid Cleo Call reference. [%04X] possibly used without preceding [0AB1] in script %s\nScript suspended.", opcode, cs->GetInfoStr().c_str());
-			return thread->Suspend();
-		}
-
-		// store return arguments
-		static SCRIPT_VAR arguments[32];
-		static bool argumentIsStr[32];
-		std::forward_list<std::string> stringParams; // scope guard for strings
-		if (returnArgs)
-		{
-			if (returnArgCount > 32)
-			{
-				SHOW_ERROR("Opcode [%04X] has too many (%d) args in script %s\nScript suspended.", opcode, returnArgCount, cs->GetInfoStr().c_str());
-				return thread->Suspend();
-			}
-
-			auto nVarArg = GetVarArgCount(thread);
-			if (returnArgCount > nVarArg)
-			{
-				SHOW_ERROR("Opcode [%04X] declared %d args, but %d was provided in script %s\nScript suspended.", opcode, returnArgCount, nVarArg, ScriptInfoStr(thread).c_str());
-				return thread->Suspend();
-			}
-
-			for (DWORD i = 0; i < returnArgCount; i++)
-			{
-				SCRIPT_VAR* arg = arguments + i;
-				argumentIsStr[i] = false;
-
-				auto paramType = (eDataType)*thread->GetBytePointer();
-				if (IsImmInteger(paramType) || IsVariable(paramType))
-				{
-					arg->dwParam = CLEO_GetIntOpcodeParam(thread);
-				}
-				else if (paramType == DT_FLOAT)
-				{
-					arg->fParam = CLEO_GetFloatOpcodeParam(thread);
-				}
-				else if (IsImmString(paramType) || IsVarString(paramType))
-				{
-					argumentIsStr[i] = true;
-
-					OPCODE_READ_PARAM_STRING(str);
-					stringParams.emplace_front(str);
-					arg->pcParam = stringParams.front().data();
-				}
-				else
-				{
-					SHOW_ERROR("Invalid argument type '0x%02X' in opcode [%04X] in script %s\nScript suspended.", paramType, opcode, ScriptInfoStr(thread).c_str());
-					return thread->Suspend();
-				}
-			}
-		}
-
-		// handle program flow
-		scmFunc->Return(cs); // jump back to cleo_call, right after last input param. Return slot var args starts here
-		delete scmFunc;
-
-		if (returnArgs)
-		{
-			DWORD returnSlotCount = GetVarArgCount(cs);
-			if (returnSlotCount != returnArgCount)
-			{
-				if (strictArgCount)
-				{
-					SHOW_ERROR_COMPAT("Opcode [%04X] returned %d params, while function caller expected %d in script %s\nScript suspended.", opcode, returnArgCount, returnSlotCount, cs->GetInfoStr().c_str());
-					return cs->Suspend();
-				}
-				else
-				{
-					LOG_WARNING(thread, "Opcode [%04X] returned %d params, while function caller expected %d in script %s", opcode, returnArgCount, returnSlotCount, cs->GetInfoStr().c_str());
-				}
-			}
-
-			// set return args
-			for (DWORD i = 0; i < std::min<DWORD>(returnArgCount, returnSlotCount); i++)
-			{
-				auto arg = (SCRIPT_VAR*)thread->GetBytePointer();
-
-				auto paramType = *(eDataType*)arg;
-				if (IsVarString(paramType))
-				{
-					OPCODE_WRITE_PARAM_STRING(arguments[i].pcParam);
-				} 
-				else if (IsVariable(paramType))
-				{
-					if (argumentIsStr[i]) // source was string, write it into provided buffer ptr
-					{
-						OPCODE_WRITE_PARAM_STRING(arguments[i].pcParam);
-					}
-					else
-						CLEO_SetIntOpcodeParam(thread, arguments[i].dwParam);
-				}
-				else
-				{
-					SHOW_ERROR("Invalid output argument type '0x%02X' in opcode [%04X] in script %s\nScript suspended.", paramType, opcode, ScriptInfoStr(thread).c_str());
-					return thread->Suspend();
-				}
-			}
-		}
-
-		SkipUnusedVarArgs(thread); // skip var args terminator too
-
-		return OR_CONTINUE;
-	}
-
-	void SkipUnusedVarArgs(CRunningScript *thread)
-	{
-		while (thread->PeekDataType() != DT_END)
-			CLEO_SkipOpcodeParams(thread, 1);
-
-		thread->IncPtr(); // skip terminator
-	}
-
-	DWORD GetVarArgCount(CRunningScript* thread)
-	{
-		// store state
-		const auto ip = thread->GetBytePointer();
-		const auto handledParams = CleoInstance.OpcodeSystem.handledParamCount;
-
-		DWORD count = 0;
-		while (thread->PeekDataType() != DT_END)
-		{
-			CLEO_SkipOpcodeParams(thread, 1);
-			count++;
-		}
-
-		// restore state
-		thread->SetIp(ip);
-		CleoInstance.OpcodeSystem.handledParamCount = handledParams;
-
-		return count;
-	}
-
-	/************************************************************************/
-	/*						Opcode definitions								*/
-	/************************************************************************/
-
-	// terminate_this_script
-	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_004E(CRunningScript* thread)
-	{
-		CleoInstance.ScriptEngine.RemoveScript(thread);
-		return OR_INTERRUPT;
-	}
-
-	// GOSUB return
-	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0051(CRunningScript* thread)
-	{
-		if (thread->SP == 0 && !IsLegacyScript(thread)) // CLEO5 - allow use of GOSUB `return` to exit cleo calls too
-		{
-			OPCODE_CONDITION_RESULT(false);
-			return CleoInstance.OpcodeSystem.CleoReturnGeneric(0x0051, thread, false); // try CLEO's function return
-		}
-
-		if (thread->SP == 0)
-		{
-			SHOW_ERROR("`return` used without preceding `gosub` call in script %s\nScript suspended.", ScriptInfoStr(thread).c_str());
-			return thread->Suspend();
-		}
-
-		return CallNativeOpcode(thread, 0x0051); // call game's original
-	}
-
-	// load_and_launch_mission_internal
-	// load_and_launch_mission_internal {index} [int]
-	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0417(CRunningScript* thread)
-	{
-		CleoInstance.ScriptEngine.missionIndex = CLEO_PeekIntOpcodeParam(thread);
-
-		return CallNativeOpcode(thread, 0x0417); // call game's original
-	}
-
-	// stream_custom_script
-	// stream_custom_script {scriptFileName} [string] [arguments]
-	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0A92(CRunningScript *thread)
-	{
-		OPCODE_READ_PARAM_STRING(path);
-
-		auto filename = reinterpret_cast<CCustomScript*>(thread)->ResolvePath(path, DIR_CLEO); // legacy: default search location is game\cleo directory
-		TRACE("[0A92] Starting new custom script %s from thread named '%s'", filename.c_str(), thread->GetName().c_str());
-
-		auto cs = new CCustomScript(filename.c_str(), false, thread);
-		thread->SetConditionResult(cs && cs->IsOk());
-		if (cs && cs->IsOk())
-		{
-			CleoInstance.ScriptEngine.AddCustomScript(cs);
-			((::CRunningScript*)thread)->ReadParametersForNewlyStartedScript((::CRunningScript*)cs);
-		}
-		else
-		{
-			if (cs) delete cs;
-			SkipUnusedVarArgs(thread);
-			LOG_WARNING(0, "Failed to load script '%s' in script ", filename.c_str(), ScriptInfoStr(thread).c_str());
-		}
-
-		return OR_CONTINUE;
-	}
-
-	// terminate_this_custom_script
-	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0A93(CRunningScript *thread)
-	{
-		CCustomScript *cs = reinterpret_cast<CCustomScript *>(thread);
-		if (thread->IsMission() || !cs->IsCustom())
-		{
-			LOG_WARNING(0, "Incorrect usage of opcode [0A93] in script '%s'. Use [004E] instead.", ScriptInfoStr(thread).c_str());
-			return OR_CONTINUE; // legacy behavior
-		}
-
-		CleoInstance.ScriptEngine.RemoveScript(thread);
-		return OR_INTERRUPT;
-	}
-
-	// load_and_launch_custom_mission
-	// load_and_launch_custom_mission {scriptFileName} [string] [arguments]
-	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0A94(CRunningScript *thread)
-	{
-		OPCODE_READ_PARAM_STRING(path);
-
-		auto filename = reinterpret_cast<CCustomScript*>(thread)->ResolvePath(path, DIR_CLEO); // legacy: default search location is game\cleo directory
-		filename += ".cm"; // add custom mission extension
-		TRACE("[0A94] Starting new custom mission '%s' from thread named '%s'", filename.c_str(), thread->GetName().c_str());
-
-		auto cs = new CCustomScript(filename.c_str(), true, thread);
-		thread->SetConditionResult(cs && cs->IsOk());
-		if (cs && cs->IsOk())
-		{
-			CleoInstance.ScriptEngine.AddCustomScript(cs);
-			CTheScripts::WipeLocalVariableMemoryForMissionScript();
-			auto fakeScriptAddress = (BYTE*)missionLocals - offsetof(CRunningScript, LocalVar); // TODO: maybe copy params ourself instead?
-			((::CRunningScript*)thread)->ReadParametersForNewlyStartedScript((::CRunningScript*)fakeScriptAddress);
-		}
-		else
-		{
-			if (cs) delete cs;
-			SkipUnusedVarArgs(thread);
-			LOG_WARNING(0, "[0A94] Failed to load mission '%s' from script '%s'.", filename.c_str(), thread->GetName().c_str());
-		}
-
-		return OR_CONTINUE;
-	}
-
-	// save_this_custom_script
-	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0A95(CRunningScript *thread)
-	{
-		if (thread->IsCustom())
-		{
-			reinterpret_cast<CCustomScript*>(thread)->EnableSaving();
-		}
-		return OR_CONTINUE;
-	}
-
-	// gosub_if_false
-	// gosub_if_false [label]
-	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0AA0(CRunningScript *thread)
-	{
-		auto offset = OPCODE_READ_PARAM_INT();
-
-		if (thread->GetConditionResult()) return OR_CONTINUE;
-
-		thread->PushStack(thread->GetBytePointer());
-		thread->Jump(offset);
-		return OR_CONTINUE;
-	}
-
-	// return_if_false
-	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0AA1(CRunningScript *thread)
-	{
-		if (thread->GetConditionResult()) return OR_CONTINUE;
-
-		if (thread->SP == 0)
-		{
-			SHOW_ERROR("`return_if_false` used without preceding `gosub` call in script %s\nScript suspended.", ScriptInfoStr(thread).c_str());
-			return thread->Suspend();
-		}
-
-		thread->SetIp(thread->PopStack());
-		return OR_CONTINUE;
-	}
-
-	// is_game_version_original
-	// is_game_version_original (logical)
-	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0AA9(CRunningScript *thread)
-	{
-		auto gameVer = CleoInstance.VersionManager.GetGameVersion();
-		auto scriptVer = CLEO_GetScriptVersion(thread);
-
-		bool result = (gameVer == GV_US10) ||
-			(scriptVer <= CLEO_VER_4_MIN && gameVer == GV_EU10);
-
-		OPCODE_CONDITION_RESULT(result);
-		return OR_CONTINUE;
-	}
-
-	// cleo_call
-	// cleo_call [label] {numParams} [int] {params} [arguments]
-	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0AB1(CRunningScript *thread)
-	{
-		int label = 0;
-		std::string moduleTxt;
-
-		auto paramType = thread->PeekDataType();
-		if (IsImmInteger(paramType) || IsVariable(paramType))
-		{
-			label = CLEO_GetIntOpcodeParam(thread); // label offset
-		}
-		else if (IsImmString(paramType) || IsVarString(paramType))
-		{
-			char tmp[MAX_STR_LEN + 1];
-			auto str = ReadStringParam(thread, tmp, sizeof(tmp)); // string with module and export name
-			if (str != nullptr) moduleTxt = str;
-		}
-		else
-		{
-			SHOW_ERROR("Invalid type of first argument in opcode [0AB1], in script %s", ScriptInfoStr(thread).c_str());
-			return thread->Suspend();
-		}
-	
-		ScmFunction* scmFunc = new ScmFunction(thread);
-		
-		// parse module reference text
-		if (!moduleTxt.empty())
-		{
-			auto pos = moduleTxt.find('@');
-			if (pos == moduleTxt.npos)
-			{
-				SHOW_ERROR("Invalid module reference '%s' in opcode [0AB1] in script %s \nScript suspended.", moduleTxt.c_str(), ScriptInfoStr(thread).c_str());
-				return thread->Suspend();
-			}
-			auto strExport = std::string_view(moduleTxt.data(), pos);
-			auto strModule = std::string_view(moduleTxt.data() + pos + 1);
-
-			// get module's file absolute path
-			auto modulePath = std::string(strModule);
-			modulePath = reinterpret_cast<CCustomScript*>(thread)->ResolvePath(modulePath.c_str(), DIR_SCRIPT); // by default search relative to current script location
-
-			// get export reference
-			auto scriptRef = CleoInstance.ModuleSystem.GetExport(modulePath, strExport);
-			if (!scriptRef.Valid())
-			{
-				SHOW_ERROR("Not found module '%s' export '%s', requested by opcode [0AB1] in script %s", modulePath.c_str(), moduleTxt.c_str(), ScriptInfoStr(thread).c_str());
-				return thread->Suspend();
-			}
-
-			auto cs = reinterpret_cast<CCustomScript*>(thread);
-			cs->SetScriptFileDir(FS::path(modulePath).parent_path().string().c_str());
-			cs->SetScriptFileName(FS::path(modulePath).filename().string().c_str());
-			cs->SetBaseIp(scriptRef.base);
-			if (cs->IsCustom()) cs->SetCodeSize(scriptRef.size);
-			label = scriptRef.offset;
-		}
-
-		// "number of input parameters" opcode argument
-		DWORD nParams = 0;
-		paramType = thread->PeekDataType();
-		if (paramType != DT_END)
-		{
-			if (IsImmInteger(paramType))
-			{
-				nParams = CLEO_GetIntOpcodeParam(thread);
-			}
-			else
-			{
-				SHOW_ERROR("Invalid type (%s) of the 'input param count' argument in opcode [0AB1] in script %s \nScript suspended.", ToKindStr(paramType), ScriptInfoStr(thread).c_str());
-				return thread->Suspend();
-			}
-		}
-		if (nParams)
-		{
-			auto nVarArg = GetVarArgCount(thread);
-			if (nParams > nVarArg) // if less it means there are return params too
-			{
-				SHOW_ERROR("Opcode [0AB1] declared %d input args, but provided %d in script %s\nScript suspended.", nParams, nVarArg, ScriptInfoStr(thread).c_str());
-				return thread->Suspend();
-			}
-
-			if (nParams > 32)
-			{
-				SHOW_ERROR("Argument count %d is out of supported range (32) of opcode [0AB1] in script %s", nParams, ScriptInfoStr(thread).c_str());
-				return thread->Suspend();
-			}
-		}
-		scmFunc->callArgCount = (BYTE)nParams;
-
-		static SCRIPT_VAR arguments[32];
-		SCRIPT_VAR* locals = thread->IsMission() ? missionLocals : thread->GetVarPtr();
-		SCRIPT_VAR* localsEnd = locals + 32;
-		SCRIPT_VAR* storedLocals = scmFunc->savedTls;
-
-		// collect arguments
-		for (DWORD i = 0; i < nParams; i++)
-		{
-			SCRIPT_VAR* arg = arguments + i;
-
-			auto paramType = thread->PeekDataType();
-			if (IsImmInteger(paramType) || IsVariable(paramType))
-			{
-				arg->dwParam = CLEO_GetIntOpcodeParam(thread);
-
-			}
-			else if(paramType == DT_FLOAT)
-			{
-				arg->fParam = CLEO_GetFloatOpcodeParam(thread);
-			}
-			else if (IsImmString(paramType) || IsVarString(paramType))
-			{
-				// imm string texts exists in script code, but without terminator character.
-				// For strings stored in variables there is no guarantee these will end with terminator.
-				// In both cases copy is necessary to create proper c-string
-				char tmp[MAX_STR_LEN + 1];
-				auto str = ReadStringParam(thread, tmp, sizeof(tmp));
-				scmFunc->stringParams.emplace_back(str);
-				arg->pcParam = (char*)scmFunc->stringParams.back().c_str();
-			}
-			else
-			{
-				SHOW_ERROR("Invalid argument type '0x%02X' in opcode [0AB1] in script %s\nScript suspended.", paramType, ScriptInfoStr(thread).c_str());
-				return thread->Suspend();
-			}
-		}
-
-		// all arguments read
-		scmFunc->retnAddress = thread->GetBytePointer();
-
-		// pass arguments as new scope local variables
-		memcpy(locals, arguments, nParams * sizeof(SCRIPT_VAR));
-
-		// initialize (clear) rest of new scope local variables
-		if (CLEO_GetScriptVersion(thread) >= CLEO_VER_4_MIN) // CLEO 3 did not cleared local variables
-		{
-			for (DWORD i = nParams; i < 32; i++)
-			{
-				thread->SetIntVar(i, 0); // fill with zeros
-			}
-		}
-
-		// jump to label
-		thread->Jump(label);
-		return OR_CONTINUE;
-	}
-
-	// cleo_return
-	// cleo_return {numRet} [int] {retParams} [arguments]
-	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0AB2(CRunningScript *thread)
-	{
-		auto returnParamCount = OPCODE_PEEK_VARARG_COUNT();
-		if (returnParamCount)
-		{
-			auto paramType = thread->PeekDataType();
-			if (!IsImmInteger(paramType))
-			{
-				SHOW_ERROR("Invalid type of first argument in opcode [0AB2], in script %s", ScriptInfoStr(thread).c_str());
-				return thread->Suspend();
-			}
-			DWORD declaredParamCount = CLEO_GetIntOpcodeParam(thread);
-
-			if (returnParamCount - 1 < declaredParamCount) // minus 'num args' itself
-			{
-				SHOW_ERROR("Opcode [0AB2] declared %d return args, but provided %d in script %s\nScript suspended.", declaredParamCount, returnParamCount - 1, ScriptInfoStr(thread).c_str());
-				return thread->Suspend();
-			}
-			else if (returnParamCount - 1 > declaredParamCount) // more args than needed, not critical
-			{
-				LOG_WARNING(thread, "Opcode [0AB2] declared %d return args, but provided %d in script %s", declaredParamCount, returnParamCount - 1, ScriptInfoStr(thread).c_str());
-			}
-
-			returnParamCount = declaredParamCount;
-		}
-
-		return CleoInstance.OpcodeSystem.CleoReturnGeneric(0x0AB2, thread, true, returnParamCount, !IsLegacyScript(thread));
-	}
-
-	// set_cleo_shared_var
-	// set_cleo_shared_var {index} [int] {value} [any]
-	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0AB3(CRunningScript *thread)
-	{
-		auto varIdx = OPCODE_READ_PARAM_INT();
-
-		const auto VarCount = _countof(CScriptEngine::CleoVariables);
-		if (varIdx < 0 || varIdx >= VarCount)
-		{
-			SHOW_ERROR("Variable index '%d' out of supported range in script %s\nScript suspended.", varIdx, ScriptInfoStr(thread).c_str());
-			return thread->Suspend();
-		}
-
-		CleoInstance.ScriptEngine.CleoVariables[varIdx] = OPCODE_READ_PARAM_ANY32();
-		return OR_CONTINUE;
-	}
-
-	// get_cleo_shared_var
-	// [var result: any] = get_cleo_shared_var {index} [int]
-	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0AB4(CRunningScript *thread)
-	{
-		auto varIdx = OPCODE_READ_PARAM_INT();
-
-		const auto VarCount = _countof(CScriptEngine::CleoVariables);
-		if (varIdx < 0 || varIdx >= VarCount)
-		{
-			SHOW_ERROR("Variable index '%d' out of supported range in script %s\nScript suspended.", varIdx, ScriptInfoStr(thread).c_str());
-			return thread->Suspend();
-		}
-
-		OPCODE_WRITE_PARAM_ANY32(CleoInstance.ScriptEngine.CleoVariables[varIdx]);
-		return OR_CONTINUE;
-	}
-
-	// get_platform
-	// [var platform: Platform] = get_platform
-	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0DD5(CRunningScript* thread)
-	{
-		OPCODE_WRITE_PARAM_INT(PLATFORM_WINDOWS);
-		return OR_CONTINUE;
-	}
-
-	// get_cleo_arg_count
-	// [var count: int] = get_cleo_arg_count
-	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_2000(CRunningScript* thread)
-	{
-		auto cs = reinterpret_cast<CCustomScript*>(thread);
-
-		ScmFunction* scmFunc = ScmFunction::Get(cs->GetScmFunction());
-		if (scmFunc == nullptr)
-		{
-			SHOW_ERROR("Quering argument count without preceding CLEO function call in script %s\nScript suspended.", cs->GetInfoStr().c_str());
-			return thread->Suspend();
-		}
-
-		OPCODE_WRITE_PARAM_INT(scmFunc->callArgCount);
-		return OR_CONTINUE;
-	}
-
-	// cleo_return_with
-	// cleo_return_with {conditionResult} [bool] {retArgs} [arguments] (logical)
-	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_2002(CRunningScript* thread)
-	{
-		auto argCount = OPCODE_PEEK_VARARG_COUNT();
-		if (argCount < 1)
-		{
-			SHOW_ERROR("Opcode [2002] missing condition result argument in script %s\nScript suspended.", ScriptInfoStr(thread).c_str());
-			return thread->Suspend();
-		}
-
-		auto result = OPCODE_READ_PARAM_BOOL();
-		argCount--;
-
-		OPCODE_CONDITION_RESULT(result);
-		return CleoInstance.OpcodeSystem.CleoReturnGeneric(0x2002, thread, true, argCount);
-	}
-
-	// cleo_return_fail
-	// cleo_return_fail [arguments] (logical)
-	OpcodeResult __stdcall CCustomOpcodeSystem::opcode_2003(CRunningScript* thread)
-	{
-		auto argCount = OPCODE_PEEK_VARARG_COUNT();
-		if (argCount != 0) // argument(s) not supported yet
-		{
-			SHOW_ERROR("Too many arguments of opcode [2003] in script %s\nScript suspended.", ScriptInfoStr(thread).c_str());
-			return thread->Suspend();
-		}
-
-		OPCODE_CONDITION_RESULT(false);
-		return CleoInstance.OpcodeSystem.CleoReturnGeneric(0x2003, thread);
-	}
+    CRunningScript* CCustomOpcodeSystem::lastScript = nullptr;
+    WORD CCustomOpcodeSystem::lastOpcode = 0xFFFF;
+    WORD* CCustomOpcodeSystem::lastOpcodePtr = nullptr;
+    WORD CCustomOpcodeSystem::lastCustomOpcode = 0;
+    std::string CCustomOpcodeSystem::lastErrorMsg = {};
+    WORD CCustomOpcodeSystem::prevOpcode = 0xFFFF;
+    BYTE CCustomOpcodeSystem::handledParamCount = 0;
+
+    // opcode handler for custom opcodes
+    OpcodeResult __fastcall CCustomOpcodeSystem::customOpcodeHandler(CRunningScript *thread, int dummy, WORD opcode)
+    {
+        OpcodeResult result = OR_NONE;
+
+        auto AfterOpcodeExecuted = [&]()
+        {
+            // execute registered callbacks
+            OpcodeResult callbackResult = OR_NONE;
+            for (void* func : CleoInstance.GetCallbacks(eCallbackId::ScriptOpcodeProcessAfter))
+            {
+                typedef OpcodeResult WINAPI callback(CRunningScript*, DWORD, OpcodeResult);
+                auto res = ((callback*)func)(thread, opcode, result);
+
+                callbackResult = std::max(res, callbackResult); // store result with highest value from all callbacks
+            }
+
+            return (callbackResult != OR_NONE) ? callbackResult : result;
+        };
+
+        prevOpcode = (thread != lastScript) ? 0xFFFF : lastOpcode;
+        lastScript = thread;
+        lastOpcode = opcode;
+        lastOpcodePtr = (WORD*)thread->GetBytePointer() - 1; // rewind to the opcode start
+        handledParamCount = 0;
+
+        // prevent past code execution
+        if (thread->IsCustom() && !IsLegacyScript(thread))
+        {
+            auto cs = (CCustomScript*)thread;
+            auto endPos = cs->GetBasePointer() + cs->GetCodeSize();
+            if ((BYTE*)lastOpcodePtr == endPos || (BYTE*)lastOpcodePtr == (endPos - 1)) // consider script can end with incomplete opcode
+            {
+                SHOW_ERROR_COMPAT("Code execution past script end in script %s\nThis usually happens when [004E] command is missing.\nScript suspended.", ScriptInfoStr(thread).c_str());
+                result = thread->Suspend();
+                return AfterOpcodeExecuted();
+            }
+        }
+
+        // execute registered callbacks
+        for (void* func : CleoInstance.GetCallbacks(eCallbackId::ScriptOpcodeProcessBefore))
+        {
+            typedef OpcodeResult WINAPI callback(CRunningScript*, DWORD);
+            result = ((callback*)func)(thread, opcode);
+
+            if(result != OR_NONE)
+                break; // processed
+        }
+
+        if (result == OR_NONE) // opcode not proccessed yet
+        {
+            if(opcode > Opcode_Max)
+            {
+                SHOW_ERROR("Opcode [%04X] out of supported range! \nCalled in script %s\nScript suspended.", opcode, ScriptInfoStr(thread).c_str());
+                result = thread->Suspend();
+                return AfterOpcodeExecuted();
+            }
+
+            CustomOpcodeHandler handler = customOpcodeProc[opcode];
+            if (handler != nullptr)
+            {
+                lastCustomOpcode = opcode;
+                result = handler(thread);
+                return AfterOpcodeExecuted();
+            }
+
+            // Not registered as custom opcode. Call game's original handler
+            result = CallNativeOpcode(thread, opcode);
+            if(result == OR_ERROR)
+            {
+                auto extensionMsg = CleoInstance.OpcodeInfoDb.GetExtensionMissingMessage(opcode);
+                if (!extensionMsg.empty()) extensionMsg = " " + extensionMsg;
+
+                SHOW_ERROR("Opcode [%04X] not found!%s\nCalled in script %s\nScript suspended.",
+                    opcode,
+                    extensionMsg.c_str(),
+                    ScriptInfoStr(thread).c_str());
+
+                result = thread->Suspend();
+                return AfterOpcodeExecuted();
+            }
+        }
+
+        return AfterOpcodeExecuted();
+    }
+
+    void CCustomOpcodeSystem::FinalizeScriptObjects()
+    {
+        TRACE("Cleaning up script data...");
+
+        CleoInstance.CallCallbacks(eCallbackId::ScriptsFinalize);
+
+        // clean up after opcode_0AB1
+        ScmFunction::Clear();
+    }
+
+    void CCustomOpcodeSystem::Inject(CCodeInjector& inj)
+    {
+        TRACE("Injecting CustomOpcodeSystem...");
+        CGameVersionManager& gvm = CleoInstance.VersionManager;
+
+        // replace all handlers in original table
+        // store original opcode handlers for later use
+        auto handlersTable = (OpcodeHandler*)::CRunningScript::CommandHandlerTable;
+        for(size_t i = 0; i < OriginalOpcodeHandlersCount; i++)
+        {
+            originalOpcodeHandlers[i] = handlersTable[i];
+            handlersTable[i] = (OpcodeHandler)customOpcodeHandler;
+        }
+
+        // initialize and apply new handlers table
+        for (size_t i = 0; i < CustomOpcodeHandlersCount; i++)
+        {
+            customOpcodeHandlers[i] = (OpcodeHandler)customOpcodeHandler;
+        }
+
+        inj.MemoryWrite(gvm.TranslateMemoryAddress(MA_OPCODE_HANDLER_REF_1), &customOpcodeHandlers);
+        inj.MemoryWrite(gvm.TranslateMemoryAddress(MA_OPCODE_HANDLER_REF_2), &customOpcodeHandlers);
+    }
+
+    void CCustomOpcodeSystem::Init()
+    {
+        if (initialized) return;
+
+        TRACE(""); // separator
+        TRACE("Initializing CLEO core opcodes...");
+
+        CLEO_RegisterOpcode(0x004E, opcode_004E);
+        CLEO_RegisterOpcode(0x0051, opcode_0051);
+        CLEO_RegisterOpcode(0x0417, opcode_0417);
+        CLEO_RegisterOpcode(0x0A92, opcode_0A92);
+        CLEO_RegisterOpcode(0x0A93, opcode_0A93);
+        CLEO_RegisterOpcode(0x0A94, opcode_0A94);
+        CLEO_RegisterOpcode(0x0A95, opcode_0A95);
+        CLEO_RegisterOpcode(0x0AA0, opcode_0AA0);
+        CLEO_RegisterOpcode(0x0AA1, opcode_0AA1);
+        CLEO_RegisterOpcode(0x0AA9, opcode_0AA9);
+        CLEO_RegisterOpcode(0x0AB1, opcode_0AB1);
+        CLEO_RegisterOpcode(0x0AB2, opcode_0AB2);
+        CLEO_RegisterOpcode(0x0AB3, opcode_0AB3);
+        CLEO_RegisterOpcode(0x0AB4, opcode_0AB4);
+
+        CLEO_RegisterOpcode(0x0DD5, opcode_0DD5); // get_platform
+
+        CLEO_RegisterOpcode(0x2000, opcode_2000); // get_cleo_arg_count
+        // 2001 free
+        CLEO_RegisterOpcode(0x2002, opcode_2002); // cleo_return_with
+        CLEO_RegisterOpcode(0x2003, opcode_2003); // cleo_return_fail
+
+        initialized = true;
+    }
+
+    CCustomOpcodeSystem::~CCustomOpcodeSystem()
+    {
+        TRACE(""); // separator
+        TRACE("Custom Opcode System finalized:");
+        TRACE(" Last opcode executed: %04X", lastOpcode);
+        TRACE(" Previous opcode executed: %04X", prevOpcode);
+    }
+
+    CCustomOpcodeSystem::OpcodeHandler CCustomOpcodeSystem::originalOpcodeHandlers[OriginalOpcodeHandlersCount];
+    CCustomOpcodeSystem::OpcodeHandler CCustomOpcodeSystem::customOpcodeHandlers[CustomOpcodeHandlersCount];
+    CustomOpcodeHandler CCustomOpcodeSystem::customOpcodeProc[Opcode_Max + 1];
+
+    bool CCustomOpcodeSystem::RegisterOpcode(WORD opcode, CustomOpcodeHandler callback)
+    {
+        if (opcode > Opcode_Max)
+        {
+            SHOW_ERROR("Can not register [%04X] opcode! Out of supported range.", opcode);
+            return false;
+        }
+
+        CustomOpcodeHandler& dst = customOpcodeProc[opcode];
+        if (*dst != nullptr)
+        {
+            LOG_WARNING(0, "Opcode [%04X] already registered! Replacing...", opcode);
+        }
+
+        dst = callback;
+        TRACE("Opcode [%04X] registered", opcode);
+        return true;
+    }
+
+    OpcodeResult _CallNativeOpcode(CRunningScript* thread, void* handler, DWORD opcode)
+    {
+        // wrapped in separate function as otherwise some problems occur in debug builds
+        OpcodeResult result;
+        _asm
+        {
+            push opcode
+            mov ecx, thread
+            call handler
+            mov result, al
+        }
+        return result;
+    }
+
+    OpcodeResult CCustomOpcodeSystem::CallNativeOpcode(CRunningScript* thread, WORD opcode)
+    {
+        if (opcode > Opcode_Max_Native)
+        {
+            return OR_ERROR;
+        }
+
+        size_t tableIdx = opcode / Opcode_Table_Size;
+        return _CallNativeOpcode(thread, originalOpcodeHandlers[tableIdx], opcode);
+    }
+
+    const char* ReadStringParam(CRunningScript *thread, char* buff, int buffSize)
+    {
+        if (buffSize > 0) buff[buffSize - 1] = '\0'; // buffer always terminated
+        return GetScriptStringParam(thread, 0, buff, buffSize - 1); // minus terminator
+    }
+
+    // write output\result string parameter
+    bool WriteStringParam(CRunningScript* thread, const char* str)
+    {
+        auto target = GetStringParamWriteBuffer(thread);
+        return WriteStringParam(target, str);
+    }
+
+    bool WriteStringParam(const StringParamBufferInfo& target, const char* str)
+    {
+        CCustomOpcodeSystem::lastErrorMsg.clear();
+
+        if (str != nullptr && (size_t)str <= MinValidAddress)
+        {
+            CCustomOpcodeSystem::lastErrorMsg = StringPrintf("Writing string from invalid '0x%X' pointer", target.data);
+            return false;
+        }
+
+        if ((size_t)target.data <= MinValidAddress)
+        {
+            CCustomOpcodeSystem::lastErrorMsg = StringPrintf("Writing string into invalid '0x%X' pointer argument", target.data);
+            return false;
+        }
+
+        if (target.size == 0)
+        {
+            return false;
+        }
+
+        bool addTerminator = target.needTerminator;
+        size_t buffLen = target.size - addTerminator;
+        size_t length = str == nullptr ? 0 : strlen(str);
+
+        if (buffLen > length) addTerminator = true; // there is space left for terminator
+
+        length = std::min(length, buffLen);
+        if (length > 0) std::memcpy(target.data, str, length);
+        if (addTerminator) target.data[length] = '\0';
+
+        return true;
+    }
+
+    StringParamBufferInfo GetStringParamWriteBuffer(CRunningScript* thread)
+    {
+        StringParamBufferInfo result;
+        CCustomOpcodeSystem::lastErrorMsg.clear();
+
+        auto paramType = thread->PeekDataType();
+        if (IsImmInteger(paramType) || IsVariable(paramType))
+        {
+            // address to output buffer
+            CScriptEngine::GetScriptParams(thread, 1);
+
+            if (opcodeParams[0].dwParam <= MinValidAddress)
+            {
+                CCustomOpcodeSystem::lastErrorMsg = StringPrintf("Writing string into invalid '0x%X' pointer argument", opcodeParams[0].dwParam);
+                return result; // error
+            }
+
+            result.data = opcodeParams[0].pcParam;
+            result.size = 0x7FFFFFFF; // user allocated memory block can be any size
+            result.needTerminator = true;
+
+            return result;
+        }
+        else
+        if (IsVarString(paramType))
+        {
+            switch(paramType)
+            {
+                // short string variable
+                case DT_VAR_TEXTLABEL:
+                case DT_LVAR_TEXTLABEL:
+                case DT_VAR_TEXTLABEL_ARRAY:
+                case DT_LVAR_TEXTLABEL_ARRAY:
+                    result.data = (char*)CScriptEngine::GetScriptParamPointer(thread);
+                    result.size = 8;
+                    result.needTerminator = false;
+                    return result;
+
+                // long string variable
+                case DT_VAR_STRING:
+                case DT_LVAR_STRING:
+                case DT_VAR_STRING_ARRAY:
+                case DT_LVAR_STRING_ARRAY:
+                    result.data = (char*)CScriptEngine::GetScriptParamPointer(thread);
+                    result.size = 16;
+                    result.needTerminator = false;
+                    return result;
+            }
+        }
+
+        CCustomOpcodeSystem::lastErrorMsg = StringPrintf("Writing string, got argument %s", ToKindStr(paramType));
+        CLEO_SkipOpcodeParams(thread, 1); // skip unhandled param
+        return result; // error
+    }
+
+    // perform 'sprintf'-operation for parameters, passed through SCM
+    int ReadFormattedString(CRunningScript *thread, char *outputStr, DWORD len, const char *format)
+    {
+        unsigned int written = 0;
+        const char *iter = format;
+        char* outIter = outputStr;
+        char bufa[MAX_STR_LEN + 1], fmtbufa[64], *fmta;
+
+        // invalid input arguments
+        if(outputStr == nullptr || len == 0)
+        {
+            LOG_WARNING(thread, "ReadFormattedString invalid input arg(s) in script %s", ScriptInfoStr(thread).c_str());
+            SkipUnusedVarArgs(thread);
+            return -1; // error
+        }
+
+        if(len > 1 && format != nullptr)
+        {
+            while (*iter)
+            {
+                while (*iter && *iter != '%')
+                {
+                    if (written++ >= len) goto _ReadFormattedString_OutOfMemory;
+                    *outIter++ = *iter++;
+                }
+
+                if (*iter == '%')
+                {
+                    // end of format string
+                    if (iter[1] == '\0')
+                    {
+                        LOG_WARNING(thread, "ReadFormattedString encountered incomplete format specifier in script %s", ScriptInfoStr(thread).c_str());
+                        SkipUnusedVarArgs(thread);
+                        return -1; // error
+                    }
+
+                    // escaped % character
+                    if (iter[1] == '%')
+                    {
+                        if (written++ >= len) goto _ReadFormattedString_OutOfMemory;
+                        *outIter++ = '%';
+                        iter += 2;
+                        continue;
+                    }
+
+                    //get flags and width specifier
+                    fmta = fmtbufa;
+                    *fmta++ = *iter++;
+                    while (*iter == '0' ||
+                           *iter == '+' ||
+                           *iter == '-' ||
+                           *iter == ' ' ||
+                           *iter == '*' ||
+                           *iter == '#')
+                    {
+                        if (*iter == '*')
+                        {
+                            //get width
+                            if (thread->PeekDataType() == DT_END) goto _ReadFormattedString_ArgMissing;
+                            CScriptEngine::GetScriptParams(thread, 1);
+                            _itoa_s(opcodeParams[0].dwParam, bufa, 10);
+
+                            char* buffiter = bufa;
+                            while (*buffiter)
+                                *fmta++ = *buffiter++;
+                        }
+                        else
+                            *fmta++ = *iter;
+                        iter++;
+                    }
+
+                    //get immidiate width value
+                    while (isdigit(*iter))
+                        *fmta++ = *iter++;
+
+                    //get precision
+                    if (*iter == '.')
+                    {
+                        *fmta++ = *iter++;
+                        if (*iter == '*')
+                        {
+                            if (thread->PeekDataType() == DT_END) goto _ReadFormattedString_ArgMissing;
+                            CScriptEngine::GetScriptParams(thread, 1);
+                            _itoa_s(opcodeParams[0].dwParam, bufa, 10);
+
+                            char* buffiter = bufa;
+                            while (*buffiter)
+                                *fmta++ = *buffiter++;
+                        }
+                        else
+                            while (isdigit(*iter))
+                                *fmta++ = *iter++;
+                    }
+                    //get size
+                    if (*iter == 'h' || *iter == 'l')
+                        *fmta++ = *iter++;
+
+                    switch (*iter)
+                    {
+                    case 's':
+                    {
+                        if (thread->PeekDataType() == DT_END) goto _ReadFormattedString_ArgMissing;
+
+                        const char* str = ReadStringParam(thread, bufa, sizeof(bufa));
+                        if(str == nullptr) // read error
+                        {
+                            static const char none[] = "(INVALID_STR)";
+                            str = none;
+                        }
+                        
+                        while (*str)
+                        {
+                            if (written++ >= len) goto _ReadFormattedString_OutOfMemory;
+                            *outIter++ = *str++;
+                        }
+                        iter++;
+                        break;
+                    }
+
+                    case 'c':
+                        if (written++ >= len) goto _ReadFormattedString_OutOfMemory;
+                        if (thread->PeekDataType() == DT_END) goto _ReadFormattedString_ArgMissing;
+                        CScriptEngine::GetScriptParams(thread, 1);
+                        *outIter++ = (char)opcodeParams[0].nParam;
+                        iter++;
+                        break;
+
+                    default:
+                    {
+                        /* For non wc types, use system sprintf and append to wide char output */
+                        /* FIXME: for unrecognised types, should ignore % when printing */
+                        if (*iter == 'p' || *iter == 'P')
+                        {
+                            if (thread->PeekDataType() == DT_END) goto _ReadFormattedString_ArgMissing;
+                            CScriptEngine::GetScriptParams(thread, 1);
+                            sprintf_s(bufa, "%08X", opcodeParams[0].dwParam);
+                        }
+                        else
+                        {
+                            *fmta++ = *iter;
+                            *fmta = '\0';
+                            if (*iter == 'a' || *iter == 'A' ||
+                                *iter == 'e' || *iter == 'E' ||
+                                *iter == 'f' || *iter == 'F' ||
+                                *iter == 'g' || *iter == 'G')
+                            {
+                                if (thread->PeekDataType() == DT_END) goto _ReadFormattedString_ArgMissing;
+                                CScriptEngine::GetScriptParams(thread, 1);
+                                sprintf_s(bufa, fmtbufa, opcodeParams[0].fParam);
+                            }
+                            else
+                            {
+                                if (thread->PeekDataType() == DT_END) goto _ReadFormattedString_ArgMissing;
+                                CScriptEngine::GetScriptParams(thread, 1);
+                                sprintf_s(bufa, fmtbufa, opcodeParams[0].pParam);
+                            }
+                        }
+                        char* bufaiter = bufa;
+                        while (*bufaiter)
+                        {
+                            if (written++ >= len) goto _ReadFormattedString_OutOfMemory;
+                            *outIter++ = *bufaiter++;
+                        }
+                        iter++;
+                        break;
+                    }
+                    }
+                }
+            }
+        }
+
+        if (written >= len)
+        {
+        _ReadFormattedString_OutOfMemory: // jump here on error
+
+            LOG_WARNING(thread, "Target buffer too small (%d) to read whole formatted string in script %s", len, ScriptInfoStr(thread).c_str());
+            SkipUnusedVarArgs(thread);
+            outputStr[len - 1] = '\0';
+            return -1; // error
+        }
+
+        // still more var-args available
+        if (thread->PeekDataType() != DT_END)
+        {
+            LOG_WARNING(thread, "More arguments than tokens in format string in script %s", ScriptInfoStr(thread).c_str());
+        }
+        SkipUnusedVarArgs(thread); // skip terminator too
+
+        outputStr[written] = '\0';
+        return (int)written;
+
+    _ReadFormattedString_ArgMissing: // jump here on error
+        LOG_WARNING(thread, "More tokens in format string than arguments in script %s", ScriptInfoStr(thread).c_str());
+        thread->IncPtr(); // skip vararg terminator
+        outputStr[written] = '\0';
+        return -1; // error
+    }
+
+    OpcodeResult CCustomOpcodeSystem::CleoReturnGeneric(WORD opcode, CRunningScript* thread, bool returnArgs, DWORD returnArgCount, bool strictArgCount)
+    {
+        auto cs = reinterpret_cast<CCustomScript*>(thread);
+
+        ScmFunction* scmFunc = ScmFunction::Get(cs->GetScmFunction());
+        if (scmFunc == nullptr)
+        {
+            SHOW_ERROR("Invalid Cleo Call reference. [%04X] possibly used without preceding [0AB1] in script %s\nScript suspended.", opcode, cs->GetInfoStr().c_str());
+            return thread->Suspend();
+        }
+
+        // store return arguments
+        static SCRIPT_VAR arguments[32];
+        static bool argumentIsStr[32];
+        std::forward_list<std::string> stringParams; // scope guard for strings
+        if (returnArgs)
+        {
+            if (returnArgCount > 32)
+            {
+                SHOW_ERROR("Opcode [%04X] has too many (%d) args in script %s\nScript suspended.", opcode, returnArgCount, cs->GetInfoStr().c_str());
+                return thread->Suspend();
+            }
+
+            auto nVarArg = GetVarArgCount(thread);
+            if (returnArgCount > nVarArg)
+            {
+                SHOW_ERROR("Opcode [%04X] declared %d args, but %d was provided in script %s\nScript suspended.", opcode, returnArgCount, nVarArg, ScriptInfoStr(thread).c_str());
+                return thread->Suspend();
+            }
+
+            for (DWORD i = 0; i < returnArgCount; i++)
+            {
+                SCRIPT_VAR* arg = arguments + i;
+                argumentIsStr[i] = false;
+
+                auto paramType = (eDataType)*thread->GetBytePointer();
+                if (IsImmInteger(paramType) || IsVariable(paramType))
+                {
+                    arg->dwParam = CLEO_GetIntOpcodeParam(thread);
+                }
+                else if (paramType == DT_FLOAT)
+                {
+                    arg->fParam = CLEO_GetFloatOpcodeParam(thread);
+                }
+                else if (IsImmString(paramType) || IsVarString(paramType))
+                {
+                    argumentIsStr[i] = true;
+
+                    OPCODE_READ_PARAM_STRING(str);
+                    stringParams.emplace_front(str);
+                    arg->pcParam = stringParams.front().data();
+                }
+                else
+                {
+                    SHOW_ERROR("Invalid argument type '0x%02X' in opcode [%04X] in script %s\nScript suspended.", paramType, opcode, ScriptInfoStr(thread).c_str());
+                    return thread->Suspend();
+                }
+            }
+        }
+
+        // handle program flow
+        scmFunc->Return(cs); // jump back to cleo_call, right after last input param. Return slot var args starts here
+        delete scmFunc;
+
+        if (returnArgs)
+        {
+            DWORD returnSlotCount = GetVarArgCount(cs);
+            if (returnSlotCount != returnArgCount)
+            {
+                if (strictArgCount)
+                {
+                    SHOW_ERROR_COMPAT("Opcode [%04X] returned %d params, while function caller expected %d in script %s\nScript suspended.", opcode, returnArgCount, returnSlotCount, cs->GetInfoStr().c_str());
+                    return cs->Suspend();
+                }
+                else
+                {
+                    LOG_WARNING(thread, "Opcode [%04X] returned %d params, while function caller expected %d in script %s", opcode, returnArgCount, returnSlotCount, cs->GetInfoStr().c_str());
+                }
+            }
+
+            // set return args
+            for (DWORD i = 0; i < std::min<DWORD>(returnArgCount, returnSlotCount); i++)
+            {
+                auto arg = (SCRIPT_VAR*)thread->GetBytePointer();
+
+                auto paramType = *(eDataType*)arg;
+                if (IsVarString(paramType))
+                {
+                    OPCODE_WRITE_PARAM_STRING(arguments[i].pcParam);
+                } 
+                else if (IsVariable(paramType))
+                {
+                    if (argumentIsStr[i]) // source was string, write it into provided buffer ptr
+                    {
+                        OPCODE_WRITE_PARAM_STRING(arguments[i].pcParam);
+                    }
+                    else
+                        CLEO_SetIntOpcodeParam(thread, arguments[i].dwParam);
+                }
+                else
+                {
+                    SHOW_ERROR("Invalid output argument type '0x%02X' in opcode [%04X] in script %s\nScript suspended.", paramType, opcode, ScriptInfoStr(thread).c_str());
+                    return thread->Suspend();
+                }
+            }
+        }
+
+        SkipUnusedVarArgs(thread); // skip var args terminator too
+
+        return OR_CONTINUE;
+    }
+
+    void SkipUnusedVarArgs(CRunningScript *thread)
+    {
+        while (thread->PeekDataType() != DT_END)
+            CLEO_SkipOpcodeParams(thread, 1);
+
+        thread->IncPtr(); // skip terminator
+    }
+
+    DWORD GetVarArgCount(CRunningScript* thread)
+    {
+        // store state
+        const auto ip = thread->GetBytePointer();
+        const auto handledParams = CleoInstance.OpcodeSystem.handledParamCount;
+
+        DWORD count = 0;
+        while (thread->PeekDataType() != DT_END)
+        {
+            CLEO_SkipOpcodeParams(thread, 1);
+            count++;
+        }
+
+        // restore state
+        thread->SetIp(ip);
+        CleoInstance.OpcodeSystem.handledParamCount = handledParams;
+
+        return count;
+    }
+
+    /************************************************************************/
+    /*                        Opcode definitions                                */
+    /************************************************************************/
+
+    // terminate_this_script
+    OpcodeResult __stdcall CCustomOpcodeSystem::opcode_004E(CRunningScript* thread)
+    {
+        CleoInstance.ScriptEngine.RemoveScript(thread);
+        return OR_INTERRUPT;
+    }
+
+    // GOSUB return
+    OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0051(CRunningScript* thread)
+    {
+        if (thread->SP == 0 && !IsLegacyScript(thread)) // CLEO5 - allow use of GOSUB `return` to exit cleo calls too
+        {
+            OPCODE_CONDITION_RESULT(false);
+            return CleoInstance.OpcodeSystem.CleoReturnGeneric(0x0051, thread, false); // try CLEO's function return
+        }
+
+        if (thread->SP == 0)
+        {
+            SHOW_ERROR("`return` used without preceding `gosub` call in script %s\nScript suspended.", ScriptInfoStr(thread).c_str());
+            return thread->Suspend();
+        }
+
+        return CallNativeOpcode(thread, 0x0051); // call game's original
+    }
+
+    // load_and_launch_mission_internal
+    // load_and_launch_mission_internal {index} [int]
+    OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0417(CRunningScript* thread)
+    {
+        CleoInstance.ScriptEngine.missionIndex = CLEO_PeekIntOpcodeParam(thread);
+
+        return CallNativeOpcode(thread, 0x0417); // call game's original
+    }
+
+    // stream_custom_script
+    // stream_custom_script {scriptFileName} [string] [arguments]
+    OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0A92(CRunningScript *thread)
+    {
+        OPCODE_READ_PARAM_STRING(path);
+
+        auto filename = reinterpret_cast<CCustomScript*>(thread)->ResolvePath(path, DIR_CLEO); // legacy: default search location is game\cleo directory
+        TRACE("[0A92] Starting new custom script %s from thread named '%s'", filename.c_str(), thread->GetName().c_str());
+
+        auto cs = new CCustomScript(filename.c_str(), false, thread);
+        thread->SetConditionResult(cs && cs->IsOk());
+        if (cs && cs->IsOk())
+        {
+            CleoInstance.ScriptEngine.AddCustomScript(cs);
+            ((::CRunningScript*)thread)->ReadParametersForNewlyStartedScript((::CRunningScript*)cs);
+        }
+        else
+        {
+            if (cs) delete cs;
+            SkipUnusedVarArgs(thread);
+            LOG_WARNING(0, "Failed to load script '%s' in script ", filename.c_str(), ScriptInfoStr(thread).c_str());
+        }
+
+        return OR_CONTINUE;
+    }
+
+    // terminate_this_custom_script
+    OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0A93(CRunningScript *thread)
+    {
+        CCustomScript *cs = reinterpret_cast<CCustomScript *>(thread);
+        if (thread->IsMission() || !cs->IsCustom())
+        {
+            LOG_WARNING(0, "Incorrect usage of opcode [0A93] in script '%s'. Use [004E] instead.", ScriptInfoStr(thread).c_str());
+            return OR_CONTINUE; // legacy behavior
+        }
+
+        CleoInstance.ScriptEngine.RemoveScript(thread);
+        return OR_INTERRUPT;
+    }
+
+    // load_and_launch_custom_mission
+    // load_and_launch_custom_mission {scriptFileName} [string] [arguments]
+    OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0A94(CRunningScript *thread)
+    {
+        OPCODE_READ_PARAM_STRING(path);
+
+        auto filename = reinterpret_cast<CCustomScript*>(thread)->ResolvePath(path, DIR_CLEO); // legacy: default search location is game\cleo directory
+        filename += ".cm"; // add custom mission extension
+        TRACE("[0A94] Starting new custom mission '%s' from thread named '%s'", filename.c_str(), thread->GetName().c_str());
+
+        auto cs = new CCustomScript(filename.c_str(), true, thread);
+        thread->SetConditionResult(cs && cs->IsOk());
+        if (cs && cs->IsOk())
+        {
+            CleoInstance.ScriptEngine.AddCustomScript(cs);
+            CTheScripts::WipeLocalVariableMemoryForMissionScript();
+            auto fakeScriptAddress = (BYTE*)missionLocals - offsetof(CRunningScript, LocalVar); // TODO: maybe copy params ourself instead?
+            ((::CRunningScript*)thread)->ReadParametersForNewlyStartedScript((::CRunningScript*)fakeScriptAddress);
+        }
+        else
+        {
+            if (cs) delete cs;
+            SkipUnusedVarArgs(thread);
+            LOG_WARNING(0, "[0A94] Failed to load mission '%s' from script '%s'.", filename.c_str(), thread->GetName().c_str());
+        }
+
+        return OR_CONTINUE;
+    }
+
+    // save_this_custom_script
+    OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0A95(CRunningScript *thread)
+    {
+        if (thread->IsCustom())
+        {
+            reinterpret_cast<CCustomScript*>(thread)->EnableSaving();
+        }
+        return OR_CONTINUE;
+    }
+
+    // gosub_if_false
+    // gosub_if_false [label]
+    OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0AA0(CRunningScript *thread)
+    {
+        auto offset = OPCODE_READ_PARAM_INT();
+
+        if (thread->GetConditionResult()) return OR_CONTINUE;
+
+        thread->PushStack(thread->GetBytePointer());
+        thread->Jump(offset);
+        return OR_CONTINUE;
+    }
+
+    // return_if_false
+    OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0AA1(CRunningScript *thread)
+    {
+        if (thread->GetConditionResult()) return OR_CONTINUE;
+
+        if (thread->SP == 0)
+        {
+            SHOW_ERROR("`return_if_false` used without preceding `gosub` call in script %s\nScript suspended.", ScriptInfoStr(thread).c_str());
+            return thread->Suspend();
+        }
+
+        thread->SetIp(thread->PopStack());
+        return OR_CONTINUE;
+    }
+
+    // is_game_version_original
+    // is_game_version_original (logical)
+    OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0AA9(CRunningScript *thread)
+    {
+        auto gameVer = CleoInstance.VersionManager.GetGameVersion();
+        auto scriptVer = CLEO_GetScriptVersion(thread);
+
+        bool result = (gameVer == GV_US10) ||
+            (scriptVer <= CLEO_VER_4_MIN && gameVer == GV_EU10);
+
+        OPCODE_CONDITION_RESULT(result);
+        return OR_CONTINUE;
+    }
+
+    // cleo_call
+    // cleo_call [label] {numParams} [int] {params} [arguments]
+    OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0AB1(CRunningScript *thread)
+    {
+        int label = 0;
+        std::string moduleTxt;
+
+        auto paramType = thread->PeekDataType();
+        if (IsImmInteger(paramType) || IsVariable(paramType))
+        {
+            label = CLEO_GetIntOpcodeParam(thread); // label offset
+        }
+        else if (IsImmString(paramType) || IsVarString(paramType))
+        {
+            char tmp[MAX_STR_LEN + 1];
+            auto str = ReadStringParam(thread, tmp, sizeof(tmp)); // string with module and export name
+            if (str != nullptr) moduleTxt = str;
+        }
+        else
+        {
+            SHOW_ERROR("Invalid type of first argument in opcode [0AB1], in script %s", ScriptInfoStr(thread).c_str());
+            return thread->Suspend();
+        }
+    
+        ScmFunction* scmFunc = new ScmFunction(thread);
+        
+        // parse module reference text
+        if (!moduleTxt.empty())
+        {
+            auto pos = moduleTxt.find('@');
+            if (pos == moduleTxt.npos)
+            {
+                SHOW_ERROR("Invalid module reference '%s' in opcode [0AB1] in script %s \nScript suspended.", moduleTxt.c_str(), ScriptInfoStr(thread).c_str());
+                return thread->Suspend();
+            }
+            auto strExport = std::string_view(moduleTxt.data(), pos);
+            auto strModule = std::string_view(moduleTxt.data() + pos + 1);
+
+            // get module's file absolute path
+            auto modulePath = std::string(strModule);
+            modulePath = reinterpret_cast<CCustomScript*>(thread)->ResolvePath(modulePath.c_str(), DIR_SCRIPT); // by default search relative to current script location
+
+            // get export reference
+            auto scriptRef = CleoInstance.ModuleSystem.GetExport(modulePath, strExport);
+            if (!scriptRef.Valid())
+            {
+                SHOW_ERROR("Not found module '%s' export '%s', requested by opcode [0AB1] in script %s", modulePath.c_str(), moduleTxt.c_str(), ScriptInfoStr(thread).c_str());
+                return thread->Suspend();
+            }
+
+            auto cs = reinterpret_cast<CCustomScript*>(thread);
+            cs->SetScriptFileDir(FS::path(modulePath).parent_path().string().c_str());
+            cs->SetScriptFileName(FS::path(modulePath).filename().string().c_str());
+            cs->SetBaseIp(scriptRef.base);
+            if (cs->IsCustom()) cs->SetCodeSize(scriptRef.size);
+            label = scriptRef.offset;
+        }
+
+        // "number of input parameters" opcode argument
+        DWORD nParams = 0;
+        paramType = thread->PeekDataType();
+        if (paramType != DT_END)
+        {
+            if (IsImmInteger(paramType))
+            {
+                nParams = CLEO_GetIntOpcodeParam(thread);
+            }
+            else
+            {
+                SHOW_ERROR("Invalid type (%s) of the 'input param count' argument in opcode [0AB1] in script %s \nScript suspended.", ToKindStr(paramType), ScriptInfoStr(thread).c_str());
+                return thread->Suspend();
+            }
+        }
+        if (nParams)
+        {
+            auto nVarArg = GetVarArgCount(thread);
+            if (nParams > nVarArg) // if less it means there are return params too
+            {
+                SHOW_ERROR("Opcode [0AB1] declared %d input args, but provided %d in script %s\nScript suspended.", nParams, nVarArg, ScriptInfoStr(thread).c_str());
+                return thread->Suspend();
+            }
+
+            if (nParams > 32)
+            {
+                SHOW_ERROR("Argument count %d is out of supported range (32) of opcode [0AB1] in script %s", nParams, ScriptInfoStr(thread).c_str());
+                return thread->Suspend();
+            }
+        }
+        scmFunc->callArgCount = (BYTE)nParams;
+
+        static SCRIPT_VAR arguments[32];
+        SCRIPT_VAR* locals = thread->IsMission() ? missionLocals : thread->GetVarPtr();
+        SCRIPT_VAR* localsEnd = locals + 32;
+        SCRIPT_VAR* storedLocals = scmFunc->savedTls;
+
+        // collect arguments
+        for (DWORD i = 0; i < nParams; i++)
+        {
+            SCRIPT_VAR* arg = arguments + i;
+
+            auto paramType = thread->PeekDataType();
+            if (IsImmInteger(paramType) || IsVariable(paramType))
+            {
+                arg->dwParam = CLEO_GetIntOpcodeParam(thread);
+
+            }
+            else if(paramType == DT_FLOAT)
+            {
+                arg->fParam = CLEO_GetFloatOpcodeParam(thread);
+            }
+            else if (IsImmString(paramType) || IsVarString(paramType))
+            {
+                // imm string texts exists in script code, but without terminator character.
+                // For strings stored in variables there is no guarantee these will end with terminator.
+                // In both cases copy is necessary to create proper c-string
+                char tmp[MAX_STR_LEN + 1];
+                auto str = ReadStringParam(thread, tmp, sizeof(tmp));
+                scmFunc->stringParams.emplace_back(str);
+                arg->pcParam = (char*)scmFunc->stringParams.back().c_str();
+            }
+            else
+            {
+                SHOW_ERROR("Invalid argument type '0x%02X' in opcode [0AB1] in script %s\nScript suspended.", paramType, ScriptInfoStr(thread).c_str());
+                return thread->Suspend();
+            }
+        }
+
+        // all arguments read
+        scmFunc->retnAddress = thread->GetBytePointer();
+
+        // pass arguments as new scope local variables
+        memcpy(locals, arguments, nParams * sizeof(SCRIPT_VAR));
+
+        // initialize (clear) rest of new scope local variables
+        if (CLEO_GetScriptVersion(thread) >= CLEO_VER_4_MIN) // CLEO 3 did not cleared local variables
+        {
+            for (DWORD i = nParams; i < 32; i++)
+            {
+                thread->SetIntVar(i, 0); // fill with zeros
+            }
+        }
+
+        // jump to label
+        thread->Jump(label);
+        return OR_CONTINUE;
+    }
+
+    // cleo_return
+    // cleo_return {numRet} [int] {retParams} [arguments]
+    OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0AB2(CRunningScript *thread)
+    {
+        auto returnParamCount = OPCODE_PEEK_VARARG_COUNT();
+        if (returnParamCount)
+        {
+            auto paramType = thread->PeekDataType();
+            if (!IsImmInteger(paramType))
+            {
+                SHOW_ERROR("Invalid type of first argument in opcode [0AB2], in script %s", ScriptInfoStr(thread).c_str());
+                return thread->Suspend();
+            }
+            DWORD declaredParamCount = CLEO_GetIntOpcodeParam(thread);
+
+            if (returnParamCount - 1 < declaredParamCount) // minus 'num args' itself
+            {
+                SHOW_ERROR("Opcode [0AB2] declared %d return args, but provided %d in script %s\nScript suspended.", declaredParamCount, returnParamCount - 1, ScriptInfoStr(thread).c_str());
+                return thread->Suspend();
+            }
+            else if (returnParamCount - 1 > declaredParamCount) // more args than needed, not critical
+            {
+                LOG_WARNING(thread, "Opcode [0AB2] declared %d return args, but provided %d in script %s", declaredParamCount, returnParamCount - 1, ScriptInfoStr(thread).c_str());
+            }
+
+            returnParamCount = declaredParamCount;
+        }
+
+        return CleoInstance.OpcodeSystem.CleoReturnGeneric(0x0AB2, thread, true, returnParamCount, !IsLegacyScript(thread));
+    }
+
+    // set_cleo_shared_var
+    // set_cleo_shared_var {index} [int] {value} [any]
+    OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0AB3(CRunningScript *thread)
+    {
+        auto varIdx = OPCODE_READ_PARAM_INT();
+
+        const auto VarCount = _countof(CScriptEngine::CleoVariables);
+        if (varIdx < 0 || varIdx >= VarCount)
+        {
+            SHOW_ERROR("Variable index '%d' out of supported range in script %s\nScript suspended.", varIdx, ScriptInfoStr(thread).c_str());
+            return thread->Suspend();
+        }
+
+        CleoInstance.ScriptEngine.CleoVariables[varIdx] = OPCODE_READ_PARAM_ANY32();
+        return OR_CONTINUE;
+    }
+
+    // get_cleo_shared_var
+    // [var result: any] = get_cleo_shared_var {index} [int]
+    OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0AB4(CRunningScript *thread)
+    {
+        auto varIdx = OPCODE_READ_PARAM_INT();
+
+        const auto VarCount = _countof(CScriptEngine::CleoVariables);
+        if (varIdx < 0 || varIdx >= VarCount)
+        {
+            SHOW_ERROR("Variable index '%d' out of supported range in script %s\nScript suspended.", varIdx, ScriptInfoStr(thread).c_str());
+            return thread->Suspend();
+        }
+
+        OPCODE_WRITE_PARAM_ANY32(CleoInstance.ScriptEngine.CleoVariables[varIdx]);
+        return OR_CONTINUE;
+    }
+
+    // get_platform
+    // [var platform: Platform] = get_platform
+    OpcodeResult __stdcall CCustomOpcodeSystem::opcode_0DD5(CRunningScript* thread)
+    {
+        OPCODE_WRITE_PARAM_INT(PLATFORM_WINDOWS);
+        return OR_CONTINUE;
+    }
+
+    // get_cleo_arg_count
+    // [var count: int] = get_cleo_arg_count
+    OpcodeResult __stdcall CCustomOpcodeSystem::opcode_2000(CRunningScript* thread)
+    {
+        auto cs = reinterpret_cast<CCustomScript*>(thread);
+
+        ScmFunction* scmFunc = ScmFunction::Get(cs->GetScmFunction());
+        if (scmFunc == nullptr)
+        {
+            SHOW_ERROR("Quering argument count without preceding CLEO function call in script %s\nScript suspended.", cs->GetInfoStr().c_str());
+            return thread->Suspend();
+        }
+
+        OPCODE_WRITE_PARAM_INT(scmFunc->callArgCount);
+        return OR_CONTINUE;
+    }
+
+    // cleo_return_with
+    // cleo_return_with {conditionResult} [bool] {retArgs} [arguments] (logical)
+    OpcodeResult __stdcall CCustomOpcodeSystem::opcode_2002(CRunningScript* thread)
+    {
+        auto argCount = OPCODE_PEEK_VARARG_COUNT();
+        if (argCount < 1)
+        {
+            SHOW_ERROR("Opcode [2002] missing condition result argument in script %s\nScript suspended.", ScriptInfoStr(thread).c_str());
+            return thread->Suspend();
+        }
+
+        auto result = OPCODE_READ_PARAM_BOOL();
+        argCount--;
+
+        OPCODE_CONDITION_RESULT(result);
+        return CleoInstance.OpcodeSystem.CleoReturnGeneric(0x2002, thread, true, argCount);
+    }
+
+    // cleo_return_fail
+    // cleo_return_fail [arguments] (logical)
+    OpcodeResult __stdcall CCustomOpcodeSystem::opcode_2003(CRunningScript* thread)
+    {
+        auto argCount = OPCODE_PEEK_VARARG_COUNT();
+        if (argCount != 0) // argument(s) not supported yet
+        {
+            SHOW_ERROR("Too many arguments of opcode [2003] in script %s\nScript suspended.", ScriptInfoStr(thread).c_str());
+            return thread->Suspend();
+        }
+
+        OPCODE_CONDITION_RESULT(false);
+        return CleoInstance.OpcodeSystem.CleoReturnGeneric(0x2003, thread);
+    }
 }

--- a/source/CGameVersionManager.cpp
+++ b/source/CGameVersionManager.cpp
@@ -6,36 +6,36 @@ namespace CLEO
 {
     memory_pointer MemoryAddresses[MA_TOTAL][GV_TOTAL] =
     {
-        // GV_US10,	    GV_US11,	GV_EU10,	GV_EU11,	GV_STEAM
-        { 0x0053E981,	memory_und, 0x0053E981, 0x0053EE21, 0x00551174 },		// MA_CALL_UPDATE_GAME_LOGICS,
+        // GV_US10,   GV_US11,    GV_EU10,    GV_EU11,    GV_STEAM
+        { 0x0053E981, memory_und, 0x0053E981, 0x0053EE21, 0x00551174 }, // MA_CALL_UPDATE_GAME_LOGICS,
 
-        // GV_US10,	    GV_US11,	GV_EU10,	GV_EU11,	GV_STEAM
-        { 0x0057B9FD,	memory_und, 0x0057B9FD, 0x0057BF71, 0x00591379 },		// MA_CALL_CTEXTURE_DRAW_BG_RECT,
+        // GV_US10,   GV_US11,    GV_EU10,    GV_EU11,    GV_STEAM
+        { 0x0057B9FD, memory_und, 0x0057B9FD, 0x0057BF71, 0x00591379 }, // MA_CALL_CTEXTURE_DRAW_BG_RECT,
 
-        // GV_US10,		GV_US11,	GV_EU10,	GV_EU11,	GV_STEAM
-        { 0x0044CA44,	memory_und, memory_und, memory_und, memory_und },		// MA_SCM_BLOCK_REF,
-        { 0x004899D7,	memory_und, memory_und, memory_und, memory_und },		// MA_MISSION_BLOCK_REF,
-        { 0x0053BDD7,	memory_und, 0x0053BDD7, memory_und, 0x0054DD49 },		// MA_CALL_INIT_SCM1,
-        { 0x005BA340,	memory_und, 0x005BA340, memory_und, 0x005D8EE9 },		// MA_CALL_INIT_SCM2,
-        { 0x005D4FD7,	memory_und, 0x005D4FD7, 0x005D57B7, 0x005F1777 },		// MA_CALL_INIT_SCM3,
-        { 0x005D14D5,	memory_und, 0x005D14D5, 0x005D157C, 0x005EDBD4 },		// MA_CALL_SAVE_SCM_DATA,
-        { 0x005D18F0,	memory_und, 0x005D18F0, 0x005D20D0, 0x005EE017 },		// MA_CALL_LOAD_SCM_DATA,
-        { 0x0046A21B,	memory_und,	0x0046A21B, 0x0046AE9B, 0x0046F9A8 },		// MA_CALL_PROCESS_SCRIPT
-        { 0x0058FCE4,	memory_und, 0x0058FCE4, 0x005904B4, 0x0059E73C },		// MA_CALL_DRAW_SCRIPT_TEXTS_BEFORE_FADE
-        { 0x0058D552,	memory_und, 0x0058D552, 0x0058DD22, 0x0059BAD4 },		// MA_CALL_DRAW_SCRIPT_TEXTS_AFTER_FADE
-        { 0x00748E6B,	memory_und, memory_und, memory_und, memory_und },		// MA_CALL_GAME_SHUTDOWN TODO: find for other versions
-        { 0x0053C758,	memory_und, memory_und, memory_und, memory_und },		// MA_CALL_GAME_RESTART_1 TODO: find for other versions
-        { 0x00748E04,	memory_und, memory_und, memory_und, memory_und },		// MA_CALL_GAME_RESTART_2 TODO: find for other versions
-        { 0x00748E3E,	memory_und, memory_und, memory_und, memory_und },		// MA_CALL_GAME_RESTART_3 TODO: find for other versions
-        { 0x0053EBE4,	memory_und, memory_und, memory_und, memory_und },		// MA_CALL_DEBUG_DISPLAY_TEXT_BUFFER_IDLE TODO: find for other versions
-        { 0x0053E86C,	memory_und, memory_und, memory_und, memory_und },		// MA_CALL_DEBUG_DISPLAY_TEXT_BUFFER_FRONTEND TODO: find for other versions
+        // GV_US10,   GV_US11,    GV_EU10,    GV_EU11,    GV_STEAM
+        { 0x0044CA44, memory_und, memory_und, memory_und, memory_und }, // MA_SCM_BLOCK_REF,
+        { 0x004899D7, memory_und, memory_und, memory_und, memory_und }, // MA_MISSION_BLOCK_REF,
+        { 0x0053BDD7, memory_und, 0x0053BDD7, memory_und, 0x0054DD49 }, // MA_CALL_INIT_SCM1,
+        { 0x005BA340, memory_und, 0x005BA340, memory_und, 0x005D8EE9 }, // MA_CALL_INIT_SCM2,
+        { 0x005D4FD7, memory_und, 0x005D4FD7, 0x005D57B7, 0x005F1777 }, // MA_CALL_INIT_SCM3,
+        { 0x005D14D5, memory_und, 0x005D14D5, 0x005D157C, 0x005EDBD4 }, // MA_CALL_SAVE_SCM_DATA,
+        { 0x005D18F0, memory_und, 0x005D18F0, 0x005D20D0, 0x005EE017 }, // MA_CALL_LOAD_SCM_DATA,
+        { 0x0046A21B, memory_und, 0x0046A21B, 0x0046AE9B, 0x0046F9A8 }, // MA_CALL_PROCESS_SCRIPT
+        { 0x0058FCE4, memory_und, 0x0058FCE4, 0x005904B4, 0x0059E73C }, // MA_CALL_DRAW_SCRIPT_TEXTS_BEFORE_FADE
+        { 0x0058D552, memory_und, 0x0058D552, 0x0058DD22, 0x0059BAD4 }, // MA_CALL_DRAW_SCRIPT_TEXTS_AFTER_FADE
+        { 0x00748E6B, memory_und, memory_und, memory_und, memory_und }, // MA_CALL_GAME_SHUTDOWN TODO: find for other versions
+        { 0x0053C758, memory_und, memory_und, memory_und, memory_und }, // MA_CALL_GAME_RESTART_1 TODO: find for other versions
+        { 0x00748E04, memory_und, memory_und, memory_und, memory_und }, // MA_CALL_GAME_RESTART_2 TODO: find for other versions
+        { 0x00748E3E, memory_und, memory_und, memory_und, memory_und }, // MA_CALL_GAME_RESTART_3 TODO: find for other versions
+        { 0x0053EBE4, memory_und, memory_und, memory_und, memory_und }, // MA_CALL_DEBUG_DISPLAY_TEXT_BUFFER_IDLE TODO: find for other versions
+        { 0x0053E86C, memory_und, memory_und, memory_und, memory_und }, // MA_CALL_DEBUG_DISPLAY_TEXT_BUFFER_FRONTEND TODO: find for other versions
 
-        // GV_US10,	    GV_US11,	GV_EU10,	GV_EU11,	GV_STEAM
-        { 0x00469FEE,	memory_und, 0x00469FEE, 0x0046A06E, 0x0046F75C },		// MA_OPCODE_HANDLER_REF_1,
-        { 0x00469EF0,	memory_und, memory_und, memory_und, memory_und },		// MA_OPCODE_HANDLER_REF_2,
+        // GV_US10,   GV_US11,    GV_EU10,    GV_EU11,    GV_STEAM
+        { 0x00469FEE, memory_und, 0x00469FEE, 0x0046A06E, 0x0046F75C }, // MA_OPCODE_HANDLER_REF_1,
+        { 0x00469EF0, memory_und, memory_und, memory_und, memory_und }, // MA_OPCODE_HANDLER_REF_2,
 
-        // GV_US10,	    GV_US11,	GV_EU10,	GV_EU11,	GV_STEAM
-        { 0x007487A8,	memory_und, 0x007487F8, 0x0074907C, 0x0078276D },		// MA_CALL_CREATE_MAIN_WINDOW,
+        // GV_US10,   GV_US11,    GV_EU10,    GV_EU11,    GV_STEAM
+        { 0x007487A8, memory_und, 0x007487F8, 0x0074907C, 0x0078276D }, // MA_CALL_CREATE_MAIN_WINDOW,
     };
 
     eGameVersion DetermineGameVersion()

--- a/source/CModuleSystem.cpp
+++ b/source/CModuleSystem.cpp
@@ -9,324 +9,324 @@ using namespace CLEO;
 
 void CModuleSystem::Clear()
 {
-	modules.clear();
+    modules.clear();
 }
 
 const ScriptDataRef CModuleSystem::GetExport(std::string modulePath, std::string_view exportName)
 {
-	NormalizePath(modulePath);
+    NormalizePath(modulePath);
 
-	auto& it = modules.find(modulePath);
-	if (it == modules.end()) // module not loaded yet?
-	{
-		if (!LoadFile(modulePath.c_str()))
-		{
-			return {};
-		}
+    auto& it = modules.find(modulePath);
+    if (it == modules.end()) // module not loaded yet?
+    {
+        if (!LoadFile(modulePath.c_str()))
+        {
+            return {};
+        }
 
-		// check if available now
-		it = modules.find(modulePath);
-		if (it == modules.end())
-		{
-			return {};
-		}
-	}
-	auto& module = it->second;
+        // check if available now
+        it = modules.find(modulePath);
+        if (it == modules.end())
+        {
+            return {};
+        }
+    }
+    auto& module = it->second;
 
-	auto e = module.GetExport(std::string(exportName));
-	return e;
+    auto e = module.GetExport(std::string(exportName));
+    return e;
 }
 
 bool CModuleSystem::LoadFile(const char* path)
 {
-	std::string normalizedPath(path);
-	NormalizePath(normalizedPath);
+    std::string normalizedPath(path);
+    NormalizePath(normalizedPath);
 
-	if (!modules[normalizedPath].LoadFromFile(normalizedPath.c_str()))
-	{
-		return false;
-	}
+    if (!modules[normalizedPath].LoadFromFile(normalizedPath.c_str()))
+    {
+        return false;
+    }
 
-	return true;
+    return true;
 }
 
 bool CModuleSystem::LoadDirectory(const char* path)
 {
-	bool result = true;
-	FilesWalk(path, ".s", [&](const char* fullPath, const char* filename)
-	{
-		result &= LoadFile(fullPath);
-	});
+    bool result = true;
+    FilesWalk(path, ".s", [&](const char* fullPath, const char* filename)
+    {
+        result &= LoadFile(fullPath);
+    });
 
-	return result;
+    return result;
 }
 
 bool CModuleSystem::LoadCleoModules()
 {
-	const auto path = FS::path(Filepath_Cleo).append("cleo_modules").string();
-	return LoadDirectory(path.c_str());
+    const auto path = FS::path(Filepath_Cleo).append("cleo_modules").string();
+    return LoadDirectory(path.c_str());
 }
 
 void CModuleSystem::NormalizePath(std::string& path)
 {
-	for (char& c : path)
-	{
-		// standarize path separators
-		if (c == '/')
-			c = '\\';
+    for (char& c : path)
+    {
+        // standarize path separators
+        if (c == '/')
+            c = '\\';
 
-		// lower case
-		c = std::tolower(c);
-	};
+        // lower case
+        c = std::tolower(c);
+    };
 }
 
 void CModuleSystem::CModule::Clear()
 {
-	filepath.clear();
-	data.clear();
-	exports.clear();
+    filepath.clear();
+    data.clear();
+    exports.clear();
 }
 
 const char* CModuleSystem::CModule::GetFilepath() const
 {
-	return filepath.c_str();
+    return filepath.c_str();
 }
 
 bool CModuleSystem::CModule::LoadFromFile(const char* path)
 {
-	Clear();
-	filepath = path;
+    Clear();
+    filepath = path;
 
-	std::ifstream file(path, std::ios::binary);
-	if (!file.good())
-	{
-		LOG_WARNING(0, "Failed to open module file '%s'", path);
-		return false;
-	}
+    std::ifstream file(path, std::ios::binary);
+    if (!file.good())
+    {
+        LOG_WARNING(0, "Failed to open module file '%s'", path);
+        return false;
+    }
 
-	const BYTE Segment_First_Instruction[] = { 0x02, 0x00, 0x01 }; // jump, param type
-	const BYTE Segment_Magic[] = { 0xFF, 0x7F, 0xFE, 0x00, 0x00 }; // Rockstar custom header magic
-	const char Header_Signature_Module_Exports[] = { 'E', 'X', 'P', 'T' }; // CLEO's module header signature
+    const BYTE Segment_First_Instruction[] = { 0x02, 0x00, 0x01 }; // jump, param type
+    const BYTE Segment_Magic[] = { 0xFF, 0x7F, 0xFE, 0x00, 0x00 }; // Rockstar custom header magic
+    const char Header_Signature_Module_Exports[] = { 'E', 'X', 'P', 'T' }; // CLEO's module header signature
 
-	// read first instruction
+    // read first instruction
 #pragma pack(push, 1)
-	struct
-	{
-		char firstInstruction[3];
-		int jumpAddress;
-		char magic[5];
-	} segment;
+    struct
+    {
+        char firstInstruction[3];
+        int jumpAddress;
+        char magic[5];
+    } segment;
 #pragma pack(pop)
 
-	file.read((char*)&segment, sizeof(segment));
-	if (file.fail())
-	{
-		LOG_WARNING(0, "Module '%s' file header read error", path);
-		return false;
-	}
+    file.read((char*)&segment, sizeof(segment));
+    if (file.fail())
+    {
+        LOG_WARNING(0, "Module '%s' file header read error", path);
+        return false;
+    }
 
-	// verify segment data
-	if (std::memcmp(segment.firstInstruction, Segment_First_Instruction, sizeof(Segment_First_Instruction)) != 0 ||
-		segment.jumpAddress >= 0 || // jump labels should be negative values
-		std::memcmp(segment.magic, Segment_Magic, sizeof(Segment_Magic)) != 0) // not a custom header
-	{
-		LOG_WARNING(0, "Module '%s' load error. Custom segment not present", path);
-		return false;
-	}
-	segment.jumpAddress = abs(segment.jumpAddress); // turn label into actual file offset
+    // verify segment data
+    if (std::memcmp(segment.firstInstruction, Segment_First_Instruction, sizeof(Segment_First_Instruction)) != 0 ||
+        segment.jumpAddress >= 0 || // jump labels should be negative values
+        std::memcmp(segment.magic, Segment_Magic, sizeof(Segment_Magic)) != 0) // not a custom header
+    {
+        LOG_WARNING(0, "Module '%s' load error. Custom segment not present", path);
+        return false;
+    }
+    segment.jumpAddress = abs(segment.jumpAddress); // turn label into actual file offset
 
-	// process custom headers
+    // process custom headers
 #pragma pack(push, 1)
-	struct
-	{
-		char signature[4];
-		int size;
-	} header;
+    struct
+    {
+        char signature[4];
+        int size;
+    } header;
 #pragma pack(pop)
 
-	bool result = false; // no custom header found yet
-	while (file.tellg() < segment.jumpAddress)
-	{
-		file.read((char*)&header, sizeof(header));
-		if (file.fail() ||
-			file.tellg() > segment.jumpAddress) // read past the segment end
-		{ 
-			LOG_WARNING(0, "Module '%s' load error. Invalid custom header", path);
-			return false;
-		}
+    bool result = false; // no custom header found yet
+    while (file.tellg() < segment.jumpAddress)
+    {
+        file.read((char*)&header, sizeof(header));
+        if (file.fail() ||
+            file.tellg() > segment.jumpAddress) // read past the segment end
+        { 
+            LOG_WARNING(0, "Module '%s' load error. Invalid custom header", path);
+            return false;
+        }
 
-		auto headerEndPos = file.tellg();
-		headerEndPos += header.size;
+        auto headerEndPos = file.tellg();
+        headerEndPos += header.size;
 
-		// CLEO Module Exports
-		if (std::memcmp(header.signature, Header_Signature_Module_Exports, sizeof(Header_Signature_Module_Exports)) == 0)
-		{
-			if (headerEndPos > segment.jumpAddress)
-			{
-				LOG_WARNING(0, "Module '%s' load error. Invalid size of exports header", path);
-				return false;
-			}
+        // CLEO Module Exports
+        if (std::memcmp(header.signature, Header_Signature_Module_Exports, sizeof(Header_Signature_Module_Exports)) == 0)
+        {
+            if (headerEndPos > segment.jumpAddress)
+            {
+                LOG_WARNING(0, "Module '%s' load error. Invalid size of exports header", path);
+                return false;
+            }
 
-			while (true)
-			{
-				ModuleExport e;
+            while (true)
+            {
+                ModuleExport e;
 
-				if (!e.LoadFromFile(file) ||
-					!file.good() ||
-					file.tellg() > headerEndPos)
-				{
-					if (e.name.empty())
-					{
-						LOG_WARNING(0, "Module '%s' export load error.", path);
-					}
-					else
-					{
-						LOG_WARNING(0, "Module's '%s' export '%s' load error.", path, e.name.c_str());
-					}
-					return false;
-				}
+                if (!e.LoadFromFile(file) ||
+                    !file.good() ||
+                    file.tellg() > headerEndPos)
+                {
+                    if (e.name.empty())
+                    {
+                        LOG_WARNING(0, "Module '%s' export load error.", path);
+                    }
+                    else
+                    {
+                        LOG_WARNING(0, "Module's '%s' export '%s' load error.", path, e.name.c_str());
+                    }
+                    return false;
+                }
 
-				exports[e.name] = std::move(e); // move to container
-				result = true; // something useful loaded
+                exports[e.name] = std::move(e); // move to container
+                result = true; // something useful loaded
 
-				if (file.tellg() == headerEndPos)
-				{
-					break; // all exports done
-				}
-			}
-		}
-		else // other unknown header type
-		{
-			file.seekg(headerEndPos, file.beg);
-			if (file.fail())
-			{
-				LOG_WARNING(0, "Module '%s' load error. Error while skipping unknown header type", path);
-				return false;
-			}
-		}
-	}
+                if (file.tellg() == headerEndPos)
+                {
+                    break; // all exports done
+                }
+            }
+        }
+        else // other unknown header type
+        {
+            file.seekg(headerEndPos, file.beg);
+            if (file.fail())
+            {
+                LOG_WARNING(0, "Module '%s' load error. Error while skipping unknown header type", path);
+                return false;
+            }
+        }
+    }
 
-	if (!file.good())
-	{
-		LOG_WARNING(0, "Module '%s' read error", path);
-		return false;
-	}
+    if (!file.good())
+    {
+        LOG_WARNING(0, "Module '%s' read error", path);
+        return false;
+    }
 
-	if (!result) // no usable elements found. No point to keeping this module
-	{
-		LOG_WARNING(0, "Module '%s' skipped. Nothing found", path);
-		return false;
-	}
+    if (!result) // no usable elements found. No point to keeping this module
+    {
+        LOG_WARNING(0, "Module '%s' skipped. Nothing found", path);
+        return false;
+    }
 
-	// get file size
-	file.seekg(0, file.end);
-	auto size = (size_t)file.tellg();
-	file.seekg(0, file.beg);
+    // get file size
+    file.seekg(0, file.end);
+    auto size = (size_t)file.tellg();
+    file.seekg(0, file.beg);
 
-	// store file data
-	data.resize(size);
-	file.read(data.data(), size);
-	if (file.fail())
-	{
-		return false;
-	}
+    // store file data
+    data.resize(size);
+    file.read(data.data(), size);
+    if (file.fail())
+    {
+        return false;
+    }
 
-	// cut Sanny extra info if present
-	auto infoSize = GetExtraInfoSize((BYTE*)data.data(), data.size());
-	if (infoSize)
-	{
-		data.resize(data.size() - infoSize);
-	}
+    // cut Sanny extra info if present
+    auto infoSize = GetExtraInfoSize((BYTE*)data.data(), data.size());
+    if (infoSize)
+    {
+        data.resize(data.size() - infoSize);
+    }
 
-	return true;
+    return true;
 }
 
 const ScriptDataRef CModuleSystem::CModule::GetExport(std::string name)
 {
-	ModuleExport::NormalizeName(name);
+    ModuleExport::NormalizeName(name);
 
-	auto& it = exports.find(name);
-	if (it == exports.end())
-	{
-		return {};
-	}
-	auto& exp = it->second;
+    auto& it = exports.find(name);
+    if (it == exports.end())
+    {
+        return {};
+    }
+    auto& exp = it->second;
 
-	return { data.data(), data.size(), exp.offset };
+    return { data.data(), data.size(), exp.offset };
 }
 
 void CModuleSystem::CModule::ModuleExport::Clear()
 {
-	name.clear();
-	offset = 0;
+    name.clear();
+    offset = 0;
 }
 
 bool CModuleSystem::CModule::ModuleExport::LoadFromFile(std::ifstream& file)
 {
-	if (!file.good())
-	{
-		return false;
-	}
+    if (!file.good())
+    {
+        return false;
+    }
 
-	// name
-	std::getline(file, name, '\0');
-	if (file.fail() || name.length() >= 0xFF)
-	{
-		return false;
-	}
-	NormalizeName(name);
+    // name
+    std::getline(file, name, '\0');
+    if (file.fail() || name.length() >= 0xFF)
+    {
+        return false;
+    }
+    NormalizeName(name);
 
-	// address
-	file.read((char*)&offset, 4);
-	if (file.fail())
-	{
-		return false;
-	}
+    // address
+    file.read((char*)&offset, 4);
+    if (file.fail())
+    {
+        return false;
+    }
 
-	// input arg count
-	unsigned char inParamCount;
-	file.read((char*)&inParamCount, 1);
-	if (file.fail())
-	{
-		return false;
-	}
+    // input arg count
+    unsigned char inParamCount;
+    file.read((char*)&inParamCount, 1);
+    if (file.fail())
+    {
+        return false;
+    }
 
-	// skip input argument types info
-	file.seekg(inParamCount, file.cur);
-	if (file.fail())
-	{
-		return false;
-	}
+    // skip input argument types info
+    file.seekg(inParamCount, file.cur);
+    if (file.fail())
+    {
+        return false;
+    }
 
-	// return value count
-	unsigned char outParamCount;
-	file.read((char*)&outParamCount, 1);
-	if (file.fail())
-	{
-		return false;
-	}
+    // return value count
+    unsigned char outParamCount;
+    file.read((char*)&outParamCount, 1);
+    if (file.fail())
+    {
+        return false;
+    }
 
-	// skip return value types info
-	file.seekg(outParamCount, file.cur);
-	if (file.fail())
-	{
-		return false;
-	}
+    // skip return value types info
+    file.seekg(outParamCount, file.cur);
+    if (file.fail())
+    {
+        return false;
+    }
 
-	// skip flags (1 byte) and address (4 bytes)
-	file.seekg(5, file.cur);
-	if (file.fail())
-	{
-		return false;
-	}
+    // skip flags (1 byte) and address (4 bytes)
+    file.seekg(5, file.cur);
+    if (file.fail())
+    {
+        return false;
+    }
 
-	return true; // done
+    return true; // done
 }
 
 void CModuleSystem::CModule::ModuleExport::NormalizeName(std::string& name)
 {
-	for (auto& ch : name)
-	{
-		ch = std::tolower(ch);
-	}
+    for (auto& ch : name)
+    {
+        ch = std::tolower(ch);
+    }
 }

--- a/source/CModuleSystem.h
+++ b/source/CModuleSystem.h
@@ -2,67 +2,67 @@
 
 namespace CLEO
 {
-	struct ScriptDataRef
-	{
-		char* base = nullptr; // script's base data
-		DWORD size = 0; // available code block size
-		int offset = 0; // address within the script
+    struct ScriptDataRef
+    {
+        char* base = nullptr; // script's base data
+        DWORD size = 0; // available code block size
+        int offset = 0; // address within the script
 
-		bool Valid() const
-		{
-			return base != nullptr && size >= sizeof(WORD); // at least one opcode
-		}
-	};
+        bool Valid() const
+        {
+            return base != nullptr && size >= sizeof(WORD); // at least one opcode
+        }
+    };
 
-	class CModuleSystem
-	{
-	public:
-		CModuleSystem() = default;
-		CModuleSystem(const CModuleSystem&) = delete; // no copying
+    class CModuleSystem
+    {
+    public:
+        CModuleSystem() = default;
+        CModuleSystem(const CModuleSystem&) = delete; // no copying
 
-		void Clear();
+        void Clear();
 
-		// registers module reference. Needs to be released with ReleaseModuleRef
-		const ScriptDataRef GetExport(std::string modulePath, std::string_view exportName);
+        // registers module reference. Needs to be released with ReleaseModuleRef
+        const ScriptDataRef GetExport(std::string modulePath, std::string_view exportName);
 
-		bool LoadFile(const char* const path); // single file
-		bool LoadDirectory(const char* const path); // all modules in directory
-		bool LoadCleoModules(); // all in cleo\cleo_modules
+        bool LoadFile(const char* const path); // single file
+        bool LoadDirectory(const char* const path); // all modules in directory
+        bool LoadCleoModules(); // all in cleo\cleo_modules
 
-	private:
-		static void NormalizePath(std::string& path);
+    private:
+        static void NormalizePath(std::string& path);
 
-		class CModule
-		{
-			friend class CModuleSystem;
+        class CModule
+        {
+            friend class CModuleSystem;
 
-			struct ModuleExport
-			{
-				std::string name;
-				int offset = 0; // address within module's data
+            struct ModuleExport
+            {
+                std::string name;
+                int offset = 0; // address within module's data
 
-				void Clear();
-				bool LoadFromFile(std::ifstream& file);
+                void Clear();
+                bool LoadFromFile(std::ifstream& file);
 
-				static void NormalizeName(std::string& name);
-			};
+                static void NormalizeName(std::string& name);
+            };
 
-			std::string filepath; // source file
-			std::vector<char> data;
-			std::map<std::string, ModuleExport> exports;
+            std::string filepath; // source file
+            std::vector<char> data;
+            std::map<std::string, ModuleExport> exports;
 
-		public:
-			CModule() = default;
-			CModule(const CModule&) = delete; // no copying
-			~CModule() = default;
+        public:
+            CModule() = default;
+            CModule(const CModule&) = delete; // no copying
+            ~CModule() = default;
 
-			void Clear();
-			const char* GetFilepath() const;
-			bool LoadFromFile(const char* path);
-			const ScriptDataRef GetExport(std::string name);
-		};
+            void Clear();
+            const char* GetFilepath() const;
+            bool LoadFromFile(const char* path);
+            const ScriptDataRef GetExport(std::string name);
+        };
 
-		std::map<std::string, CModule> modules;
-	};
+        std::map<std::string, CModule> modules;
+    };
 }
 

--- a/source/CleoBase.h
+++ b/source/CleoBase.h
@@ -24,15 +24,15 @@ namespace CLEO
         };
 
         // order here defines init and deinit order!
-        CDmaFix					DmaFix;
-        CGameMenu				GameMenu;
-        CCodeInjector			CodeInjector;
-        CPluginSystem			PluginSystem;
-        CGameVersionManager		VersionManager;
-        CScriptEngine			ScriptEngine;
-        CCustomOpcodeSystem		OpcodeSystem;
-        CModuleSystem			ModuleSystem;
-        OpcodeInfoDatabase		OpcodeInfoDb;
+        CDmaFix DmaFix;
+        CGameMenu GameMenu;
+        CCodeInjector CodeInjector;
+        CPluginSystem PluginSystem;
+        CGameVersionManager VersionManager;
+        CScriptEngine ScriptEngine;
+        CCustomOpcodeSystem OpcodeSystem;
+        CModuleSystem ModuleSystem;
+        OpcodeInfoDatabase OpcodeInfoDb;
 
         int saveSlot = -1; // -1 if not loaded from save
 

--- a/source/Mem.h
+++ b/source/Mem.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#define OP_NOP			0x90
-#define OP_RET			0xC3
-#define OP_CALL			0xE8
-#define OP_JMP			0xE9
-#define OP_JMPSHORT		0xEB
+#define OP_NOP      0x90
+#define OP_RET      0xC3
+#define OP_CALL     0xE8
+#define OP_JMP      0xE9
+#define OP_JMPSHORT 0xEB
 
 template<typename T, typename U>
 inline void MemWrite(U p, const T v) { *(T*)p = v; }

--- a/source/OpcodeInfoDatabase.cpp
+++ b/source/OpcodeInfoDatabase.cpp
@@ -7,221 +7,221 @@ using namespace simdjson;
 
 bool OpcodeInfoDatabase::Load(const char* filepath)
 {
-	Clear();
+    Clear();
 
-	dom::parser parser;
-	dom::element root;
+    dom::parser parser;
+    dom::element root;
 
-	auto error = parser.load(filepath).get(root);
-	if (error) 
-	{ 
-		TRACE("Failed to parse opcodes database '%s' file. Code %d", filepath, error);
-		return false;
-	}
+    auto error = parser.load(filepath).get(root);
+    if (error) 
+    { 
+        TRACE("Failed to parse opcodes database '%s' file. Code %d", filepath, error);
+        return false;
+    }
 
-	const char* version;
-	if (root["meta"]["version"].get_c_str().get(version))
-	{
-		TRACE("Invalid opcodes database '%s' file.", filepath);
-		return false;
-	}
+    const char* version;
+    if (root["meta"]["version"].get_c_str().get(version))
+    {
+        TRACE("Invalid opcodes database '%s' file.", filepath);
+        return false;
+    }
 
-	dom::array ext;
-	if (root["extensions"].get_array().get(ext))
-	{
-		TRACE("Invalid opcodes database '%s' file.", filepath);
-		return false;
-	}
+    dom::array ext;
+    if (root["extensions"].get_array().get(ext))
+    {
+        TRACE("Invalid opcodes database '%s' file.", filepath);
+        return false;
+    }
 
-	for (auto& e : ext)
-	{
-		Extension extension;
+    for (auto& e : ext)
+    {
+        Extension extension;
 
-		const char* name;
-		if (e["name"].get_c_str().get(name))
-		{
-			continue; // invalid extension
-		}
-		extension.name = name;
+        const char* name;
+        if (e["name"].get_c_str().get(name))
+        {
+            continue; // invalid extension
+        }
+        extension.name = name;
 
-		dom::array commands;
-		if (e["commands"].get_array().get(commands))
-		{
-			continue; // invalid extension
-		}
+        dom::array commands;
+        if (e["commands"].get_array().get(commands))
+        {
+            continue; // invalid extension
+        }
 
-		for (auto& c : commands)
-		{
-			bool unsupported;
-			if (!c["attrs"]["is_unsupported"].get_bool().get(unsupported) && unsupported)
-			{
-				continue; // command defined as unsupported
-			}
+        for (auto& c : commands)
+        {
+            bool unsupported;
+            if (!c["attrs"]["is_unsupported"].get_bool().get(unsupported) && unsupported)
+            {
+                continue; // command defined as unsupported
+            }
 
-			const char* commandId;
-			if (c["id"].get_c_str().get(commandId))
-			{
-				continue; // invalid command
-			}
+            const char* commandId;
+            if (c["id"].get_c_str().get(commandId))
+            {
+                continue; // invalid command
+            }
 
-			const char* commandName;
-			if (c["name"].get_c_str().get(commandName))
-			{
-				continue; // invalid command
-			}
+            const char* commandName;
+            if (c["name"].get_c_str().get(commandName))
+            {
+                continue; // invalid command
+            }
 
-			auto idLong = stoul(commandId, nullptr, 16);
-			if (idLong > 0x7FFF)
-			{
-				continue; // opcode out of bounds
-			}
-			auto id = (uint16_t)idLong;
+            auto idLong = stoul(commandId, nullptr, 16);
+            if (idLong > 0x7FFF)
+            {
+                continue; // opcode out of bounds
+            }
+            auto id = (uint16_t)idLong;
 
-			extension.opcodes.emplace(piecewise_construct, make_tuple(id), make_tuple(id, commandName));
-			auto& opcode = extension.opcodes.at(id);
+            extension.opcodes.emplace(piecewise_construct, make_tuple(id), make_tuple(id, commandName));
+            auto& opcode = extension.opcodes.at(id);
 
-			// read arguments info
-			dom::array inputArgs;
-			if (!c["input"].get_array().get(inputArgs))
-			{
-				for (auto& p : inputArgs)
-				{
-					const char* argName;
-					if (!p["name"].get_c_str().get(argName))
-					{
-						opcode.arguments.emplace_back(argName);
-					}
-				}
-			}
-		}
+            // read arguments info
+            dom::array inputArgs;
+            if (!c["input"].get_array().get(inputArgs))
+            {
+                for (auto& p : inputArgs)
+                {
+                    const char* argName;
+                    if (!p["name"].get_c_str().get(argName))
+                    {
+                        opcode.arguments.emplace_back(argName);
+                    }
+                }
+            }
+        }
 
-		if (!extension.opcodes.empty())
-		{
-			extensions[extension.name] = move(extension);
-		}
-	}
+        if (!extension.opcodes.empty())
+        {
+            extensions[extension.name] = move(extension);
+        }
+    }
 
-	TRACE("Opcodes database version %s loaded from '%s'", version, filepath);
-	ok = true;
-	return true;
+    TRACE("Opcodes database version %s loaded from '%s'", version, filepath);
+    ok = true;
+    return true;
 }
 
 void OpcodeInfoDatabase::Clear()
 {
-	ok = false;
-	extensions.clear();
+    ok = false;
+    extensions.clear();
 }
 
 const char* OpcodeInfoDatabase::GetExtensionName(uint16_t opcode) const
 {
-	if (ok)
-	{
-		for (auto& entry : extensions)
-		{
-			auto& extension = entry.second;
-			auto& opcodes = extension.opcodes;
+    if (ok)
+    {
+        for (auto& entry : extensions)
+        {
+            auto& extension = entry.second;
+            auto& opcodes = extension.opcodes;
 
-			if (opcodes.find(opcode) != opcodes.end())
-			{
-				return extension.name.c_str();
-			}
-		}
-	}
+            if (opcodes.find(opcode) != opcodes.end())
+            {
+                return extension.name.c_str();
+            }
+        }
+    }
 
-	return nullptr;
+    return nullptr;
 }
 
 const char* OpcodeInfoDatabase::GetExtensionName(const char* commandName) const
 {
-	if (ok)
-	{
-		for (auto& entry : extensions)
-		{
-			auto& extension = entry.second;
-			auto& opcodes = extension.opcodes;
+    if (ok)
+    {
+        for (auto& entry : extensions)
+        {
+            auto& extension = entry.second;
+            auto& opcodes = extension.opcodes;
 
-			for (auto& opcode : opcodes)
-			{
-				if (_strcmpi(commandName, opcode.second.name.c_str()) == 0)
-				{
-					return extension.name.c_str();
-				}
-			}
-		}
-	}
+            for (auto& opcode : opcodes)
+            {
+                if (_strcmpi(commandName, opcode.second.name.c_str()) == 0)
+                {
+                    return extension.name.c_str();
+                }
+            }
+        }
+    }
 
-	return nullptr;
+    return nullptr;
 }
 
 uint16_t OpcodeInfoDatabase::GetOpcode(const char* commandName) const
 {
-	if (ok)
-	{
-		for (auto& entry : extensions)
-		{
-			auto& extension = entry.second;
-			auto& opcodes = extension.opcodes;
+    if (ok)
+    {
+        for (auto& entry : extensions)
+        {
+            auto& extension = entry.second;
+            auto& opcodes = extension.opcodes;
 
-			for (auto& opcode : opcodes)
-			{
-				if (_strcmpi(commandName, opcode.second.name.c_str()) == 0)
-				{
-					return opcode.first;
-				}
-			}
-		}
-	}
+            for (auto& opcode : opcodes)
+            {
+                if (_strcmpi(commandName, opcode.second.name.c_str()) == 0)
+                {
+                    return opcode.first;
+                }
+            }
+        }
+    }
 
-	return 0xFFFF;
+    return 0xFFFF;
 }
 
 const char* OpcodeInfoDatabase::GetCommandName(uint16_t opcode) const
 {
-	if (ok)
-	{
-		for (auto& entry : extensions)
-		{
-			auto& opcodes = entry.second.opcodes;
+    if (ok)
+    {
+        for (auto& entry : extensions)
+        {
+            auto& opcodes = entry.second.opcodes;
 
-			if (opcodes.find(opcode) != opcodes.end())
-			{
-				return opcodes.at(opcode).name.c_str();
-			}
-		}
-	}
+            if (opcodes.find(opcode) != opcodes.end())
+            {
+                return opcodes.at(opcode).name.c_str();
+            }
+        }
+    }
 
-	return nullptr;
+    return nullptr;
 }
 
 const char* OpcodeInfoDatabase::GetArgumentName(uint16_t opcode, size_t paramIdx) const
 {
-	if (ok)
-	{
-		for (auto& entry : extensions)
-		{
-			auto& opcodes = entry.second.opcodes;
+    if (ok)
+    {
+        for (auto& entry : extensions)
+        {
+            auto& opcodes = entry.second.opcodes;
 
-			if (opcodes.find(opcode) != opcodes.end())
-			{
-				if(paramIdx < opcodes.at(opcode).arguments.size())
-				{
-					return opcodes.at(opcode).arguments[paramIdx].name.c_str();
-				}
-			}
-		}
-	}
+            if (opcodes.find(opcode) != opcodes.end())
+            {
+                if(paramIdx < opcodes.at(opcode).arguments.size())
+                {
+                    return opcodes.at(opcode).arguments[paramIdx].name.c_str();
+                }
+            }
+        }
+    }
 
-	return nullptr;
+    return nullptr;
 }
 
 std::string OpcodeInfoDatabase::GetExtensionMissingMessage(uint16_t opcode) const
 {
-	auto extensionName = GetExtensionName(opcode);
-	if (extensionName == nullptr)
-	{
-		return {};
-	}
+    auto extensionName = GetExtensionName(opcode);
+    if (extensionName == nullptr)
+    {
+        return {};
+    }
 
-	return CLEO::StringPrintf("CLEO extension plugin \"%s\" is missing!", extensionName);
+    return CLEO::StringPrintf("CLEO extension plugin \"%s\" is missing!", extensionName);
 }
 

--- a/source/OpcodeInfoDatabase.h
+++ b/source/OpcodeInfoDatabase.h
@@ -6,51 +6,51 @@
 
 class OpcodeInfoDatabase
 {
-	struct OpcodeArgument
-	{
-		std::string name;
+    struct OpcodeArgument
+    {
+        std::string name;
 
-		OpcodeArgument() = default;
-		OpcodeArgument(const char* name) : name(name)
-		{
-		}
-	};
+        OpcodeArgument() = default;
+        OpcodeArgument(const char* name) : name(name)
+        {
+        }
+    };
 
-	struct Opcode
-	{
-		uint16_t id;
-		std::string name;
-		std::vector<OpcodeArgument> arguments;
+    struct Opcode
+    {
+        uint16_t id;
+        std::string name;
+        std::vector<OpcodeArgument> arguments;
 
-		Opcode() = default;
-		Opcode(uint16_t id, std::string name) : id(id), name(name)
-		{
-		}
-	};
+        Opcode() = default;
+        Opcode(uint16_t id, std::string name) : id(id), name(name)
+        {
+        }
+    };
 
-	struct Extension
-	{
-		std::string name;
-		std::map<uint16_t, Opcode> opcodes;
-	};
+    struct Extension
+    {
+        std::string name;
+        std::map<uint16_t, Opcode> opcodes;
+    };
 
-	std::atomic<bool> ok = false;
-	std::map<std::string, Extension> extensions;
+    std::atomic<bool> ok = false;
+    std::map<std::string, Extension> extensions;
 
 public:
-	OpcodeInfoDatabase() = default;
+    OpcodeInfoDatabase() = default;
 
-	void Clear();
-	bool Load(const char* filepath); // triggers asynchronic load
+    void Clear();
+    bool Load(const char* filepath); // triggers asynchronic load
 
-	const char* GetExtensionName(uint16_t opcode) const; // nullptr if not found
-	const char* GetExtensionName(const char* commandName) const; // nullptr if not found
+    const char* GetExtensionName(uint16_t opcode) const; // nullptr if not found
+    const char* GetExtensionName(const char* commandName) const; // nullptr if not found
 
-	uint16_t GetOpcode(const char* commandName) const; // 0xFFFF if not found
-	const char* GetCommandName(uint16_t opcode) const; // nullptr if not found
+    uint16_t GetOpcode(const char* commandName) const; // 0xFFFF if not found
+    const char* GetCommandName(uint16_t opcode) const; // nullptr if not found
 
-	const char* GetArgumentName(uint16_t opcode, size_t paramIdx) const; // nullptr if not found
+    const char* GetArgumentName(uint16_t opcode, size_t paramIdx) const; // nullptr if not found
 
-	std::string GetExtensionMissingMessage(uint16_t opcode) const; // extension "x" missing message if known, empty text otherwise
+    std::string GetExtensionMissingMessage(uint16_t opcode) const; // extension "x" missing message if known, empty text otherwise
 };
 

--- a/source/ScmFunction.cpp
+++ b/source/ScmFunction.cpp
@@ -6,119 +6,119 @@
 
 namespace CLEO
 {
-	ScmFunction* ScmFunction::store[Store_Size] = { 0 };
-	size_t ScmFunction::allocationPlace = 0;
+    ScmFunction* ScmFunction::store[Store_Size] = { 0 };
+    size_t ScmFunction::allocationPlace = 0;
 
-	ScmFunction* ScmFunction::Get(unsigned short idx)
-	{
-		if (idx >= Store_Size)
-			return nullptr;
+    ScmFunction* ScmFunction::Get(unsigned short idx)
+    {
+        if (idx >= Store_Size)
+            return nullptr;
 
-		return store[idx];
-	}
+        return store[idx];
+    }
 
-	void ScmFunction::Clear()
-	{
-		for each (ScmFunction* scmFunc in store)
-		{
-			if (scmFunc != nullptr) delete scmFunc;
-		}
-		ScmFunction::allocationPlace = 0;
-	}
+    void ScmFunction::Clear()
+    {
+        for each (ScmFunction* scmFunc in store)
+        {
+            if (scmFunc != nullptr) delete scmFunc;
+        }
+        ScmFunction::allocationPlace = 0;
+    }
 
-	void* ScmFunction::operator new(size_t size)
-	{
-		size_t start_search = allocationPlace;
-		while (store[allocationPlace] != nullptr) // find first unused position in store
-		{
-			if (++allocationPlace >= Store_Size) allocationPlace = 0; // end of store reached
-			if (allocationPlace == start_search)
-			{
-				SHOW_ERROR("CLEO function storage stack overfllow!");
-				throw std::bad_alloc();	// the store is filled up
-			}
-		}
-		ScmFunction* obj = reinterpret_cast<ScmFunction*>(::operator new(size));
-		store[allocationPlace] = obj;
-		return obj;
-	}
+    void* ScmFunction::operator new(size_t size)
+    {
+        size_t start_search = allocationPlace;
+        while (store[allocationPlace] != nullptr) // find first unused position in store
+        {
+            if (++allocationPlace >= Store_Size) allocationPlace = 0; // end of store reached
+            if (allocationPlace == start_search)
+            {
+                SHOW_ERROR("CLEO function storage stack overfllow!");
+                throw std::bad_alloc();    // the store is filled up
+            }
+        }
+        ScmFunction* obj = reinterpret_cast<ScmFunction*>(::operator new(size));
+        store[allocationPlace] = obj;
+        return obj;
+    }
 
-	void ScmFunction::operator delete(void* mem)
-	{
-		store[reinterpret_cast<ScmFunction*>(mem)->thisScmFunctionId] = nullptr;
-		::operator delete(mem);
-	}
+    void ScmFunction::operator delete(void* mem)
+    {
+        store[reinterpret_cast<ScmFunction*>(mem)->thisScmFunctionId] = nullptr;
+        ::operator delete(mem);
+    }
 
-	ScmFunction::ScmFunction(CLEO::CRunningScript* thread) :
-		prevScmFunctionId(reinterpret_cast<CCustomScript*>(thread)->GetScmFunction())
-	{
-		auto cs = reinterpret_cast<CCustomScript*>(thread);
+    ScmFunction::ScmFunction(CLEO::CRunningScript* thread) :
+        prevScmFunctionId(reinterpret_cast<CCustomScript*>(thread)->GetScmFunction())
+    {
+        auto cs = reinterpret_cast<CCustomScript*>(thread);
 
-		// create snapshot of current scope
-		savedBaseIP = cs->BaseIP;
-		savedCodeSize = cs->IsCustom() ? cs->GetCodeSize() : -1;
+        // create snapshot of current scope
+        savedBaseIP = cs->BaseIP;
+        savedCodeSize = cs->IsCustom() ? cs->GetCodeSize() : -1;
 
-		std::copy(std::begin(cs->Stack), std::end(cs->Stack), std::begin(savedStack));
-		savedSP = cs->SP;
+        std::copy(std::begin(cs->Stack), std::end(cs->Stack), std::begin(savedStack));
+        savedSP = cs->SP;
 
-		auto scope = cs->IsMission() ? missionLocals : cs->LocalVar;
-		std::copy(scope, scope + _countof(CRunningScript::LocalVar), savedTls);
+        auto scope = cs->IsMission() ? missionLocals : cs->LocalVar;
+        std::copy(scope, scope + _countof(CRunningScript::LocalVar), savedTls);
 
-		savedCondResult = cs->bCondResult;
-		savedLogicalOp = cs->LogicalOp;
-		savedNotFlag = cs->NotFlag;
+        savedCondResult = cs->bCondResult;
+        savedLogicalOp = cs->LogicalOp;
+        savedNotFlag = cs->NotFlag;
 
-		savedScriptFileDir = cs->GetScriptFileDir();
-		savedScriptFileName = cs->GetScriptFileName();
+        savedScriptFileDir = cs->GetScriptFileDir();
+        savedScriptFileName = cs->GetScriptFileName();
 
-		// init new scope
-		std::fill(std::begin(cs->Stack), std::end(cs->Stack), nullptr);
-		cs->SP = 0;
-		cs->bCondResult = false;
-		cs->LogicalOp = eLogicalOperation::NONE;
-		cs->NotFlag = false;
+        // init new scope
+        std::fill(std::begin(cs->Stack), std::end(cs->Stack), nullptr);
+        cs->SP = 0;
+        cs->bCondResult = false;
+        cs->LogicalOp = eLogicalOperation::NONE;
+        cs->NotFlag = false;
 
-		cs->SetScmFunction(thisScmFunctionId = (unsigned short)allocationPlace);
-	}
+        cs->SetScmFunction(thisScmFunctionId = (unsigned short)allocationPlace);
+    }
 
-	void ScmFunction::Return(CRunningScript* thread)
-	{
-		auto cs = reinterpret_cast<CCustomScript*>(thread);
+    void ScmFunction::Return(CRunningScript* thread)
+    {
+        auto cs = reinterpret_cast<CCustomScript*>(thread);
 
-		cs->BaseIP = savedBaseIP;
-		if (cs->IsCustom()) cs->SetCodeSize(savedCodeSize);
+        cs->BaseIP = savedBaseIP;
+        if (cs->IsCustom()) cs->SetCodeSize(savedCodeSize);
 
-		// restore parent scope's gosub call stack
-		std::copy(std::begin(savedStack), std::end(savedStack), std::begin(cs->Stack));
-		cs->SP = savedSP;
+        // restore parent scope's gosub call stack
+        std::copy(std::begin(savedStack), std::end(savedStack), std::begin(cs->Stack));
+        cs->SP = savedSP;
 
-		// restore parent scope's local variables
-		std::copy(savedTls, savedTls + 32, cs->IsMission() ? missionLocals : cs->LocalVar);
+        // restore parent scope's local variables
+        std::copy(savedTls, savedTls + 32, cs->IsMission() ? missionLocals : cs->LocalVar);
 
-		// process conditional result of just ended function in parent scope
-		bool condResult = cs->bCondResult;
-		if (savedNotFlag) condResult = !condResult;
+        // process conditional result of just ended function in parent scope
+        bool condResult = cs->bCondResult;
+        if (savedNotFlag) condResult = !condResult;
 
-		if (savedLogicalOp >= eLogicalOperation::ANDS_1 && savedLogicalOp < eLogicalOperation::AND_END)
-		{
-			cs->bCondResult = savedCondResult && condResult;
-			cs->LogicalOp = --savedLogicalOp;
-		}
-		else if (savedLogicalOp >= eLogicalOperation::ORS_1 && savedLogicalOp < eLogicalOperation::OR_END)
-		{
-			cs->bCondResult = savedCondResult || condResult;
-			cs->LogicalOp = --savedLogicalOp;
-		}
-		else // eLogicalOperation::NONE
-		{
-			cs->bCondResult = condResult;
-			cs->LogicalOp = savedLogicalOp;
-		}
+        if (savedLogicalOp >= eLogicalOperation::ANDS_1 && savedLogicalOp < eLogicalOperation::AND_END)
+        {
+            cs->bCondResult = savedCondResult && condResult;
+            cs->LogicalOp = --savedLogicalOp;
+        }
+        else if (savedLogicalOp >= eLogicalOperation::ORS_1 && savedLogicalOp < eLogicalOperation::OR_END)
+        {
+            cs->bCondResult = savedCondResult || condResult;
+            cs->LogicalOp = --savedLogicalOp;
+        }
+        else // eLogicalOperation::NONE
+        {
+            cs->bCondResult = condResult;
+            cs->LogicalOp = savedLogicalOp;
+        }
 
-		cs->SetScriptFileDir(savedScriptFileDir.c_str());
-		cs->SetScriptFileName(savedScriptFileName.c_str());
+        cs->SetScriptFileDir(savedScriptFileDir.c_str());
+        cs->SetScriptFileName(savedScriptFileName.c_str());
 
-		cs->SetIp(retnAddress);
-		cs->SetScmFunction(prevScmFunctionId);
-	}
+        cs->SetIp(retnAddress);
+        cs->SetScmFunction(prevScmFunctionId);
+    }
 };

--- a/source/ScmFunction.h
+++ b/source/ScmFunction.h
@@ -5,35 +5,35 @@
 
 namespace CLEO
 {
-	struct ScmFunction
-	{
-		static const size_t Store_Size = 0x400;
-		static ScmFunction* store[Store_Size];
-		static size_t allocationPlace; // contains an index of last allocated object
-		static ScmFunction* Get(unsigned short idx);
-		static void Clear();
+    struct ScmFunction
+    {
+        static const size_t Store_Size = 0x400;
+        static ScmFunction* store[Store_Size];
+        static size_t allocationPlace; // contains an index of last allocated object
+        static ScmFunction* Get(unsigned short idx);
+        static void Clear();
 
-		unsigned short prevScmFunctionId, thisScmFunctionId;
-		BYTE callArgCount = 0; // args provided to cleo_call
+        unsigned short prevScmFunctionId, thisScmFunctionId;
+        BYTE callArgCount = 0; // args provided to cleo_call
 
-		// saved nesting context state
-		void* savedBaseIP;
-		size_t savedCodeSize; // Custom Scripts only
-		BYTE* retnAddress;
-		BYTE* savedStack[8]; // gosub stack
-		WORD savedSP;
-		SCRIPT_VAR savedTls[32];
-		std::list<std::string> stringParams; // texts with this scope lifetime
-		bool savedCondResult;
-		eLogicalOperation savedLogicalOp;
-		bool savedNotFlag;
-		std::string savedScriptFileDir; // modules switching
-		std::string savedScriptFileName; // modules switching
+        // saved nesting context state
+        void* savedBaseIP;
+        size_t savedCodeSize; // Custom Scripts only
+        BYTE* retnAddress;
+        BYTE* savedStack[8]; // gosub stack
+        WORD savedSP;
+        SCRIPT_VAR savedTls[32];
+        std::list<std::string> stringParams; // texts with this scope lifetime
+        bool savedCondResult;
+        eLogicalOperation savedLogicalOp;
+        bool savedNotFlag;
+        std::string savedScriptFileDir; // modules switching
+        std::string savedScriptFileName; // modules switching
 
-		void* operator new(size_t size);
-		void operator delete(void* mem);
-		ScmFunction(CRunningScript* thread);
+        void* operator new(size_t size);
+        void operator delete(void* mem);
+        ScmFunction(CRunningScript* thread);
 
-		void Return(CRunningScript* thread);
-	};
+        void Return(CRunningScript* thread);
+    };
 }

--- a/source/ScriptDelegate.h
+++ b/source/ScriptDelegate.h
@@ -4,23 +4,23 @@
 
 namespace CLEO
 {
-	struct ScriptDeleteDelegate
-	{
-		std::vector<FuncScriptDeleteDelegateT> funcs;
+    struct ScriptDeleteDelegate
+    {
+        std::vector<FuncScriptDeleteDelegateT> funcs;
 
-		template<class FuncScriptDeleteDelegateT> void operator+=(FuncScriptDeleteDelegateT mFunc)
-		{
-			funcs.push_back(mFunc);
-		}
+        template<class FuncScriptDeleteDelegateT> void operator+=(FuncScriptDeleteDelegateT mFunc)
+        {
+            funcs.push_back(mFunc);
+        }
 
-		template<class FuncScriptDeleteDelegateT> void operator-=(FuncScriptDeleteDelegateT mFunc)
-		{
-			funcs.erase(std::remove(funcs.begin(), funcs.end(), mFunc), funcs.end());
-		}
+        template<class FuncScriptDeleteDelegateT> void operator-=(FuncScriptDeleteDelegateT mFunc)
+        {
+            funcs.erase(std::remove(funcs.begin(), funcs.end(), mFunc), funcs.end());
+        }
 
-		void operator()(CRunningScript* script)
-		{
-			for (auto& f : funcs) f(script);
-		}
-	};
+        void operator()(CRunningScript* script)
+        {
+            for (auto& f : funcs) f(script);
+        }
+    };
 }


### PR DESCRIPTION
Preparation for Clang formatting.
Replaced all occurences of tab indentation with 4 spaces.
Manually fixed existing alignment that was destroyed in few places.