### PR TITLE
Added stack overflow error prevention for GOSUB commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 5.2.0
 - added script execution log (`cleo\_cleo_script.log`). By default, it records all instructions from the last frame before exit or crash. Configurable via `cleo_plugins\DebugUtils.ini`.
+- added call stack overflow error check to **gosub** and **gosub_if_false** commands
 - added check for preceding **gosub** call in **0AA1 ([return_if_false](https://library.sannybuilder.com/#/sa/script/extensions/CLEO/0AA1))**
 - added limit for memory allocated per script (see `cleo_plugins\SA.MemoryOperations.ini`). Exceeding the limit will cause a warning in game
 - added listing of remaining memory blocks allocated by scripts to the cleo.log when closing or starting new game

--- a/source/CCustomOpcodeSystem.h
+++ b/source/CCustomOpcodeSystem.h
@@ -39,6 +39,7 @@ namespace CLEO
 
         // new/customized opcodes
         static OpcodeResult __stdcall opcode_004E(CRunningScript* thread); // terminate_this_script
+        static OpcodeResult __stdcall opcode_0050(CRunningScript* thread); // gosub
         static OpcodeResult __stdcall opcode_0051(CRunningScript* thread); // GOSUB return
         static OpcodeResult __stdcall opcode_0417(CRunningScript* thread); // load_and_launch_mission_internal
 


### PR DESCRIPTION
instead of crashing the game show error and suspend the script.
```
{$CLEO}
debug_on
wait 2000

gosub @routine

terminate_this_script

:routine
    trace "routine"
    wait {time} 100
    gosub @routine
return
```
<img width="524" height="90" alt="image" src="https://github.com/user-attachments/assets/cc6b52a6-d961-4b63-8402-a36fb983b449" />