### PR TITLE
Allow allocation of 0 sized memory block

### DIFF
--- a/cleo_plugins/MemoryOperations/MemoryOperations.cpp
+++ b/cleo_plugins/MemoryOperations/MemoryOperations.cpp
@@ -687,7 +687,7 @@ class MemoryOperations
         int size = OPCODE_READ_PARAM_INT();
 
         // validate params
-        if (size <= 0)
+        if (size < 0)
         {
             SUSPEND("Invalid '%d' size argument", size);
         }

--- a/tests/cleo_tests/MemoryOperations/0AC8.txt
+++ b/tests/cleo_tests/MemoryOperations/0AC8.txt
@@ -11,7 +11,8 @@ function tests
     after_each(@free)
     
     it("should return valid pointer", test1)
-    it("should point to zero-filled mem in CLEO5", test2)
+    it("should allocate zero sized block", test2)
+    it("should point to zero-filled mem in CLEO5", test3)
     return
 
     function test1
@@ -21,6 +22,13 @@ function tests
     end
     
     function test2
+        // 0@ is set in before_each callback
+        1@ = allocate_memory {size} 0
+        assert_ptr(1@)
+        assert_neq(1@, 0x11223344)
+    end
+    
+    function test3
         2@ = 0xCCCCCCCC
         2@ = read_memory 0@ {size} 4 {vp} false
         assert_eq(2@, 0)


### PR DESCRIPTION
Allowed allocation of 0 sized blocks (malloc still returns valid pointers in such case).

Added out-of-bounds check during release of memory block.
<img width="480" height="274" alt="image" src="https://github.com/user-attachments/assets/f9417e1f-6876-4bde-a214-efb09acadeaa" />

Fixes #511
