### PR TITLE
OPCODE_READ_PARAM_STREAM macro

### DIFF
--- a/cleo_plugins/Audio/Audio.cpp
+++ b/cleo_plugins/Audio/Audio.cpp
@@ -8,12 +8,12 @@
 using namespace CLEO;
 using namespace plugin;
 
-#define OPCODE_READ_PARAM_STREAM()                                                                                     \
-    auto stream = (CAudioStream*)OPCODE_READ_PARAM_UINT();                                                             \
-    if (stream != nullptr && !soundSystem.HasStream(stream))                                                           \
+#define OPCODE_READ_PARAM_STREAM(_varName)                                                                             \
+    auto _varName = (CAudioStream*)OPCODE_READ_PARAM_UINT();                                                           \
+    if (_varName != nullptr && !soundSystem.HasStream(_varName))                                                       \
     {                                                                                                                  \
         SHOW_ERROR(                                                                                                    \
-            "Invalid or already closed '0x%X' audio stream handle param in script %s \nScript suspended.", stream,     \
+            "Invalid or already closed '0x%X' audio stream handle param in script %s \nScript suspended.", _varName,   \
             ScriptInfoStr(thread).c_str()                                                                              \
         );                                                                                                             \
         return thread->Suspend();                                                                                      \
@@ -129,7 +129,7 @@ class Audio
     // 0AAD=2,set_audiostream %1d% perform_action %2d%
     static OpcodeResult __stdcall opcode_0AAD(CLEO::CRunningScript* thread)
     {
-        OPCODE_READ_PARAM_STREAM();
+        OPCODE_READ_PARAM_STREAM(stream);
         auto action = OPCODE_READ_PARAM_INT();
 
         if (stream)
@@ -161,7 +161,7 @@ class Audio
     // 0AAE=1,release_audiostream %1d%
     static OpcodeResult __stdcall opcode_0AAE(CLEO::CRunningScript* thread)
     {
-        OPCODE_READ_PARAM_STREAM();
+        OPCODE_READ_PARAM_STREAM(stream);
 
         if (stream) soundSystem.DestroyStream(stream);
 
@@ -171,7 +171,7 @@ class Audio
     // 0AAF=2,%2d% = get_audiostream_length %1d%
     static OpcodeResult __stdcall opcode_0AAF(CLEO::CRunningScript* thread)
     {
-        OPCODE_READ_PARAM_STREAM();
+        OPCODE_READ_PARAM_STREAM(stream);
 
         auto length = 0.0f;
         if (stream) length = stream->GetLength();
@@ -183,7 +183,7 @@ class Audio
     // 0AB9=2,get_audio_stream_state %1d% store_to %2d%
     static OpcodeResult __stdcall opcode_0AB9(CLEO::CRunningScript* thread)
     {
-        OPCODE_READ_PARAM_STREAM();
+        OPCODE_READ_PARAM_STREAM(stream);
 
         auto state = CAudioStream::StreamState::Stopped;
         if (stream) state = stream->GetState();
@@ -195,7 +195,7 @@ class Audio
     // 0ABB=2,%2d% = get_audio_stream_volume %1d%
     static OpcodeResult __stdcall opcode_0ABB(CLEO::CRunningScript* thread)
     {
-        OPCODE_READ_PARAM_STREAM();
+        OPCODE_READ_PARAM_STREAM(stream);
 
         auto volume = 0.0f;
         if (stream) volume = stream->GetVolume();
@@ -207,7 +207,7 @@ class Audio
     // 0ABC=2,set_audiostream %1d% volume %2d%
     static OpcodeResult __stdcall opcode_0ABC(CLEO::CRunningScript* thread)
     {
-        OPCODE_READ_PARAM_STREAM();
+        OPCODE_READ_PARAM_STREAM(stream);
         auto volume = OPCODE_READ_PARAM_FLOAT();
 
         if (stream) stream->SetVolume(volume);
@@ -218,7 +218,7 @@ class Audio
     // 0AC0=2,loop_audiostream %1d% flag %2d%
     static OpcodeResult __stdcall opcode_0AC0(CLEO::CRunningScript* thread)
     {
-        OPCODE_READ_PARAM_STREAM();
+        OPCODE_READ_PARAM_STREAM(stream);
         auto loop = OPCODE_READ_PARAM_BOOL();
 
         if (stream) stream->SetLooping(loop);
@@ -248,7 +248,7 @@ class Audio
     // 0AC2=4,set_3d_audiostream %1d% position %2d% %3d% %4d%
     static OpcodeResult __stdcall opcode_0AC2(CLEO::CRunningScript* thread)
     {
-        OPCODE_READ_PARAM_STREAM();
+        OPCODE_READ_PARAM_STREAM(stream);
 
         if (stream && !stream->Is3d())
         {
@@ -271,7 +271,7 @@ class Audio
     // 0AC3=2,link_3d_audiostream %1d% to_object %2d%
     static OpcodeResult __stdcall opcode_0AC3(CLEO::CRunningScript* thread)
     {
-        OPCODE_READ_PARAM_STREAM();
+        OPCODE_READ_PARAM_STREAM(stream);
         auto handle = OPCODE_READ_PARAM_OBJECT_HANDLE();
 
         if (stream && !stream->Is3d())
@@ -294,7 +294,7 @@ class Audio
     // 0AC4=2,link_3d_audiostream %1d% to_actor %2d%
     static OpcodeResult __stdcall opcode_0AC4(CLEO::CRunningScript* thread)
     {
-        OPCODE_READ_PARAM_STREAM();
+        OPCODE_READ_PARAM_STREAM(stream);
         auto handle = OPCODE_READ_PARAM_PED_HANDLE();
 
         if (stream && !stream->Is3d())
@@ -317,7 +317,7 @@ class Audio
     // 0AC5=2,link_3d_audiostream %1d% to_vehicle %2d%
     static OpcodeResult __stdcall opcode_0AC5(CLEO::CRunningScript* thread)
     {
-        OPCODE_READ_PARAM_STREAM();
+        OPCODE_READ_PARAM_STREAM(stream);
         auto handle = OPCODE_READ_PARAM_VEHICLE_HANDLE();
 
         if (stream && !stream->Is3d())
@@ -340,7 +340,7 @@ class Audio
     // 2500=1,  is_audio_stream_playing %1d%
     static OpcodeResult __stdcall opcode_2500(CLEO::CRunningScript* thread)
     {
-        OPCODE_READ_PARAM_STREAM();
+        OPCODE_READ_PARAM_STREAM(stream);
 
         auto state = CAudioStream::StreamState::Stopped;
         if (stream) state = stream->GetState();
@@ -352,7 +352,7 @@ class Audio
     // 2501=2,%2d% = get_audiostream_duration %1d%
     static OpcodeResult __stdcall opcode_2501(CLEO::CRunningScript* thread)
     {
-        OPCODE_READ_PARAM_STREAM();
+        OPCODE_READ_PARAM_STREAM(stream);
 
         auto length = 0.0f;
         if (stream)
@@ -373,7 +373,7 @@ class Audio
     // 2502=2,get_audio_stream_speed %1d% store_to %2d%
     static OpcodeResult __stdcall opcode_2502(CLEO::CRunningScript* thread)
     {
-        OPCODE_READ_PARAM_STREAM();
+        OPCODE_READ_PARAM_STREAM(stream);
 
         auto speed = 0.0f;
         if (stream) speed = stream->GetSpeed();
@@ -385,7 +385,7 @@ class Audio
     // 2503=2,set_audio_stream_speed %1d% speed %2d%
     static OpcodeResult __stdcall opcode_2503(CLEO::CRunningScript* thread)
     {
-        OPCODE_READ_PARAM_STREAM();
+        OPCODE_READ_PARAM_STREAM(stream);
         auto speed = OPCODE_READ_PARAM_FLOAT();
 
         if (stream) stream->SetSpeed(speed);
@@ -396,7 +396,7 @@ class Audio
     // 2504=3,set_audio_stream_volume_with_transition %1d% volume %2d% time_ms %2d%
     static OpcodeResult __stdcall opcode_2504(CLEO::CRunningScript* thread)
     {
-        OPCODE_READ_PARAM_STREAM();
+        OPCODE_READ_PARAM_STREAM(stream);
         auto volume = OPCODE_READ_PARAM_FLOAT();
         auto time   = OPCODE_READ_PARAM_INT();
 
@@ -408,7 +408,7 @@ class Audio
     // 2505=3,set_audio_stream_speed_with_transition %1d% speed %2d% time_ms %2d%
     static OpcodeResult __stdcall opcode_2505(CLEO::CRunningScript* thread)
     {
-        OPCODE_READ_PARAM_STREAM();
+        OPCODE_READ_PARAM_STREAM(stream);
         auto speed = OPCODE_READ_PARAM_FLOAT();
         auto time  = OPCODE_READ_PARAM_INT();
 
@@ -420,7 +420,7 @@ class Audio
     // 2506=2,set_audio_stream_source_size %1d% radius %2d%
     static OpcodeResult __stdcall opcode_2506(CLEO::CRunningScript* thread)
     {
-        OPCODE_READ_PARAM_STREAM();
+        OPCODE_READ_PARAM_STREAM(stream);
         auto radius = OPCODE_READ_PARAM_FLOAT();
 
         if (stream) stream->Set3dSourceSize(radius);
@@ -431,7 +431,7 @@ class Audio
     // 2507=2,get_audio_stream_progress %1d% store_to %2d%
     static OpcodeResult __stdcall opcode_2507(CLEO::CRunningScript* thread)
     {
-        OPCODE_READ_PARAM_STREAM();
+        OPCODE_READ_PARAM_STREAM(stream);
 
         auto progress = 0.0f;
         if (stream) progress = stream->GetProgress();
@@ -443,7 +443,7 @@ class Audio
     // 2508=2,set_audio_stream_progress %1d% speed %2d%
     static OpcodeResult __stdcall opcode_2508(CLEO::CRunningScript* thread)
     {
-        OPCODE_READ_PARAM_STREAM();
+        OPCODE_READ_PARAM_STREAM(stream);
         auto speed = OPCODE_READ_PARAM_FLOAT();
 
         if (stream) stream->SetProgress(speed);
@@ -454,7 +454,7 @@ class Audio
     // 2509=2,get_audio_stream_type %1d% store_to %2d%
     static OpcodeResult __stdcall opcode_2509(CLEO::CRunningScript* thread)
     {
-        OPCODE_READ_PARAM_STREAM();
+        OPCODE_READ_PARAM_STREAM(stream);
 
         auto type = eStreamType::None;
         if (stream) type = stream->GetType();
@@ -466,7 +466,7 @@ class Audio
     // 250A=2,set_audio_stream_type %1d% type %2d%
     static OpcodeResult __stdcall opcode_250A(CLEO::CRunningScript* thread)
     {
-        OPCODE_READ_PARAM_STREAM();
+        OPCODE_READ_PARAM_STREAM(stream);
         auto type = OPCODE_READ_PARAM_INT();
 
         if (stream) stream->SetType((eStreamType)type);
@@ -477,7 +477,7 @@ class Audio
     // 250B=2,get_audio_stream_progress_seconds %1d% store_to %2d%
     static OpcodeResult __stdcall opcode_250B(CLEO::CRunningScript* thread)
     {
-        OPCODE_READ_PARAM_STREAM();
+        OPCODE_READ_PARAM_STREAM(stream);
 
         auto progress = 0.0f;
         if (stream)
@@ -493,7 +493,7 @@ class Audio
     // 250C=2,set_audio_stream_progress_seconds %1d% value %2d%
     static OpcodeResult __stdcall opcode_250C(CLEO::CRunningScript* thread)
     {
-        OPCODE_READ_PARAM_STREAM();
+        OPCODE_READ_PARAM_STREAM(stream);
         auto progress = OPCODE_READ_PARAM_FLOAT();
 
         if (stream)


### PR DESCRIPTION
Clang highlights it was written in awkward manner.
Updated to single macro instead of repeating the same two actions in single line.