### PR TITLE
opcode_0A9A: pathname increased from 16 to 64 bytes

### DIFF
--- a/cleo_plugins/FileSystemOperations/FileSystemOperations.cpp
+++ b/cleo_plugins/FileSystemOperations/FileSystemOperations.cpp
@@ -138,7 +138,7 @@ class FileSystemOperations
     {
         OPCODE_READ_PARAM_FILEPATH(filename);
 
-        char mode[16];
+        char mode[64];
         auto paramType = thread->PeekDataType();
         if (IsImmInteger(paramType) || IsVariable(paramType))
         {


### PR DESCRIPTION
Please note that files located in a directory with more than 16 bits cannot be opened. This limits the possibility of having a hierarchical file organization.
```js
DIR_DYOS = "CLEO/DYOS (MatiDragon)/script.bin"
```
The game only reads `CLEO/DYOS (MatiD` and the rest of the characters are left out.